### PR TITLE
feat: make embedder idle timeout configurable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,22 @@ pub const BACKFILL_BATCH_SIZE: usize = 8;
 pub const MAX_QUERY_EXPANSIONS: usize = 5;
 pub const RECENT_DAYS: i64 = 30;
 pub const EMBEDDER_IDLE_TIMEOUT_SECS: u64 = 600;
+
+/// Load embedder idle timeout from config.
+/// TSM_EMBEDDER_IDLE_TIMEOUT env > config file > default (600s). 0 = disable.
+pub fn embedder_idle_timeout_secs() -> u64 {
+    if let Ok(val) = std::env::var("TSM_EMBEDDER_IDLE_TIMEOUT") {
+        if let Ok(n) = val.parse::<u64>() {
+            return n;
+        }
+    }
+    if let Some(val) = load_config_value("embedder_idle_timeout_secs") {
+        if let Ok(n) = val.parse::<u64>() {
+            return n;
+        }
+    }
+    EMBEDDER_IDLE_TIMEOUT_SECS
+}
 pub const DICT_CANDIDATE_FREQ_THRESHOLD: i64 = 5;
 pub const WORKER_ENCODE_TIMEOUT_PER_ITEM_SECS: u64 = 5;
 pub const WORKER_ENCODE_TIMEOUT_BASE_SECS: u64 = 10;
@@ -269,6 +285,30 @@ mod tests {
     #[test]
     fn test_dict_candidate_freq_threshold() {
         assert_eq!(DICT_CANDIDATE_FREQ_THRESHOLD, 5);
+    }
+
+    #[test]
+    fn test_embedder_idle_timeout_default() {
+        std::env::remove_var("TSM_EMBEDDER_IDLE_TIMEOUT");
+        std::env::remove_var("TSM_CONFIG");
+        let timeout = embedder_idle_timeout_secs();
+        assert_eq!(timeout, EMBEDDER_IDLE_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn test_embedder_idle_timeout_env() {
+        std::env::set_var("TSM_EMBEDDER_IDLE_TIMEOUT", "0");
+        let timeout = embedder_idle_timeout_secs();
+        assert_eq!(timeout, 0);
+        std::env::remove_var("TSM_EMBEDDER_IDLE_TIMEOUT");
+    }
+
+    #[test]
+    fn test_embedder_idle_timeout_env_custom() {
+        std::env::set_var("TSM_EMBEDDER_IDLE_TIMEOUT", "3600");
+        let timeout = embedder_idle_timeout_secs();
+        assert_eq!(timeout, 3600);
+        std::env::remove_var("TSM_EMBEDDER_IDLE_TIMEOUT");
     }
 
     #[test]

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -17,7 +17,6 @@ use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer};
 use crate::config;
 
 const MODEL_ID: &str = "cl-nagoya/ruri-v3-30m";
-use crate::config::EMBEDDER_IDLE_TIMEOUT_SECS as IDLE_TIMEOUT_SECS;
 
 /// The embedder engine: loads model and produces embeddings.
 pub struct Embedder {
@@ -237,14 +236,17 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
     let running = Arc::new(AtomicBool::new(true));
     let last_activity = Arc::new(std::sync::Mutex::new(Instant::now()));
 
-    // Watchdog thread
-    {
+    // Watchdog thread (skipped when idle timeout is 0)
+    let idle_timeout_secs = config::embedder_idle_timeout_secs();
+    if idle_timeout_secs > 0 {
         let running = Arc::clone(&running);
         let last_activity = Arc::clone(&last_activity);
         let socket_path = socket_path.to_path_buf();
         std::thread::spawn(move || {
-            watchdog(&running, &last_activity, &socket_path);
+            watchdog(&running, &last_activity, &socket_path, idle_timeout_secs);
         });
+    } else {
+        eprintln!("Idle timeout disabled.");
     }
 
     while running.load(Ordering::Relaxed) {
@@ -275,8 +277,13 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn watchdog(running: &AtomicBool, last_activity: &std::sync::Mutex<Instant>, socket_path: &Path) {
-    let timeout = Duration::from_secs(IDLE_TIMEOUT_SECS);
+fn watchdog(
+    running: &AtomicBool,
+    last_activity: &std::sync::Mutex<Instant>,
+    socket_path: &Path,
+    timeout_secs: u64,
+) {
+    let timeout = Duration::from_secs(timeout_secs);
     loop {
         std::thread::sleep(Duration::from_secs(10));
         if !running.load(Ordering::Relaxed) {
@@ -284,7 +291,7 @@ fn watchdog(running: &AtomicBool, last_activity: &std::sync::Mutex<Instant>, soc
         }
         let elapsed = last_activity.lock().unwrap().elapsed();
         if elapsed >= timeout {
-            eprintln!("Idle timeout reached ({IDLE_TIMEOUT_SECS}s). Stopping.");
+            eprintln!("Idle timeout reached ({timeout_secs}s). Stopping.");
             running.store(false, Ordering::Relaxed);
             // Poke the listener to unblock accept
             let _ = UnixStream::connect(socket_path);


### PR DESCRIPTION
## Summary

- embedder デーモンのアイドルタイムアウトを設定可能に
- `tsm.toml` の `embedder_idle_timeout_secs` または環境変数 `TSM_EMBEDDER_IDLE_TIMEOUT` で指定
- `0` を設定すると自動停止を無効化（watchdog スレッドをスキップ）
- デフォルトは従来通り 600秒（10分）

## Test plan

- [x] `config::tests` 全19件パス（新規3件含む）
- [x] 既存の失敗テスト（`backfill_*` 6件）は変更前から同一で無関係
- [ ] `embedder_idle_timeout_secs = 0` で embedder が停止しないことを実機確認
- [ ] `embedder_idle_timeout_secs = 30` 等で短縮タイムアウトが効くことを確認