### PR TITLE
fix: load_config_value handles non-string TOML values

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -95,8 +95,13 @@ fn load_config_value(key: &str) -> Option<String> {
     for path in candidates {
         if let Ok(content) = std::fs::read_to_string(&path) {
             if let Ok(table) = content.parse::<toml::Table>() {
-                if let Some(val) = table.get(key).and_then(|v| v.as_str()) {
-                    return Some(val.to_string());
+                if let Some(val) = table.get(key) {
+                    // Handle both string and non-string TOML values
+                    let s = match val.as_str() {
+                        Some(s) => s.to_string(),
+                        None => val.to_string(),
+                    };
+                    return Some(s);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- `load_config_value` が `as_str()` のみだったため、integer 型の TOML 値（`embedder_idle_timeout_secs = 0` 等）が読めなかった
- string の場合は従来通り `as_str()`、それ以外は `Display` でフォールバック

## Test plan

- [x] config tests 全19件パス
- [x] `embedder_idle_timeout_secs = 0` で「Idle timeout disabled.」のログ確認済み
- [x] 既存の string 型設定（`data_dir`, `project_root`）に影響なし