### PR TITLE
feat: periodic vector backfill during embedder idle time

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,25 @@ pub fn embedder_idle_timeout_secs() -> u64 {
     }
     EMBEDDER_IDLE_TIMEOUT_SECS
 }
+
+pub const EMBEDDER_BACKFILL_INTERVAL_SECS: u64 = 300;
+
+/// Load embedder backfill interval from config.
+/// TSM_EMBEDDER_BACKFILL_INTERVAL env > config file > default (300s). 0 = disable.
+pub fn embedder_backfill_interval_secs() -> u64 {
+    if let Ok(val) = std::env::var("TSM_EMBEDDER_BACKFILL_INTERVAL") {
+        if let Ok(n) = val.parse::<u64>() {
+            return n;
+        }
+    }
+    if let Some(val) = load_config_value("embedder_backfill_interval_secs") {
+        if let Ok(n) = val.parse::<u64>() {
+            return n;
+        }
+    }
+    EMBEDDER_BACKFILL_INTERVAL_SECS
+}
+
 pub const DICT_CANDIDATE_FREQ_THRESHOLD: i64 = 5;
 pub const WORKER_ENCODE_TIMEOUT_PER_ITEM_SECS: u64 = 5;
 pub const WORKER_ENCODE_TIMEOUT_BASE_SECS: u64 = 10;
@@ -314,6 +333,30 @@ mod tests {
         let timeout = embedder_idle_timeout_secs();
         assert_eq!(timeout, 3600);
         std::env::remove_var("TSM_EMBEDDER_IDLE_TIMEOUT");
+    }
+
+    #[test]
+    fn test_embedder_backfill_interval_default() {
+        std::env::remove_var("TSM_EMBEDDER_BACKFILL_INTERVAL");
+        std::env::remove_var("TSM_CONFIG");
+        let interval = embedder_backfill_interval_secs();
+        assert_eq!(interval, EMBEDDER_BACKFILL_INTERVAL_SECS);
+    }
+
+    #[test]
+    fn test_embedder_backfill_interval_env() {
+        std::env::set_var("TSM_EMBEDDER_BACKFILL_INTERVAL", "0");
+        let interval = embedder_backfill_interval_secs();
+        assert_eq!(interval, 0);
+        std::env::remove_var("TSM_EMBEDDER_BACKFILL_INTERVAL");
+    }
+
+    #[test]
+    fn test_embedder_backfill_interval_env_custom() {
+        std::env::set_var("TSM_EMBEDDER_BACKFILL_INTERVAL", "60");
+        let interval = embedder_backfill_interval_secs();
+        assert_eq!(interval, 60);
+        std::env::remove_var("TSM_EMBEDDER_BACKFILL_INTERVAL");
     }
 
     #[test]

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -249,6 +249,15 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
         eprintln!("Idle timeout disabled.");
     }
 
+    // Periodic backfill thread (skipped when interval is 0)
+    let backfill_interval_secs = config::embedder_backfill_interval_secs();
+    if backfill_interval_secs > 0 {
+        let running = Arc::clone(&running);
+        std::thread::spawn(move || {
+            periodic_backfill(&running, backfill_interval_secs);
+        });
+    }
+
     while running.load(Ordering::Relaxed) {
         match listener.accept() {
             Ok((stream, _)) => {
@@ -296,6 +305,57 @@ fn watchdog(
             // Poke the listener to unblock accept
             let _ = UnixStream::connect(socket_path);
             break;
+        }
+    }
+}
+
+fn periodic_backfill(running: &AtomicBool, interval_secs: u64) {
+    let interval = Duration::from_secs(interval_secs);
+    let db_path = crate::config::db_path();
+
+    // Wait one full interval before first check (startup backfill handles the initial run)
+    let mut elapsed = Duration::ZERO;
+    while elapsed < interval {
+        std::thread::sleep(Duration::from_secs(10));
+        if !running.load(Ordering::Relaxed) {
+            return;
+        }
+        elapsed += Duration::from_secs(10);
+    }
+
+    loop {
+        if !running.load(Ordering::Relaxed) {
+            break;
+        }
+
+        if db_path.exists() {
+            if let Ok(conn) = crate::db::get_connection(&db_path) {
+                let chunks: i64 = conn
+                    .query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
+                    .unwrap_or(0);
+                let vecs: i64 = conn
+                    .query_row("SELECT COUNT(*) FROM chunks_vec", [], |r| r.get(0))
+                    .unwrap_or(0);
+                drop(conn);
+
+                if chunks > vecs {
+                    let missing = chunks - vecs;
+                    eprintln!("Periodic backfill: {missing} vectors missing. Starting backfill.");
+                    if let Err(e) = crate::cli::backfill_with_worker(&db_path) {
+                        eprintln!("Periodic backfill warning: {e}");
+                    }
+                }
+            }
+        }
+
+        // Sleep for the next interval (in 10s increments to check running flag)
+        let mut elapsed = Duration::ZERO;
+        while elapsed < interval {
+            std::thread::sleep(Duration::from_secs(10));
+            if !running.load(Ordering::Relaxed) {
+                return;
+            }
+            elapsed += Duration::from_secs(10);
         }
     }
 }


### PR DESCRIPTION
## Summary

- embedder デーモンのアイドル時間に定期的にベクトル backfill を実行
- `embedder_backfill_interval_secs` で間隔を設定可能（デフォルト 300秒、0 で無効）
- 起動直後の backfill と重複しないよう、最初の1インターバルはスキップ
- backfill 中もクライアントリクエストに応答可能（別スレッド）
- mismatch がない場合は backfill をスキップ

Closes #14

## Test plan

- [x] config tests 全22件パス（新規3件含む）
- [x] embedder tests 全6件パス
- [x] release ビルド成功
- [ ] 実機で embedder 起動 → インデックス追加 → 5分後に自動 backfill 確認