### PR TITLE
fix: improve backfill worker crash resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ tsm search -q "query" -k 5
 # Index all documents
 tsm index
 
-# Start embedder daemon (required for vector search)
-tsm embedder-start
-
 # Health check
 tsm doctor
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -278,7 +278,13 @@ fn backfill_with_worker_sized(db_path: &Path, batch_size: usize) -> anyhow::Resu
     };
 
     loop {
-        let encode_fn = |texts: &[String]| worker.borrow_mut().encode(texts);
+        let encode_fn = |texts: &[String]| {
+            let timeout = std::time::Duration::from_secs(
+                config::WORKER_ENCODE_TIMEOUT_BASE_SECS
+                    + config::WORKER_ENCODE_TIMEOUT_PER_ITEM_SECS * texts.len() as u64,
+            );
+            worker.borrow_mut().encode(texts, timeout)
+        };
         let stats = indexer::backfill_vectors(&conn, &encode_fn, batch_size, Some(&progress_cb))?;
 
         if stats.errors == 0 {

--- a/src/db.rs
+++ b/src/db.rs
@@ -97,6 +97,12 @@ CREATE INDEX IF NOT EXISTS idx_dict_candidates_status_freq
     ON dictionary_candidates(status, frequency DESC);
 
 CREATE INDEX IF NOT EXISTS idx_chunks_document_id ON chunks(document_id);
+
+CREATE TABLE IF NOT EXISTS chunks_vec_skip (
+    chunk_id INTEGER PRIMARY KEY,
+    reason   TEXT NOT NULL DEFAULT 'encode_error',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
 "#;
 
 static VEC_INIT: Once = Once::new();

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -563,15 +563,16 @@ impl WorkerHandle {
     /// Send texts and receive embeddings via the pipe protocol.
     /// Returns Err on timeout or if the child has died.
     pub fn encode(&mut self, texts: &[String], timeout: Duration) -> Result<Vec<Vec<f32>>> {
+        if self.stdout.is_none() {
+            anyhow::bail!("worker handle is dead (killed after a previous timeout or crash)");
+        }
+
         let request = serde_json::json!({ "texts": texts });
         let request_bytes = serde_json::to_vec(&request)?;
         write_message(&mut self.stdin, &request_bytes)?;
 
         // Take stdout to move into a reader thread so we can enforce a timeout.
-        let mut stdout = self
-            .stdout
-            .take()
-            .context("worker stdout already taken")?;
+        let mut stdout = self.stdout.take().unwrap();
 
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
@@ -581,11 +582,13 @@ impl WorkerHandle {
 
         let (read_result, stdout_back) = match rx.recv_timeout(timeout) {
             Ok(pair) => pair,
-            Err(_) => {
-                // Timeout — kill the worker. The reader thread will get a broken pipe
-                // and exit naturally once the child process is gone.
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                 self.kill();
                 anyhow::bail!("worker encode timed out after {timeout:?}");
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                self.kill();
+                anyhow::bail!("worker reader thread died unexpectedly");
             }
         };
 

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -500,7 +500,7 @@ pub fn embed_via_socket_at(socket_path: &Path, texts: &[String]) -> Option<Vec<V
 pub struct WorkerHandle {
     child: Child,
     stdin: std::process::ChildStdin,
-    stdout: BufReader<std::process::ChildStdout>,
+    stdout: Option<BufReader<std::process::ChildStdout>>,
 }
 
 impl WorkerHandle {
@@ -556,21 +556,42 @@ impl WorkerHandle {
         Ok(Self {
             child,
             stdin,
-            stdout,
+            stdout: Some(stdout),
         })
     }
 
     /// Send texts and receive embeddings via the pipe protocol.
     /// Returns Err on timeout or if the child has died.
-    pub fn encode(&mut self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    pub fn encode(&mut self, texts: &[String], timeout: Duration) -> Result<Vec<Vec<f32>>> {
         let request = serde_json::json!({ "texts": texts });
         let request_bytes = serde_json::to_vec(&request)?;
         write_message(&mut self.stdin, &request_bytes)?;
 
-        // Read response — blocking read on pipe.
-        // If the child crashes, read_message returns Err (broken pipe).
-        let response_data = read_message(&mut self.stdout)
-            .context("worker pipe read error (child may have crashed)")?;
+        // Take stdout to move into a reader thread so we can enforce a timeout.
+        let mut stdout = self
+            .stdout
+            .take()
+            .context("worker stdout already taken")?;
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = read_message(&mut stdout);
+            let _ = tx.send((result, stdout));
+        });
+
+        let (read_result, stdout_back) = match rx.recv_timeout(timeout) {
+            Ok(pair) => pair,
+            Err(_) => {
+                // Timeout — kill the worker. The reader thread will get a broken pipe
+                // and exit naturally once the child process is gone.
+                self.kill();
+                anyhow::bail!("worker encode timed out after {timeout:?}");
+            }
+        };
+
+        self.stdout = Some(stdout_back);
+        let response_data =
+            read_result.context("worker pipe read error (child may have crashed)")?;
 
         let response: serde_json::Value = serde_json::from_slice(&response_data)?;
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -505,14 +505,20 @@ fn panic_message(info: &Box<dyn std::any::Any + Send>) -> String {
 /// Record a chunk in the skip table so it is not retried on subsequent backfill runs.
 /// The skip record is automatically cleaned up when the parent document is re-indexed
 /// (chunks are deleted and re-created with new IDs).
-fn mark_chunk_skip(conn: &Connection, chunk_id: i64, reason: &str) {
-    let _ = conn.execute(
+fn mark_chunk_skip(conn: &Connection, chunk_id: i64, reason: &str) -> bool {
+    match conn.execute(
         "INSERT OR IGNORE INTO chunks_vec_skip(chunk_id, reason) VALUES (?, ?)",
         rusqlite::params![chunk_id, reason],
-    );
+    ) {
+        Ok(_) => true,
+        Err(e) => {
+            eprintln!("    WARNING: failed to write skip record for chunk {chunk_id}: {e} — chunk will be retried next run");
+            false
+        }
+    }
 }
 
-/// Retry each chunk in the batch individually, writing sentinels for failures.
+/// Retry each chunk in the batch individually, skipping persistent failures.
 fn retry_individually(
     batch: &[(i64, String, String)],
     encode_fn: EncodeFn,
@@ -527,25 +533,25 @@ fn retry_individually(
                 if write_vec_row(conn, *chunk_id, &embeddings[0]) {
                     stats.filled += 1;
                 } else {
-                    eprintln!("    chunk {chunk_id} ({file_path}): insert error — writing sentinel");
-                    mark_chunk_skip(conn, *chunk_id, "encode_error");
+                    eprintln!("    chunk {chunk_id} ({file_path}): insert error — skipping");
+                    mark_chunk_skip(conn, *chunk_id, "insert_error");
                     stats.errors += 1;
                 }
             }
             Ok(Ok(_)) => {
-                eprintln!("    chunk {chunk_id} ({file_path}): empty embedding — writing sentinel");
-                mark_chunk_skip(conn, *chunk_id, "encode_error");
+                eprintln!("    chunk {chunk_id} ({file_path}): empty embedding — skipping");
+                mark_chunk_skip(conn, *chunk_id, "empty_embedding");
                 stats.errors += 1;
             }
             Ok(Err(e)) => {
-                eprintln!("    chunk {chunk_id} ({file_path}): error ({e}) — writing sentinel");
+                eprintln!("    chunk {chunk_id} ({file_path}): error ({e}) — skipping");
                 mark_chunk_skip(conn, *chunk_id, "encode_error");
                 stats.errors += 1;
             }
             Err(panic_info) => {
                 let msg = panic_message(&panic_info);
-                eprintln!("    chunk {chunk_id} ({file_path}): PANIC ({msg}) — writing sentinel");
-                mark_chunk_skip(conn, *chunk_id, "encode_error");
+                eprintln!("    chunk {chunk_id} ({file_path}): PANIC ({msg}) — skipping");
+                mark_chunk_skip(conn, *chunk_id, "panic");
                 stats.panics += 1;
                 stats.errors += 1;
             }
@@ -629,7 +635,8 @@ pub fn backfill_vectors(
                     if write_vec_row(&tx, *chunk_id, emb) {
                         stats.filled += 1;
                     } else {
-                        eprintln!("Insert error for chunk {chunk_id} (skipping)");
+                        eprintln!("Insert error for chunk {chunk_id} — skipping");
+                        mark_chunk_skip(conn, *chunk_id, "insert_error");
                         stats.errors += 1;
                     }
                 }
@@ -645,7 +652,8 @@ pub fn backfill_vectors(
                     eprintln!("  Retrying {} chunks individually...", batch.len());
                     retry_individually(&batch, encode_fn, conn, &mut stats);
                 } else {
-                    mark_chunk_skip(conn, batch_start_id, "embedding_count_mismatch");
+                    let chunk_id = batch[0].0;
+                    mark_chunk_skip(conn, chunk_id, "embedding_count_mismatch");
                     stats.errors += 1;
                 }
             }
@@ -655,8 +663,9 @@ pub fn backfill_vectors(
                     eprintln!("  Retrying {} chunks individually...", batch.len());
                     retry_individually(&batch, encode_fn, conn, &mut stats);
                 } else {
-                    eprintln!("  chunk {batch_start_id}: failed individually — writing sentinel");
-                    mark_chunk_skip(conn, batch_start_id, "encode_error");
+                    let chunk_id = batch[0].0;
+                    eprintln!("  chunk {chunk_id}: failed individually — skipping");
+                    mark_chunk_skip(conn, chunk_id, "encode_error");
                     stats.errors += 1;
                 }
             }
@@ -668,8 +677,9 @@ pub fn backfill_vectors(
                     eprintln!("  Retrying {} chunks individually...", batch.len());
                     retry_individually(&batch, encode_fn, conn, &mut stats);
                 } else {
-                    eprintln!("  chunk {batch_start_id}: failed individually — writing sentinel");
-                    mark_chunk_skip(conn, batch_start_id, "encode_error");
+                    let chunk_id = batch[0].0;
+                    eprintln!("  chunk {chunk_id}: failed individually — skipping");
+                    mark_chunk_skip(conn, chunk_id, "panic");
                     stats.errors += 1;
                 }
             }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1096,6 +1096,103 @@ mod tests {
         assert_eq!(stats2.errors, 0, "no errors on second run");
     }
 
+    #[test]
+    fn test_backfill_embedding_count_mismatch_triggers_retry() {
+        let (conn, dir) = setup();
+        for i in 0..3 {
+            let md = format!("# Doc {i}\n\nContent for doc number {i}.\n");
+            let path = write_md(dir.path(), &format!("daily/notes/test{i}.md"), &md);
+            index_file(&conn, &path, dir.path()).unwrap();
+        }
+        clear_vectors(&conn);
+
+        // Return wrong number of embeddings for batch (> 1), correct for individual (== 1)
+        let encode_mismatch = |texts: &[String]| -> anyhow::Result<Vec<Vec<f32>>> {
+            if texts.len() > 1 {
+                // Return only 1 embedding for a batch of N
+                mock_encode(&texts[..1].to_vec())
+            } else {
+                mock_encode(texts)
+            }
+        };
+
+        let stats = backfill_vectors(&conn, &encode_mismatch, 8, None).unwrap();
+        let chunk_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            stats.filled as i64, chunk_count,
+            "all chunks should be filled via individual retry after mismatch"
+        );
+    }
+
+    #[test]
+    fn test_backfill_skip_cleared_on_reindex() {
+        let (conn, dir) = setup();
+        let path = write_md(
+            dir.path(),
+            "daily/notes/test.md",
+            "# Hello\n\nContent here.\n",
+        );
+        index_file(&conn, &path, dir.path()).unwrap();
+        clear_vectors(&conn);
+
+        // Fail to create skip records
+        backfill_vectors(&conn, &mock_encode_fail, BACKFILL_BATCH_SIZE, None).unwrap();
+        let skip_before: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks_vec_skip", [], |r| r.get(0))
+            .unwrap();
+        assert!(skip_before > 0);
+
+        // Re-index same file with new content → old chunks deleted → skip records cleaned
+        std::fs::write(&path, "# Updated\n\nNew content.\n").unwrap();
+        index_file(&conn, &path, dir.path()).unwrap();
+        // Clear vectors that may have been inserted by a running embedder daemon
+        clear_vectors(&conn);
+
+        let skip_after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks_vec_skip", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            skip_after, 0,
+            "skip records should be cleaned up on re-index"
+        );
+
+        // Backfill should now succeed for the new chunks
+        let stats = backfill_vectors(&conn, &mock_encode, BACKFILL_BATCH_SIZE, None).unwrap();
+        assert!(stats.filled > 0, "new chunks should be backfilled");
+        assert_eq!(stats.errors, 0);
+    }
+
+    #[test]
+    fn test_backfill_batch_panic_retries_individually() {
+        let (conn, dir) = setup();
+        for i in 0..3 {
+            let md = format!("# Doc {i}\n\nContent for document number {i}.\n");
+            let path = write_md(dir.path(), &format!("daily/notes/test{i}.md"), &md);
+            index_file(&conn, &path, dir.path()).unwrap();
+        }
+        clear_vectors(&conn);
+
+        // Panic on batch (len > 1), succeed on individual (len == 1)
+        let encode_panic_batch = |texts: &[String]| -> anyhow::Result<Vec<Vec<f32>>> {
+            if texts.len() > 1 {
+                panic!("batch panic");
+            }
+            mock_encode(texts)
+        };
+
+        let stats = backfill_vectors(&conn, &encode_panic_batch, 8, None).unwrap();
+        let chunk_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
+            .unwrap();
+        assert!(stats.panics > 0, "should have caught batch panic");
+        assert_eq!(
+            stats.filled as i64, chunk_count,
+            "all chunks should be filled via individual retry after batch panic"
+        );
+    }
+
     // ─── entity integration tests ────────────────────────────
 
     #[test]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -71,6 +71,12 @@ fn delete_old_entries(conn: &Connection, doc_id: i64) -> anyhow::Result<()> {
             param_refs.as_slice(),
         );
 
+        // chunks_vec_skip — may not exist
+        let _ = conn.execute(
+            &format!("DELETE FROM chunks_vec_skip WHERE chunk_id IN ({placeholders})"),
+            param_refs.as_slice(),
+        );
+
         // chunk_entities — may not exist
         let _ = conn.execute(
             &format!("DELETE FROM chunk_entities WHERE chunk_id IN ({placeholders})"),
@@ -496,6 +502,57 @@ fn panic_message(info: &Box<dyn std::any::Any + Send>) -> String {
     }
 }
 
+/// Record a chunk in the skip table so it is not retried on subsequent backfill runs.
+/// The skip record is automatically cleaned up when the parent document is re-indexed
+/// (chunks are deleted and re-created with new IDs).
+fn mark_chunk_skip(conn: &Connection, chunk_id: i64, reason: &str) {
+    let _ = conn.execute(
+        "INSERT OR IGNORE INTO chunks_vec_skip(chunk_id, reason) VALUES (?, ?)",
+        rusqlite::params![chunk_id, reason],
+    );
+}
+
+/// Retry each chunk in the batch individually, writing sentinels for failures.
+fn retry_individually(
+    batch: &[(i64, String, String)],
+    encode_fn: EncodeFn,
+    conn: &Connection,
+    stats: &mut BackfillStats,
+) {
+    for (chunk_id, content, file_path) in batch {
+        let single = vec![content.clone()];
+        let result = catch_unwind(AssertUnwindSafe(|| encode_fn(&single)));
+        match result {
+            Ok(Ok(ref embeddings)) if !embeddings.is_empty() => {
+                if write_vec_row(conn, *chunk_id, &embeddings[0]) {
+                    stats.filled += 1;
+                } else {
+                    eprintln!("    chunk {chunk_id} ({file_path}): insert error — writing sentinel");
+                    mark_chunk_skip(conn, *chunk_id, "encode_error");
+                    stats.errors += 1;
+                }
+            }
+            Ok(Ok(_)) => {
+                eprintln!("    chunk {chunk_id} ({file_path}): empty embedding — writing sentinel");
+                mark_chunk_skip(conn, *chunk_id, "encode_error");
+                stats.errors += 1;
+            }
+            Ok(Err(e)) => {
+                eprintln!("    chunk {chunk_id} ({file_path}): error ({e}) — writing sentinel");
+                mark_chunk_skip(conn, *chunk_id, "encode_error");
+                stats.errors += 1;
+            }
+            Err(panic_info) => {
+                let msg = panic_message(&panic_info);
+                eprintln!("    chunk {chunk_id} ({file_path}): PANIC ({msg}) — writing sentinel");
+                mark_chunk_skip(conn, *chunk_id, "encode_error");
+                stats.panics += 1;
+                stats.errors += 1;
+            }
+        }
+    }
+}
+
 /// Fill in missing vectors for chunks that have FTS5 entries but no vector entries.
 /// Uses keyset pagination to avoid loading all missing chunks into memory at once.
 /// Each INSERT auto-commits individually (rusqlite default autocommit mode).
@@ -538,8 +595,9 @@ pub fn backfill_vectors(
                 "SELECT c.id, c.content, d.file_path
                  FROM chunks c
                  LEFT JOIN chunks_vec v ON c.id = v.rowid
+                 LEFT JOIN chunks_vec_skip s ON c.id = s.chunk_id
                  JOIN documents d ON c.document_id = d.id
-                 WHERE v.rowid IS NULL AND c.id > ?
+                 WHERE v.rowid IS NULL AND s.chunk_id IS NULL AND c.id > ?
                  ORDER BY c.id
                  LIMIT ?",
             )?
@@ -565,10 +623,10 @@ pub fn backfill_vectors(
             .collect();
 
         match catch_unwind(AssertUnwindSafe(|| encode_fn(&texts))) {
-            Ok(Ok(embeddings)) => {
+            Ok(Ok(embeddings)) if embeddings.len() == batch.len() => {
                 let tx = conn.unchecked_transaction()?;
                 for ((chunk_id, _, _), emb) in batch.iter().zip(embeddings.iter()) {
-                    if write_vec_row(conn, *chunk_id, emb) {
+                    if write_vec_row(&tx, *chunk_id, emb) {
                         stats.filled += 1;
                     } else {
                         eprintln!("Insert error for chunk {chunk_id} (skipping)");
@@ -577,17 +635,43 @@ pub fn backfill_vectors(
                 }
                 tx.commit()?;
             }
+            Ok(Ok(embeddings)) => {
+                eprintln!(
+                    "Embedding count mismatch (got {}, expected {}) for batch {batch_start_id}..{batch_end_id}",
+                    embeddings.len(),
+                    batch.len()
+                );
+                if batch.len() > 1 {
+                    eprintln!("  Retrying {} chunks individually...", batch.len());
+                    retry_individually(&batch, encode_fn, conn, &mut stats);
+                } else {
+                    mark_chunk_skip(conn, batch_start_id, "embedding_count_mismatch");
+                    stats.errors += 1;
+                }
+            }
             Ok(Err(e)) => {
-                eprintln!("Batch error (chunks {batch_start_id}..{batch_end_id}): {e} — skipping");
-                stats.errors += batch.len();
+                eprintln!("Batch error (chunks {batch_start_id}..{batch_end_id}): {e}");
+                if batch.len() > 1 {
+                    eprintln!("  Retrying {} chunks individually...", batch.len());
+                    retry_individually(&batch, encode_fn, conn, &mut stats);
+                } else {
+                    eprintln!("  chunk {batch_start_id}: failed individually — writing sentinel");
+                    mark_chunk_skip(conn, batch_start_id, "encode_error");
+                    stats.errors += 1;
+                }
             }
             Err(panic_info) => {
                 let msg = panic_message(&panic_info);
-                eprintln!(
-                    "PANIC in encode (chunks {batch_start_id}..{batch_end_id}): {msg} — skipping"
-                );
+                eprintln!("PANIC in encode (chunks {batch_start_id}..{batch_end_id}): {msg}");
                 stats.panics += 1;
-                stats.errors += batch.len();
+                if batch.len() > 1 {
+                    eprintln!("  Retrying {} chunks individually...", batch.len());
+                    retry_individually(&batch, encode_fn, conn, &mut stats);
+                } else {
+                    eprintln!("  chunk {batch_start_id}: failed individually — writing sentinel");
+                    mark_chunk_skip(conn, batch_start_id, "encode_error");
+                    stats.errors += 1;
+                }
             }
         }
 
@@ -926,6 +1010,80 @@ mod tests {
             stats.filled > 0,
             "should have filled some chunks after the panic"
         );
+    }
+
+    #[test]
+    fn test_backfill_retry_individually_on_batch_error() {
+        let (conn, dir) = setup();
+        // Create 3 files → at least 3 chunks
+        for i in 0..3 {
+            let md = format!("# Doc {i}\n\nContent for document number {i}.\n");
+            let path = write_md(dir.path(), &format!("daily/notes/test{i}.md"), &md);
+            index_file(&conn, &path, dir.path()).unwrap();
+        }
+        clear_vectors(&conn);
+
+        let chunk_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
+            .unwrap();
+        assert!(chunk_count >= 3, "need at least 3 chunks");
+
+        // Fail on batch (len > 1), succeed on individual (len == 1)
+        let encode_fail_batch = |texts: &[String]| -> anyhow::Result<Vec<Vec<f32>>> {
+            if texts.len() > 1 {
+                anyhow::bail!("batch error");
+            }
+            mock_encode(texts)
+        };
+
+        // Use batch_size > 1 to trigger batch failure + individual retry
+        let stats = backfill_vectors(&conn, &encode_fail_batch, 8, None).unwrap();
+        assert_eq!(
+            stats.filled as i64, chunk_count,
+            "all chunks should be filled via individual retry"
+        );
+        assert_eq!(stats.errors, 0, "no chunks should remain as errors");
+    }
+
+    #[test]
+    fn test_backfill_skip_written_for_persistent_failure() {
+        let (conn, dir) = setup();
+        let path = write_md(
+            dir.path(),
+            "daily/notes/test.md",
+            "# Hello\n\nContent here.\n",
+        );
+        index_file(&conn, &path, dir.path()).unwrap();
+        clear_vectors(&conn);
+
+        // Always fail
+        let stats =
+            backfill_vectors(&conn, &mock_encode_fail, BACKFILL_BATCH_SIZE, None).unwrap();
+        assert!(stats.errors > 0);
+
+        // Skip records should have been written
+        let skip_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks_vec_skip", [], |r| r.get(0))
+            .unwrap();
+        assert!(
+            skip_count > 0,
+            "skip records should be written for failed chunks"
+        );
+
+        // chunks_vec should remain empty (no sentinel vectors polluting search)
+        let vec_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks_vec", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(vec_count, 0, "no vectors should be written for failed chunks");
+
+        // A second run should find no missing vectors (skip table excludes them)
+        let stats2 =
+            backfill_vectors(&conn, &mock_encode_fail, BACKFILL_BATCH_SIZE, None).unwrap();
+        assert_eq!(
+            stats2.filled, 0,
+            "no chunks should be retried after skip"
+        );
+        assert_eq!(stats2.errors, 0, "no errors on second run");
     }
 
     // ─── entity integration tests ────────────────────────────


### PR DESCRIPTION
## Summary

Closes #21

- Add timeout to `WorkerHandle::encode()` using `mpsc::channel` + thread (`base 10s + 5s × batch_size`), kill worker on timeout
- Retry failed batches individually (1 chunk at a time) to isolate problematic chunks instead of skipping entire batches
- Track failed chunks in new `chunks_vec_skip` table instead of sentinel zero-vectors, avoiding search result pollution
- Guard against embedding count mismatch from worker response
- Fix transaction usage in backfill success path (`conn` → `&tx`)
- Clean up skip records when documents are re-indexed

## Test plan

- [x] `test_backfill_retry_individually_on_batch_error` — batch failure triggers individual retry, all good chunks succeed
- [x] `test_backfill_skip_written_for_persistent_failure` — persistent failures recorded in skip table, second run skips them
- [x] All 307 existing tests pass
- [ ] Manual test: `tsm rebuild --force` with production data to verify crash recovery