### PR TITLE
feat: show related documents in search hook output

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "the-space-memory",
   "description": "Cross-workspace knowledge search engine with hybrid FTS5 + vector search",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "Mitsukuni Sato"
   },

--- a/hooks/scripts/search.sh
+++ b/hooks/scripts/search.sh
@@ -56,6 +56,11 @@ echo "[$(date -Iseconds)] OK: $COUNT results" >> "$LOG"
 jq -n --argjson results "$RESULT" '{
   hookSpecificOutput: {
     hookEventName: "UserPromptSubmit",
-    additionalContext: ("ナレッジ検索結果 (自動):\n" + ($results | map("- [\(.source_file)] \(.section_path): \(.snippet[0:100])") | join("\n")))
+    additionalContext: ("ナレッジ検索結果 (自動):\n" + ($results | map(
+      "- [\(.source_file)] \(.section_path): \(.snippet[0:100])"
+      + (if (.related_docs // [] | length) > 0
+         then "\n  関連: " + (.related_docs | map("[\(.file_path)](\(.link_type))") | join(", "))
+         else "" end)
+    ) | join("\n")))
   }
 }'


### PR DESCRIPTION
## Summary

- Display `related_docs` (from `document_links` table) in the UserPromptSubmit search hook output
- Each search result now shows linked documents with link type (`explicit`, `tag`, `entity`) when available
- Data was already returned by `tsm search --format json` but the hook was ignoring it

### Before
```
- [source_file] section_path: snippet...
```

### After
```
- [source_file] section_path: snippet...
  関連: [related/file.md](tag), [other/file.md](entity)
```

## Test plan

- [x] Verified `tsm search --format json` returns `related_docs` with link types
- [x] Verified jq template correctly formats results with and without related docs
- [ ] Manual test: trigger UserPromptSubmit hook and verify related docs appear in context