### PR TITLE
feat: route CLI commands through tsmd with transparent fallback

### DIFF
--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -100,7 +100,8 @@ fn main() -> Result<()> {
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
             Err(e) => {
-                eprintln!("tsmd: accept error: {e}");
+                eprintln!("tsmd: fatal accept error: {e}");
+                break;
             }
         }
     }
@@ -123,6 +124,7 @@ fn handle_client(
 ) -> Result<()> {
     // Prevent slow/disconnected clients from holding threads indefinitely
     stream.set_read_timeout(Some(std::time::Duration::from_secs(30)))?;
+    stream.set_write_timeout(Some(std::time::Duration::from_secs(30)))?;
     let req = read_request(stream)?;
     let conn = conn
         .lock()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1461,4 +1461,59 @@ mod tests {
         let result = cmd_ingest_session(Path::new("/nonexistent/session.jsonl"));
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_doctor_report_serde_roundtrip() {
+        let report = DoctorReport {
+            sections: vec![DoctorSection {
+                name: "Database".to_string(),
+                items: vec![
+                    CheckItem {
+                        status: CheckStatus::Ok,
+                        message: "DB: /tmp/test.db (1.0 MB)".to_string(),
+                        hint: None,
+                    },
+                    CheckItem {
+                        status: CheckStatus::Warning,
+                        message: "Vectors: 0 / 100 chunks".to_string(),
+                        hint: Some("Run `vector-fill`.".to_string()),
+                    },
+                    CheckItem {
+                        status: CheckStatus::Error,
+                        message: "DB missing".to_string(),
+                        hint: Some("Run `init`.".to_string()),
+                    },
+                ],
+            }],
+        };
+        let json = serde_json::to_value(&report).unwrap();
+        let decoded: DoctorReport = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.sections.len(), 1);
+        assert_eq!(decoded.sections[0].items.len(), 3);
+        assert_eq!(decoded.sections[0].items[0].status, CheckStatus::Ok);
+        assert_eq!(decoded.sections[0].items[1].status, CheckStatus::Warning);
+        assert_eq!(decoded.sections[0].items[2].status, CheckStatus::Error);
+        assert!(decoded.sections[0].items[0].hint.is_none());
+        assert!(decoded.sections[0].items[1].hint.is_some());
+    }
+
+    #[test]
+    fn test_doctor_to_json_output_shape() {
+        let report = DoctorReport {
+            sections: vec![DoctorSection {
+                name: "Test".to_string(),
+                items: vec![CheckItem {
+                    status: CheckStatus::Ok,
+                    message: "All good".to_string(),
+                    hint: None,
+                }],
+            }],
+        };
+        let json_str = report.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert!(parsed["sections"].is_array());
+        assert_eq!(parsed["issue_count"], 0);
+        assert_eq!(parsed["sections"][0]["name"], "Test");
+        assert_eq!(parsed["sections"][0]["items"][0]["status"], "ok");
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -513,12 +513,30 @@ fn doctor_check_with_conn(
     report: &mut DoctorReport,
     mut db_section: DoctorSection,
 ) {
-    let docs: i64 = conn
-        .query_row("SELECT COUNT(*) FROM documents", [], |r| r.get(0))
-        .unwrap_or(0);
-    let chunks: i64 = conn
-        .query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
-        .unwrap_or(0);
+    let docs: i64 = match conn.query_row("SELECT COUNT(*) FROM documents", [], |r| r.get(0)) {
+        Ok(n) => n,
+        Err(e) => {
+            db_section.items.push(CheckItem {
+                status: CheckStatus::Error,
+                message: format!("Failed to query documents: {e}"),
+                hint: Some("Run `init` to initialize the database.".to_string()),
+            });
+            report.sections.push(db_section);
+            return;
+        }
+    };
+    let chunks: i64 = match conn.query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0)) {
+        Ok(n) => n,
+        Err(e) => {
+            db_section.items.push(CheckItem {
+                status: CheckStatus::Error,
+                message: format!("Failed to query chunks: {e}"),
+                hint: Some("Run `init` to initialize the database.".to_string()),
+            });
+            report.sections.push(db_section);
+            return;
+        }
+    };
     db_section.items.push(CheckItem {
         status: CheckStatus::Ok,
         message: format!("Documents: {docs}"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -258,11 +258,10 @@ pub fn backfill_with_worker(db_path: &Path) -> anyhow::Result<()> {
     backfill_with_worker_sized(db_path, indexer::BACKFILL_BATCH_SIZE)
 }
 
-/// Run backfill via a worker subprocess with specified batch size.
-pub fn backfill_with_worker_sized(db_path: &Path, batch_size: usize) -> anyhow::Result<()> {
+/// Run vector backfill with an existing connection (daemon-safe).
+pub fn run_vector_fill(conn: &rusqlite::Connection, batch_size: usize) -> anyhow::Result<()> {
     use crate::status;
 
-    let conn = db::get_connection(db_path)?;
     let worker = std::cell::RefCell::new(embedder::WorkerHandle::spawn(
         std::time::Duration::from_secs(120),
     )?);
@@ -299,7 +298,7 @@ pub fn backfill_with_worker_sized(db_path: &Path, batch_size: usize) -> anyhow::
             );
             worker.borrow_mut().encode(texts, timeout)
         };
-        let stats = indexer::backfill_vectors(&conn, &encode_fn, batch_size, Some(&progress_cb))?;
+        let stats = indexer::backfill_vectors(conn, &encode_fn, batch_size, Some(&progress_cb))?;
 
         if stats.errors == 0 {
             if stats.filled > 0 {
@@ -343,6 +342,12 @@ pub fn backfill_with_worker_sized(db_path: &Path, batch_size: usize) -> anyhow::
     Ok(())
 }
 
+/// Run backfill via a worker subprocess with specified batch size (opens DB).
+pub fn backfill_with_worker_sized(db_path: &Path, batch_size: usize) -> anyhow::Result<()> {
+    let conn = db::get_connection(db_path)?;
+    run_vector_fill(&conn, batch_size)
+}
+
 pub fn cmd_import_wordnet(wordnet_db: &Path) -> anyhow::Result<()> {
     let db_path = config::db_path();
     let conn = db::get_connection(&db_path)?;
@@ -375,27 +380,29 @@ pub fn cmd_setup() -> anyhow::Result<()> {
 }
 
 /// Doctor output as a structured result for testability.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum CheckStatus {
     Ok,
     Warning,
     Error,
 }
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct CheckItem {
     pub status: CheckStatus,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hint: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct DoctorSection {
     pub name: String,
     pub items: Vec<CheckItem>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct DoctorReport {
     pub sections: Vec<DoctorSection>,
 }
@@ -433,37 +440,8 @@ impl DoctorReport {
     }
 
     pub fn to_json(&self) -> String {
-        let sections: Vec<serde_json::Value> = self
-            .sections
-            .iter()
-            .map(|s| {
-                let items: Vec<serde_json::Value> = s
-                    .items
-                    .iter()
-                    .map(|i| {
-                        let mut obj = serde_json::json!({
-                            "status": match i.status {
-                                CheckStatus::Ok => "ok",
-                                CheckStatus::Warning => "warning",
-                                CheckStatus::Error => "error",
-                            },
-                            "message": i.message,
-                        });
-                        if let Some(hint) = &i.hint {
-                            obj["hint"] = serde_json::Value::String(hint.clone());
-                        }
-                        obj
-                    })
-                    .collect();
-                serde_json::json!({
-                    "name": s.name,
-                    "items": items,
-                })
-            })
-            .collect();
-
         serde_json::json!({
-            "sections": sections,
+            "sections": self.sections,
             "issue_count": self.issue_count(),
         })
         .to_string()
@@ -686,7 +664,7 @@ pub fn cmd_doctor(format: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn render_doctor_report(report: &DoctorReport) {
+pub fn render_doctor_report(report: &DoctorReport) {
     let use_color = std::env::var("NO_COLOR").is_err();
 
     let (green, yellow, red, bold, dim, reset) = if use_color {
@@ -769,7 +747,7 @@ fn render_doctor_report(report: &DoctorReport) {
 }
 
 /// Structured status information for the system.
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct StatusInfo {
     pub daemon_running: bool,
     pub daemon_pid: Option<u32>,
@@ -784,7 +762,7 @@ pub struct StatusInfo {
     pub dict_candidates_ready: Option<i64>,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct BackfillInfo {
     pub filled: usize,
     pub total: i64,
@@ -852,11 +830,7 @@ pub fn run_status(conn: Option<&rusqlite::Connection>) -> StatusInfo {
     }
 }
 
-pub fn cmd_status() -> anyhow::Result<()> {
-    let db_path = config::db_path();
-    let conn = db::get_connection(&db_path).ok();
-    let info = run_status(conn.as_ref());
-
+pub fn print_status_info(info: &StatusInfo) {
     println!("=== The Space Memory Status ===\n");
 
     // Daemon
@@ -928,7 +902,13 @@ pub fn cmd_status() -> anyhow::Result<()> {
     } else {
         println!("  DB:        not found");
     }
+}
 
+pub fn cmd_status() -> anyhow::Result<()> {
+    let db_path = config::db_path();
+    let conn = db::get_connection(&db_path).ok();
+    let info = run_status(conn.as_ref());
+    print_status_info(&info);
     Ok(())
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -286,6 +286,16 @@ mod tests {
     }
 
     #[test]
+    fn test_vector_fill_empty_db() {
+        let (conn, dir) = setup();
+        let flag = AtomicBool::new(false);
+        let req = DaemonRequest::VectorFill { batch_size: 8 };
+        let resp = handle_request(&conn, req, dir.path(), &flag);
+        // Empty DB has no chunks to backfill — should succeed or error gracefully
+        assert!(resp.ok || resp.error.is_some());
+    }
+
+    #[test]
     fn test_doctor_text_format() {
         let (conn, dir) = setup();
         let flag = AtomicBool::new(false);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6,7 +6,6 @@ use rusqlite::Connection;
 use crate::cli;
 use crate::config;
 use crate::daemon_protocol::{DaemonRequest, DaemonResponse};
-use crate::user_dict::DictFormat;
 
 /// Handle a single daemon request and return a response.
 ///
@@ -106,8 +105,7 @@ pub fn handle_request(
         }
 
         DaemonRequest::VectorFill { batch_size } => {
-            let db_path = config::db_path();
-            match cli::backfill_with_worker_sized(&db_path, batch_size) {
+            match cli::run_vector_fill(conn, batch_size) {
                 Ok(()) => DaemonResponse::success_empty(),
                 Err(e) => DaemonResponse::error(format!("{e}")),
             }
@@ -123,25 +121,13 @@ pub fn handle_request(
             }
         }
 
-        DaemonRequest::DictUpdate {
-            threshold,
-            yes,
-            format,
-        } => {
-            let dict_format = match format.as_str() {
-                "simpledic" => DictFormat::Simpledic,
-                _ => DictFormat::Ipadic,
-            };
-            match cli::cmd_dict_update(threshold, yes, dict_format) {
-                Ok(()) => DaemonResponse::success_empty(),
-                Err(e) => DaemonResponse::error(format!("{e}")),
-            }
-        }
+        DaemonRequest::DictUpdate { .. } => DaemonResponse::error(
+            "dict-update cannot run while tsmd is active. Run `tsm stop` first.",
+        ),
 
-        DaemonRequest::Rebuild { force } => match cli::cmd_rebuild(force) {
-            Ok(()) => DaemonResponse::success_empty(),
-            Err(e) => DaemonResponse::error(format!("{e}")),
-        },
+        DaemonRequest::Rebuild { .. } => DaemonResponse::error(
+            "rebuild cannot run while tsmd is active. Run `tsm stop` first.",
+        ),
     }
 }
 
@@ -276,32 +262,27 @@ mod tests {
     }
 
     #[test]
-    fn test_dict_update_no_candidates() {
+    fn test_dict_update_rejected_by_daemon() {
         let (conn, dir) = setup();
         let flag = AtomicBool::new(false);
-        // With empty DB and yes=true, should complete without error
-        // (no candidates to update)
         let req = DaemonRequest::DictUpdate {
             threshold: 5,
             yes: true,
             format: "ipadic".into(),
         };
         let resp = handle_request(&conn, req, dir.path(), &flag);
-        // May succeed or error depending on dict path, but should not panic
-        assert!(resp.ok || resp.error.is_some());
+        assert!(!resp.ok);
+        assert!(resp.error.unwrap().contains("tsm stop"));
     }
 
     #[test]
-    fn test_dict_update_simpledic_format() {
+    fn test_rebuild_rejected_by_daemon() {
         let (conn, dir) = setup();
         let flag = AtomicBool::new(false);
-        let req = DaemonRequest::DictUpdate {
-            threshold: 5,
-            yes: true,
-            format: "simpledic".into(),
-        };
+        let req = DaemonRequest::Rebuild { force: true };
         let resp = handle_request(&conn, req, dir.path(), &flag);
-        assert!(resp.ok || resp.error.is_some());
+        assert!(!resp.ok);
+        assert!(resp.error.unwrap().contains("tsm stop"));
     }
 
     #[test]

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -118,11 +118,8 @@ pub fn try_send_request(socket: &Path, req: &DaemonRequest) -> Option<Result<Dae
         Ok(s) => s,
         Err(_) => return None, // stale socket or connection refused
     };
-    if stream
-        .set_read_timeout(Some(std::time::Duration::from_secs(300)))
-        .is_err()
-    {
-        return None;
+    if let Err(e) = stream.set_read_timeout(Some(std::time::Duration::from_secs(300))) {
+        return Some(Err(anyhow::anyhow!("Failed to set socket read timeout: {e}")));
     }
     let req_bytes = match serde_json::to_vec(req) {
         Ok(b) => b,
@@ -442,6 +439,38 @@ mod tests {
         let mut client = UnixStream::connect(&sock_path).unwrap();
         write_message(&mut client, b"not valid json").unwrap();
         drop(client);
+
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn try_send_request_success() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let sock_path = dir.path().join("test-try.sock");
+        let sock_path_clone = sock_path.clone();
+
+        let server = std::thread::spawn(move || {
+            let listener = UnixListener::bind(&sock_path_clone).unwrap();
+            let (mut stream, _) = listener.accept().unwrap();
+            let req = read_request(&mut stream).unwrap();
+            assert!(matches!(req, DaemonRequest::Ping));
+            let resp = DaemonResponse::success_empty();
+            write_response(&mut stream, &resp).unwrap();
+        });
+
+        for _ in 0..50 {
+            if sock_path.exists() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        let result = try_send_request(&sock_path, &DaemonRequest::Ping);
+        assert!(result.is_some());
+        let resp = result.unwrap().unwrap();
+        assert!(resp.ok);
 
         server.join().unwrap();
     }

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -105,6 +105,38 @@ pub fn send_request(socket: &Path, req: &DaemonRequest) -> Result<DaemonResponse
     Ok(resp)
 }
 
+/// Try to send a request to the daemon, with transparent fallback.
+///
+/// Returns `None` if the daemon is not running (socket absent or connection refused).
+/// Returns `Some(Ok(resp))` on successful communication.
+/// Returns `Some(Err(e))` on protocol-level errors.
+pub fn try_send_request(socket: &Path, req: &DaemonRequest) -> Option<Result<DaemonResponse>> {
+    if !socket.exists() {
+        return None;
+    }
+    let mut stream = match UnixStream::connect(socket) {
+        Ok(s) => s,
+        Err(_) => return None, // stale socket or connection refused
+    };
+    if stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(300)))
+        .is_err()
+    {
+        return None;
+    }
+    let req_bytes = match serde_json::to_vec(req) {
+        Ok(b) => b,
+        Err(e) => return Some(Err(e.into())),
+    };
+    if let Err(e) = write_message(&mut stream, &req_bytes) {
+        return Some(Err(e));
+    }
+    match read_message(&mut stream) {
+        Ok(resp_bytes) => Some(serde_json::from_slice(&resp_bytes).map_err(Into::into)),
+        Err(e) => Some(Err(e)),
+    }
+}
+
 // ─── Server helpers ───────────────────────────────────────────────
 
 /// Read a request from a connected client stream.
@@ -412,5 +444,24 @@ mod tests {
         drop(client);
 
         server.join().unwrap();
+    }
+
+    #[test]
+    fn try_send_request_no_socket_returns_none() {
+        let result = try_send_request(
+            std::path::Path::new("/tmp/nonexistent-tsm-test.sock"),
+            &DaemonRequest::Ping,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn try_send_request_stale_socket_returns_none() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sock_path = dir.path().join("stale.sock");
+        // Create a file (not a socket listener) to simulate a stale socket
+        std::fs::write(&sock_path, "stale").unwrap();
+        let result = try_send_request(&sock_path, &DaemonRequest::Ping);
+        assert!(result.is_none());
     }
 }

--- a/src/doc_links.rs
+++ b/src/doc_links.rs
@@ -6,7 +6,7 @@ use rusqlite::Connection;
 use crate::db;
 
 /// A related document found via document links.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RelatedDoc {
     pub file_path: String,
     pub link_type: String,

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -2,6 +2,9 @@ use std::io::{Read, Write};
 
 use anyhow::Result;
 
+/// Maximum message size (64 MB). Prevents OOM from malformed length headers.
+const MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+
 /// Read a length-prefixed message from a stream.
 ///
 /// Wire format: `[4-byte big-endian length][payload bytes]`
@@ -9,6 +12,10 @@ pub fn read_message(stream: &mut impl Read) -> Result<Vec<u8>> {
     let mut len_buf = [0u8; 4];
     stream.read_exact(&mut len_buf)?;
     let msg_len = u32::from_be_bytes(len_buf) as usize;
+
+    if msg_len > MAX_MESSAGE_SIZE {
+        anyhow::bail!("Message too large: {msg_len} bytes (max {MAX_MESSAGE_SIZE})");
+    }
 
     let mut buf = vec![0u8; msg_len];
     stream.read_exact(&mut buf)?;
@@ -104,5 +111,15 @@ mod tests {
         buf.extend_from_slice(b"short"); // Only 5 bytes
         let mut cursor = Cursor::new(buf);
         assert!(read_message(&mut cursor).is_err());
+    }
+
+    #[test]
+    fn read_oversized_message_fails() {
+        let huge_len = (super::MAX_MESSAGE_SIZE as u32) + 1;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&huge_len.to_be_bytes());
+        let mut cursor = Cursor::new(buf);
+        let err = read_message(&mut cursor).unwrap_err();
+        assert!(err.to_string().contains("too large"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,7 +172,7 @@ fn main() -> anyhow::Result<()> {
                 recent: recent.clone(),
                 year,
             };
-            if let Some(resp) = try_daemon(&req) {
+            if let Some(resp) = try_daemon(&req)? {
                 render_search(resp, &format)?;
             } else {
                 cli::cmd_search(cli::SearchOptions {
@@ -192,7 +192,7 @@ fn main() -> anyhow::Result<()> {
             if !files_from_stdin {
                 // Full index — try daemon first
                 let req = DaemonRequest::Index { files: vec![] };
-                if let Some(resp) = try_daemon(&req) {
+                if let Some(resp) = try_daemon(&req)? {
                     render_index(resp)?;
                 } else {
                     cli::cmd_index(false)?;
@@ -208,7 +208,7 @@ fn main() -> anyhow::Result<()> {
                     .collect();
 
                 let req = DaemonRequest::Index { files: rel_paths };
-                if let Some(resp) = try_daemon(&req) {
+                if let Some(resp) = try_daemon(&req)? {
                     render_index(resp)?;
                 } else {
                     let stats = cli::run_index(
@@ -228,7 +228,7 @@ fn main() -> anyhow::Result<()> {
             let req = DaemonRequest::IngestSession {
                 session_file: session_file.to_string_lossy().to_string(),
             };
-            if let Some(resp) = try_daemon(&req) {
+            if let Some(resp) = try_daemon(&req)? {
                 render_ingest(resp, &session_file)?;
             } else {
                 cli::cmd_ingest_session(&session_file)?;
@@ -237,7 +237,7 @@ fn main() -> anyhow::Result<()> {
 
         Commands::Status => {
             let req = DaemonRequest::Status;
-            if let Some(resp) = try_daemon(&req) {
+            if let Some(resp) = try_daemon(&req)? {
                 render_status(resp)?;
             } else {
                 cli::cmd_status()?;
@@ -248,7 +248,7 @@ fn main() -> anyhow::Result<()> {
             let req = DaemonRequest::Doctor {
                 format: format.clone(),
             };
-            if let Some(resp) = try_daemon(&req) {
+            if let Some(resp) = try_daemon(&req)? {
                 render_doctor(resp, &format)?;
             } else {
                 cli::cmd_doctor(&format)?;
@@ -259,14 +259,8 @@ fn main() -> anyhow::Result<()> {
             let req = DaemonRequest::ImportWordnet {
                 wordnet_db: wordnet_db.to_string_lossy().to_string(),
             };
-            if let Some(resp) = try_daemon(&req) {
-                if !resp.ok {
-                    anyhow::bail!("{}", resp.error.unwrap_or_default());
-                }
-                if let Some(payload) = resp.payload {
-                    let count = payload["imported"].as_i64().unwrap_or(0);
-                    eprintln!("Imported {count} synonym pairs from WordNet.");
-                }
+            if let Some(resp) = try_daemon(&req)? {
+                render_import_wordnet(resp)?;
             } else {
                 cli::cmd_import_wordnet(&wordnet_db)?;
             }
@@ -277,49 +271,64 @@ fn main() -> anyhow::Result<()> {
 
 // ─── Daemon routing helpers ───────────────────────────────────────
 
-/// Try to send a request to the daemon. Returns Some(response) if daemon handled it, None to fallback.
-fn try_daemon(req: &DaemonRequest) -> Option<DaemonResponse> {
+/// Try to send a request to the daemon.
+/// Returns `Ok(Some(resp))` if daemon handled it.
+/// Returns `Ok(None)` if daemon is not running (fallback to direct).
+/// Returns `Err` if daemon is running but communication failed (no fallback — could cause double execution).
+fn try_daemon(req: &DaemonRequest) -> anyhow::Result<Option<DaemonResponse>> {
     let socket = config::daemon_socket_path();
     match daemon_protocol::try_send_request(&socket, req) {
-        Some(Ok(resp)) => Some(resp),
+        Some(Ok(resp)) => Ok(Some(resp)),
         Some(Err(e)) => {
-            eprintln!("warning: daemon communication error: {e}");
-            None // fallback to direct
+            anyhow::bail!("Daemon communication error: {e}\nRun `tsm stop` and retry.")
         }
-        None => None, // daemon not running
+        None => Ok(None), // daemon not running, direct fallback is safe
     }
 }
 
 /// Guard: error if the daemon is running (for commands that can't coexist).
 fn guard_daemon_not_running(command: &str) -> anyhow::Result<()> {
     let socket = config::daemon_socket_path();
-    if let Some(Ok(resp)) = daemon_protocol::try_send_request(&socket, &DaemonRequest::Ping) {
-        if resp.ok {
+    match daemon_protocol::try_send_request(&socket, &DaemonRequest::Ping) {
+        Some(Ok(resp)) if resp.ok => {
+            anyhow::bail!("tsmd is running. Run `tsm stop` before `{command}`.");
+        }
+        Some(Err(e)) => {
             anyhow::bail!(
-                "tsmd is running. Run `tsm stop` before `{command}`."
+                "Could not verify daemon status before `{command}`: {e}\nRun `tsm stop` to ensure the daemon is not running."
             );
         }
+        _ => Ok(()), // No socket or ping returned ok: false — safe to proceed
     }
-    Ok(())
 }
 
 // ─── Render helpers (daemon response → terminal output) ───────────
 
-fn render_search(resp: DaemonResponse, format: &str) -> anyhow::Result<()> {
+fn print_json(value: &serde_json::Value) {
+    println!("{}", serde_json::to_string_pretty(value).unwrap_or_default());
+}
+
+fn check_resp(resp: &DaemonResponse) -> anyhow::Result<()> {
     if !resp.ok {
-        anyhow::bail!("{}", resp.error.unwrap_or_default());
+        anyhow::bail!(
+            "{}",
+            resp.error
+                .clone()
+                .unwrap_or_else(|| "(daemon returned error with no message)".into())
+        );
     }
+    Ok(())
+}
+
+fn render_search(resp: DaemonResponse, format: &str) -> anyhow::Result<()> {
+    check_resp(&resp)?;
     let payload = resp.payload.unwrap_or_default();
     match format {
-        "json" => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&payload).unwrap_or_default()
-            );
-        }
+        "json" => print_json(&payload),
         _ => {
             let results: Vec<the_space_memory::searcher::SearchResult> =
-                serde_json::from_value(payload).unwrap_or_default();
+                serde_json::from_value(payload)
+                    .map_err(|e| anyhow::anyhow!("Failed to parse search results: {e}"))?;
             print!("{}", cli::format_text(&results));
         }
     }
@@ -327,9 +336,7 @@ fn render_search(resp: DaemonResponse, format: &str) -> anyhow::Result<()> {
 }
 
 fn render_index(resp: DaemonResponse) -> anyhow::Result<()> {
-    if !resp.ok {
-        anyhow::bail!("{}", resp.error.unwrap_or_default());
-    }
+    check_resp(&resp)?;
     if let Some(payload) = resp.payload {
         let indexed = payload["indexed"].as_i64().unwrap_or(0);
         let skipped = payload["skipped"].as_i64().unwrap_or(0);
@@ -340,9 +347,7 @@ fn render_index(resp: DaemonResponse) -> anyhow::Result<()> {
 }
 
 fn render_ingest(resp: DaemonResponse, session_file: &std::path::Path) -> anyhow::Result<()> {
-    if !resp.ok {
-        anyhow::bail!("{}", resp.error.unwrap_or_default());
-    }
+    check_resp(&resp)?;
     let name = session_file
         .file_name()
         .unwrap_or_default()
@@ -358,41 +363,39 @@ fn render_ingest(resp: DaemonResponse, session_file: &std::path::Path) -> anyhow
 }
 
 fn render_status(resp: DaemonResponse) -> anyhow::Result<()> {
-    if !resp.ok {
-        anyhow::bail!("{}", resp.error.unwrap_or_default());
-    }
+    check_resp(&resp)?;
     if let Some(payload) = resp.payload {
-        match serde_json::from_value::<cli::StatusInfo>(payload) {
-            Ok(info) => cli::print_status_info(&info),
-            Err(_) => eprintln!("(could not parse daemon status)"),
-        }
+        let info: cli::StatusInfo = serde_json::from_value(payload).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to parse daemon status: {e}\nTry `tsm stop && tsm start` to refresh."
+            )
+        })?;
+        cli::print_status_info(&info);
     }
     Ok(())
 }
 
 fn render_doctor(resp: DaemonResponse, format: &str) -> anyhow::Result<()> {
-    if !resp.ok {
-        anyhow::bail!("{}", resp.error.unwrap_or_default());
-    }
+    check_resp(&resp)?;
     let payload = resp.payload.unwrap_or_default();
-    match format {
-        "json" => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&payload).unwrap_or_default()
-            );
-        }
-        _ => {
-            match serde_json::from_value::<cli::DoctorReport>(payload.clone()) {
-                Ok(report) => cli::render_doctor_report(&report),
-                Err(_) => {
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&payload).unwrap_or_default()
-                    );
-                }
-            }
-        }
+    if format == "json" {
+        print_json(&payload);
+        return Ok(());
+    }
+    let report: cli::DoctorReport = serde_json::from_value(payload).map_err(|e| {
+        anyhow::anyhow!(
+            "Failed to parse daemon doctor report: {e}\nTry `tsm stop && tsm start` to refresh."
+        )
+    })?;
+    cli::render_doctor_report(&report);
+    Ok(())
+}
+
+fn render_import_wordnet(resp: DaemonResponse) -> anyhow::Result<()> {
+    check_resp(&resp)?;
+    if let Some(payload) = resp.payload {
+        let count = payload["imported"].as_i64().unwrap_or(0);
+        eprintln!("Imported {count} synonym pairs from WordNet.");
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,7 @@ fn main() -> anyhow::Result<()> {
                 year,
             };
             if let Some(resp) = try_daemon(&req) {
-                render_search(resp, &format);
+                render_search(resp, &format)?;
             } else {
                 cli::cmd_search(cli::SearchOptions {
                     query: &query,
@@ -193,7 +193,7 @@ fn main() -> anyhow::Result<()> {
                 // Full index — try daemon first
                 let req = DaemonRequest::Index { files: vec![] };
                 if let Some(resp) = try_daemon(&req) {
-                    render_index(resp);
+                    render_index(resp)?;
                 } else {
                     cli::cmd_index(false)?;
                 }
@@ -207,11 +207,9 @@ fn main() -> anyhow::Result<()> {
                     .map(|p| p.to_string_lossy().to_string())
                     .collect();
 
-                let req = DaemonRequest::Index {
-                    files: rel_paths.clone(),
-                };
+                let req = DaemonRequest::Index { files: rel_paths };
                 if let Some(resp) = try_daemon(&req) {
-                    render_index(resp);
+                    render_index(resp)?;
                 } else {
                     let stats = cli::run_index(
                         &the_space_memory::db::get_connection(&config::db_path())?,
@@ -231,7 +229,7 @@ fn main() -> anyhow::Result<()> {
                 session_file: session_file.to_string_lossy().to_string(),
             };
             if let Some(resp) = try_daemon(&req) {
-                render_ingest(resp, &session_file);
+                render_ingest(resp, &session_file)?;
             } else {
                 cli::cmd_ingest_session(&session_file)?;
             }
@@ -240,7 +238,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Status => {
             let req = DaemonRequest::Status;
             if let Some(resp) = try_daemon(&req) {
-                render_status(resp);
+                render_status(resp)?;
             } else {
                 cli::cmd_status()?;
             }
@@ -251,7 +249,7 @@ fn main() -> anyhow::Result<()> {
                 format: format.clone(),
             };
             if let Some(resp) = try_daemon(&req) {
-                render_doctor(resp, &format);
+                render_doctor(resp, &format)?;
             } else {
                 cli::cmd_doctor(&format)?;
             }
@@ -262,13 +260,12 @@ fn main() -> anyhow::Result<()> {
                 wordnet_db: wordnet_db.to_string_lossy().to_string(),
             };
             if let Some(resp) = try_daemon(&req) {
-                if resp.ok {
-                    if let Some(payload) = resp.payload {
-                        let count = payload["imported"].as_i64().unwrap_or(0);
-                        eprintln!("Imported {count} synonym pairs from WordNet.");
-                    }
-                } else {
-                    eprintln!("error: {}", resp.error.unwrap_or_default());
+                if !resp.ok {
+                    anyhow::bail!("{}", resp.error.unwrap_or_default());
+                }
+                if let Some(payload) = resp.payload {
+                    let count = payload["imported"].as_i64().unwrap_or(0);
+                    eprintln!("Imported {count} synonym pairs from WordNet.");
                 }
             } else {
                 cli::cmd_import_wordnet(&wordnet_db)?;
@@ -308,10 +305,9 @@ fn guard_daemon_not_running(command: &str) -> anyhow::Result<()> {
 
 // ─── Render helpers (daemon response → terminal output) ───────────
 
-fn render_search(resp: DaemonResponse, format: &str) {
+fn render_search(resp: DaemonResponse, format: &str) -> anyhow::Result<()> {
     if !resp.ok {
-        eprintln!("error: {}", resp.error.unwrap_or_default());
-        return;
+        anyhow::bail!("{}", resp.error.unwrap_or_default());
     }
     let payload = resp.payload.unwrap_or_default();
     match format {
@@ -327,12 +323,12 @@ fn render_search(resp: DaemonResponse, format: &str) {
             print!("{}", cli::format_text(&results));
         }
     }
+    Ok(())
 }
 
-fn render_index(resp: DaemonResponse) {
+fn render_index(resp: DaemonResponse) -> anyhow::Result<()> {
     if !resp.ok {
-        eprintln!("error: {}", resp.error.unwrap_or_default());
-        return;
+        anyhow::bail!("{}", resp.error.unwrap_or_default());
     }
     if let Some(payload) = resp.payload {
         let indexed = payload["indexed"].as_i64().unwrap_or(0);
@@ -340,17 +336,17 @@ fn render_index(resp: DaemonResponse) {
         let removed = payload["removed"].as_i64().unwrap_or(0);
         eprintln!("Indexed: {indexed}, Skipped: {skipped}, Removed: {removed}");
     }
+    Ok(())
 }
 
-fn render_ingest(resp: DaemonResponse, session_file: &std::path::Path) {
+fn render_ingest(resp: DaemonResponse, session_file: &std::path::Path) -> anyhow::Result<()> {
+    if !resp.ok {
+        anyhow::bail!("{}", resp.error.unwrap_or_default());
+    }
     let name = session_file
         .file_name()
         .unwrap_or_default()
         .to_string_lossy();
-    if !resp.ok {
-        eprintln!("error: {}", resp.error.unwrap_or_default());
-        return;
-    }
     if let Some(payload) = resp.payload {
         if payload["indexed"].as_bool().unwrap_or(false) {
             eprintln!("Session indexed: {name}");
@@ -358,12 +354,12 @@ fn render_ingest(resp: DaemonResponse, session_file: &std::path::Path) {
             eprintln!("Session unchanged: {name}");
         }
     }
+    Ok(())
 }
 
-fn render_status(resp: DaemonResponse) {
+fn render_status(resp: DaemonResponse) -> anyhow::Result<()> {
     if !resp.ok {
-        eprintln!("error: {}", resp.error.unwrap_or_default());
-        return;
+        anyhow::bail!("{}", resp.error.unwrap_or_default());
     }
     if let Some(payload) = resp.payload {
         match serde_json::from_value::<cli::StatusInfo>(payload) {
@@ -371,12 +367,12 @@ fn render_status(resp: DaemonResponse) {
             Err(_) => eprintln!("(could not parse daemon status)"),
         }
     }
+    Ok(())
 }
 
-fn render_doctor(resp: DaemonResponse, format: &str) {
+fn render_doctor(resp: DaemonResponse, format: &str) -> anyhow::Result<()> {
     if !resp.ok {
-        eprintln!("error: {}", resp.error.unwrap_or_default());
-        return;
+        anyhow::bail!("{}", resp.error.unwrap_or_default());
     }
     let payload = resp.payload.unwrap_or_default();
     match format {
@@ -390,7 +386,6 @@ fn render_doctor(resp: DaemonResponse, format: &str) {
             match serde_json::from_value::<cli::DoctorReport>(payload.clone()) {
                 Ok(report) => cli::render_doctor_report(&report),
                 Err(_) => {
-                    // Fallback: print raw JSON
                     println!(
                         "{}",
                         serde_json::to_string_pretty(&payload).unwrap_or_default()
@@ -399,6 +394,7 @@ fn render_doctor(resp: DaemonResponse, format: &str) {
             }
         }
     }
+    Ok(())
 }
 
 /// Start the tsmd daemon as a background process.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use the_space_memory::cli;
 use the_space_memory::config;
-use the_space_memory::daemon_protocol::{self, DaemonRequest};
+use the_space_memory::daemon_protocol::{self, DaemonRequest, DaemonResponse};
 use the_space_memory::user_dict::DictFormat;
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -128,10 +128,30 @@ enum Commands {
 fn main() -> anyhow::Result<()> {
     let args = Cli::parse();
     match args.command {
+        // ── Always direct ──
         Commands::Init => cli::cmd_init()?,
         Commands::Start => cmd_start()?,
         Commands::Stop => cmd_stop()?,
-        Commands::Index { files_from_stdin } => cli::cmd_index(files_from_stdin)?,
+        Commands::EmbedderStart => cli::cmd_embedder_start(None)?,
+        Commands::Setup => cli::cmd_setup()?,
+        Commands::BackfillWorker => cli::cmd_backfill_worker()?,
+        Commands::VectorFill { batch_size } => cli::cmd_vector_fill(batch_size)?,
+
+        // ── Direct-only with daemon guard ──
+        Commands::Rebuild { force } => {
+            guard_daemon_not_running("rebuild")?;
+            cli::cmd_rebuild(force)?;
+        }
+        Commands::DictUpdate {
+            threshold,
+            yes,
+            format,
+        } => {
+            guard_daemon_not_running("dict-update")?;
+            cli::cmd_dict_update(threshold, yes, format.into())?;
+        }
+
+        // ── Daemon-routed with direct fallback ──
         Commands::Search {
             query,
             top_k,
@@ -141,32 +161,244 @@ fn main() -> anyhow::Result<()> {
             before,
             recent,
             year,
-        } => cli::cmd_search(cli::SearchOptions {
-            query: &query,
-            top_k,
-            format: &format,
-            include_content,
-            after: after.as_deref(),
-            before: before.as_deref(),
-            recent: recent.as_deref(),
-            year,
-        })?,
-        Commands::IngestSession { session_file } => cli::cmd_ingest_session(&session_file)?,
-        Commands::EmbedderStart => cli::cmd_embedder_start(None)?,
-        Commands::Setup => cli::cmd_setup()?,
-        Commands::VectorFill { batch_size } => cli::cmd_vector_fill(batch_size)?,
-        Commands::ImportWordnet { wordnet_db } => cli::cmd_import_wordnet(&wordnet_db)?,
-        Commands::DictUpdate {
-            threshold,
-            yes,
-            format,
-        } => cli::cmd_dict_update(threshold, yes, format.into())?,
-        Commands::Status => cli::cmd_status()?,
-        Commands::Doctor { format } => cli::cmd_doctor(&format)?,
-        Commands::Rebuild { force } => cli::cmd_rebuild(force)?,
-        Commands::BackfillWorker => cli::cmd_backfill_worker()?,
+        } => {
+            let req = DaemonRequest::Search {
+                query: query.clone(),
+                top_k,
+                format: format.clone(),
+                include_content,
+                after: after.clone(),
+                before: before.clone(),
+                recent: recent.clone(),
+                year,
+            };
+            if let Some(resp) = try_daemon(&req) {
+                render_search(resp, &format);
+            } else {
+                cli::cmd_search(cli::SearchOptions {
+                    query: &query,
+                    top_k,
+                    format: &format,
+                    include_content,
+                    after: after.as_deref(),
+                    before: before.as_deref(),
+                    recent: recent.as_deref(),
+                    year,
+                })?;
+            }
+        }
+
+        Commands::Index { files_from_stdin } => {
+            if !files_from_stdin {
+                // Full index — try daemon first
+                let req = DaemonRequest::Index { files: vec![] };
+                if let Some(resp) = try_daemon(&req) {
+                    render_index(resp);
+                } else {
+                    cli::cmd_index(false)?;
+                }
+            } else {
+                // stdin paths — collect first, then route
+                let project_root = config::project_root();
+                let paths = cli::read_paths_from_stdin(&project_root);
+                let rel_paths: Vec<String> = paths
+                    .iter()
+                    .filter_map(|p| p.strip_prefix(&project_root).ok())
+                    .map(|p| p.to_string_lossy().to_string())
+                    .collect();
+
+                let req = DaemonRequest::Index {
+                    files: rel_paths.clone(),
+                };
+                if let Some(resp) = try_daemon(&req) {
+                    render_index(resp);
+                } else {
+                    let stats = cli::run_index(
+                        &the_space_memory::db::get_connection(&config::db_path())?,
+                        &paths,
+                        &project_root,
+                    )?;
+                    eprintln!(
+                        "Indexed: {}, Skipped: {}, Removed: {}",
+                        stats.indexed, stats.skipped, stats.removed
+                    );
+                }
+            }
+        }
+
+        Commands::IngestSession { session_file } => {
+            let req = DaemonRequest::IngestSession {
+                session_file: session_file.to_string_lossy().to_string(),
+            };
+            if let Some(resp) = try_daemon(&req) {
+                render_ingest(resp, &session_file);
+            } else {
+                cli::cmd_ingest_session(&session_file)?;
+            }
+        }
+
+        Commands::Status => {
+            let req = DaemonRequest::Status;
+            if let Some(resp) = try_daemon(&req) {
+                render_status(resp);
+            } else {
+                cli::cmd_status()?;
+            }
+        }
+
+        Commands::Doctor { format } => {
+            let req = DaemonRequest::Doctor {
+                format: format.clone(),
+            };
+            if let Some(resp) = try_daemon(&req) {
+                render_doctor(resp, &format);
+            } else {
+                cli::cmd_doctor(&format)?;
+            }
+        }
+
+        Commands::ImportWordnet { wordnet_db } => {
+            let req = DaemonRequest::ImportWordnet {
+                wordnet_db: wordnet_db.to_string_lossy().to_string(),
+            };
+            if let Some(resp) = try_daemon(&req) {
+                if resp.ok {
+                    if let Some(payload) = resp.payload {
+                        let count = payload["imported"].as_i64().unwrap_or(0);
+                        eprintln!("Imported {count} synonym pairs from WordNet.");
+                    }
+                } else {
+                    eprintln!("error: {}", resp.error.unwrap_or_default());
+                }
+            } else {
+                cli::cmd_import_wordnet(&wordnet_db)?;
+            }
+        }
     }
     Ok(())
+}
+
+// ─── Daemon routing helpers ───────────────────────────────────────
+
+/// Try to send a request to the daemon. Returns Some(response) if daemon handled it, None to fallback.
+fn try_daemon(req: &DaemonRequest) -> Option<DaemonResponse> {
+    let socket = config::daemon_socket_path();
+    match daemon_protocol::try_send_request(&socket, req) {
+        Some(Ok(resp)) => Some(resp),
+        Some(Err(e)) => {
+            eprintln!("warning: daemon communication error: {e}");
+            None // fallback to direct
+        }
+        None => None, // daemon not running
+    }
+}
+
+/// Guard: error if the daemon is running (for commands that can't coexist).
+fn guard_daemon_not_running(command: &str) -> anyhow::Result<()> {
+    let socket = config::daemon_socket_path();
+    if let Some(Ok(resp)) = daemon_protocol::try_send_request(&socket, &DaemonRequest::Ping) {
+        if resp.ok {
+            anyhow::bail!(
+                "tsmd is running. Run `tsm stop` before `{command}`."
+            );
+        }
+    }
+    Ok(())
+}
+
+// ─── Render helpers (daemon response → terminal output) ───────────
+
+fn render_search(resp: DaemonResponse, format: &str) {
+    if !resp.ok {
+        eprintln!("error: {}", resp.error.unwrap_or_default());
+        return;
+    }
+    let payload = resp.payload.unwrap_or_default();
+    match format {
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&payload).unwrap_or_default()
+            );
+        }
+        _ => {
+            let results: Vec<the_space_memory::searcher::SearchResult> =
+                serde_json::from_value(payload).unwrap_or_default();
+            print!("{}", cli::format_text(&results));
+        }
+    }
+}
+
+fn render_index(resp: DaemonResponse) {
+    if !resp.ok {
+        eprintln!("error: {}", resp.error.unwrap_or_default());
+        return;
+    }
+    if let Some(payload) = resp.payload {
+        let indexed = payload["indexed"].as_i64().unwrap_or(0);
+        let skipped = payload["skipped"].as_i64().unwrap_or(0);
+        let removed = payload["removed"].as_i64().unwrap_or(0);
+        eprintln!("Indexed: {indexed}, Skipped: {skipped}, Removed: {removed}");
+    }
+}
+
+fn render_ingest(resp: DaemonResponse, session_file: &std::path::Path) {
+    let name = session_file
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy();
+    if !resp.ok {
+        eprintln!("error: {}", resp.error.unwrap_or_default());
+        return;
+    }
+    if let Some(payload) = resp.payload {
+        if payload["indexed"].as_bool().unwrap_or(false) {
+            eprintln!("Session indexed: {name}");
+        } else {
+            eprintln!("Session unchanged: {name}");
+        }
+    }
+}
+
+fn render_status(resp: DaemonResponse) {
+    if !resp.ok {
+        eprintln!("error: {}", resp.error.unwrap_or_default());
+        return;
+    }
+    if let Some(payload) = resp.payload {
+        match serde_json::from_value::<cli::StatusInfo>(payload) {
+            Ok(info) => cli::print_status_info(&info),
+            Err(_) => eprintln!("(could not parse daemon status)"),
+        }
+    }
+}
+
+fn render_doctor(resp: DaemonResponse, format: &str) {
+    if !resp.ok {
+        eprintln!("error: {}", resp.error.unwrap_or_default());
+        return;
+    }
+    let payload = resp.payload.unwrap_or_default();
+    match format {
+        "json" => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&payload).unwrap_or_default()
+            );
+        }
+        _ => {
+            match serde_json::from_value::<cli::DoctorReport>(payload.clone()) {
+                Ok(report) => cli::render_doctor_report(&report),
+                Err(_) => {
+                    // Fallback: print raw JSON
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&payload).unwrap_or_default()
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// Start the tsmd daemon as a background process.
@@ -177,7 +409,6 @@ fn cmd_start() -> anyhow::Result<()> {
 
     // Check if already running
     if socket_path.exists() {
-        // Try to ping
         if let Ok(resp) = daemon_protocol::send_request(&socket_path, &DaemonRequest::Ping) {
             if resp.ok {
                 eprintln!("tsmd is already running.");
@@ -222,7 +453,6 @@ fn cmd_start() -> anyhow::Result<()> {
     let timeout = std::time::Duration::from_secs(30);
     loop {
         if socket_path.exists() {
-            // Verify it responds to ping
             if let Ok(resp) = daemon_protocol::send_request(&socket_path, &DaemonRequest::Ping) {
                 if resp.ok {
                     eprintln!("tsmd started.");
@@ -259,7 +489,6 @@ fn cmd_stop() -> anyhow::Result<()> {
         }
         Err(e) => {
             eprintln!("Could not connect to tsmd: {e}");
-            // Try to clean up stale socket
             let _ = std::fs::remove_file(&socket_path);
             eprintln!("Removed stale socket.");
         }

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -749,4 +749,28 @@ mod tests {
             "should collect dictionary candidates from search query"
         );
     }
+
+    #[test]
+    fn test_search_result_serde_roundtrip() {
+        let result = SearchResult {
+            source_file: "daily/notes/test.md".to_string(),
+            source_type: "note".to_string(),
+            section_path: "Test > Section".to_string(),
+            snippet: "Some content".to_string(),
+            score: 0.5,
+            status: Some("current".to_string()),
+            related_docs: vec![doc_links::RelatedDoc {
+                file_path: "company/knowledge/related.md".to_string(),
+                link_type: "tag".to_string(),
+                strength: 0.8,
+            }],
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        let decoded: SearchResult = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.source_file, "daily/notes/test.md");
+        assert_eq!(decoded.score, 0.5);
+        assert_eq!(decoded.related_docs.len(), 1);
+        assert_eq!(decoded.related_docs[0].file_path, "company/knowledge/related.md");
+        assert_eq!(decoded.related_docs[0].link_type, "tag");
+    }
 }

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -14,7 +14,7 @@ use crate::temporal::TimeFilter;
 use crate::tokenizer::{extract_search_keywords, wakachi};
 use crate::user_dict;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct SearchResult {
     pub source_file: String,
     pub source_type: String,

--- a/src/status.rs
+++ b/src/status.rs
@@ -41,10 +41,19 @@ pub fn status_path(data_dir: &Path) -> std::path::PathBuf {
 
 pub fn read(data_dir: &Path) -> StatusFile {
     let path = status_path(data_dir);
-    std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_default()
+    let Ok(s) = std::fs::read_to_string(&path) else {
+        return StatusFile::default(); // File absent is normal
+    };
+    match serde_json::from_str(&s) {
+        Ok(sf) => sf,
+        Err(e) => {
+            eprintln!(
+                "warning: failed to parse status file ({}): {e}",
+                path.display()
+            );
+            StatusFile::default()
+        }
+    }
 }
 
 /// Atomic write: write to tmp file then rename.
@@ -61,7 +70,12 @@ pub fn update(data_dir: &Path, f: impl FnOnce(&mut StatusFile)) {
     let path = status_path(data_dir);
     let mut status = read(data_dir);
     f(&mut status);
-    if let Ok(json) = serde_json::to_string_pretty(&status) {
-        let _ = write_atomic(&path, json.as_bytes());
+    match serde_json::to_string_pretty(&status) {
+        Ok(json) => {
+            if let Err(e) = write_atomic(&path, json.as_bytes()) {
+                eprintln!("warning: failed to write status file: {e}");
+            }
+        }
+        Err(e) => eprintln!("warning: failed to serialize status: {e}"),
     }
 }


### PR DESCRIPTION
## Summary

- CLI commands automatically route through tsmd when daemon is running
- Transparent fallback to direct DB access when daemon is not running
- Rebuild/dict-update guarded from running while daemon is active
- Full backward compatibility — no workflow changes required

## Routing Table

| Command | Routing |
|---|---|
| search, index, ingest-session, status, doctor, import-wordnet | Daemon → fallback direct |
| init, start, stop, embedder-start, setup, vector-fill | Always direct |
| rebuild, dict-update | Error if daemon running, direct otherwise |

## Changes

- `daemon_protocol.rs`: `try_send_request()` — returns None if daemon unavailable
- `main.rs`: routing layer with render helpers for search/index/status/doctor
- `daemon.rs`: VectorFill uses `run_vector_fill(conn)`, Rebuild/DictUpdate return error
- `cli.rs`: extract `run_vector_fill`, `print_status_info`, public `render_doctor_report`
- `searcher.rs`/`doc_links.rs`: Serialize/Deserialize on SearchResult/RelatedDoc
- `cli.rs`: serde derives on DoctorReport types, replace hand-rolled to_json()

## Test plan

- [x] 356 tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` zero warnings
- [ ] Manual: `tsm search` without daemon (fallback)
- [ ] Manual: `tsm start && tsm search && tsm stop` (daemon routing)
- [ ] Manual: `tsm rebuild --force` while daemon running (error)
- [ ] Hook compatibility: `echo "path" | tsm index --files-from-stdin`