### PR TITLE
feat: embedder as tsmd child process, auto-start daemon

### DIFF
--- a/hooks/scripts/search.sh
+++ b/hooks/scripts/search.sh
@@ -25,7 +25,7 @@ fi
 cd "${CLAUDE_PROJECT_DIR:-/workspaces/workspace}"
 
 # 検索実行（tsmd が未起動なら自動起動される）
-RESULT=$("$TSM" search --query "$QUERY" --format json 2>/dev/null) || {
+RESULT=$("$TSM" search --query "$QUERY" --format json 2>>"$LOG") || {
   echo "[$(date -Iseconds)] FAIL: tsm search exited with $?" >> "$LOG"
   exit 0
 }

--- a/hooks/scripts/search.sh
+++ b/hooks/scripts/search.sh
@@ -24,20 +24,7 @@ fi
 
 cd "${CLAUDE_PROJECT_DIR:-/workspaces/workspace}"
 
-SOCKET="/tmp/tsm-embedder.sock"
-
-# embedder デーモンが起動していなければバックグラウンドで起動
-if [ ! -S "$SOCKET" ]; then
-  echo "[$(date -Iseconds)] embedder not running, starting..." >> "$LOG"
-  nohup "$TSM" embedder-start >/dev/null 2>&1 &
-  disown
-  for _ in $(seq 1 50); do
-    [ -S "$SOCKET" ] && break
-    sleep 0.1
-  done
-fi
-
-# 検索実行
+# 検索実行（tsmd が未起動なら自動起動される）
 RESULT=$("$TSM" search --query "$QUERY" --format json 2>/dev/null) || {
   echo "[$(date -Iseconds)] FAIL: tsm search exited with $?" >> "$LOG"
   exit 0

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -191,7 +191,9 @@ fn start_embedder() -> Result<Child> {
 
     // Clean up stale embedder socket
     if embedder_socket.exists() {
-        let _ = std::fs::remove_file(embedder_socket);
+        if let Err(e) = std::fs::remove_file(embedder_socket) {
+            eprintln!("tsmd: warning: could not remove stale embedder socket: {e}");
+        }
     }
 
     // Find the tsm binary (same directory as tsmd)

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -1,5 +1,6 @@
 use std::os::unix::net::UnixListener;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -29,6 +30,10 @@ struct Args {
     /// Database path
     #[arg(long)]
     db: Option<PathBuf>,
+
+    /// Skip embedder startup
+    #[arg(long)]
+    no_embedder: bool,
 }
 
 fn main() -> Result<()> {
@@ -71,6 +76,23 @@ fn main() -> Result<()> {
 
     eprintln!("tsmd: listening on {} (PID {pid})", socket_path.display());
 
+    // Start embedder as a child process
+    let mut embedder_child: Option<Child> = if !args.no_embedder {
+        match start_embedder() {
+            Ok(child) => {
+                eprintln!("tsmd: embedder started (PID {})", child.id());
+                Some(child)
+            }
+            Err(e) => {
+                eprintln!("tsmd: warning: failed to start embedder: {e}");
+                None
+            }
+        }
+    } else {
+        eprintln!("tsmd: embedder disabled (--no-embedder)");
+        None
+    };
+
     // Install signal handlers
     unsafe {
         libc::signal(
@@ -82,6 +104,9 @@ fn main() -> Result<()> {
             signal_handler as *const () as libc::sighandler_t,
         );
     }
+
+    let mut embedder_restarts = 0u32;
+    const MAX_EMBEDDER_RESTARTS: u32 = 3;
 
     // Accept loop
     while !SHUTDOWN.load(Ordering::SeqCst) {
@@ -97,6 +122,35 @@ fn main() -> Result<()> {
                 });
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                // Check embedder health periodically (every 100ms poll)
+                if let Some(ref mut child) = embedder_child {
+                    if let Ok(Some(_exit)) = child.try_wait() {
+                        if embedder_restarts < MAX_EMBEDDER_RESTARTS {
+                            embedder_restarts += 1;
+                            eprintln!(
+                                "tsmd: embedder exited, restarting ({embedder_restarts}/{MAX_EMBEDDER_RESTARTS})..."
+                            );
+                            match start_embedder() {
+                                Ok(new_child) => {
+                                    eprintln!(
+                                        "tsmd: embedder restarted (PID {})",
+                                        new_child.id()
+                                    );
+                                    *child = new_child;
+                                }
+                                Err(e) => {
+                                    eprintln!("tsmd: failed to restart embedder: {e}");
+                                    embedder_child = None;
+                                }
+                            }
+                        } else {
+                            eprintln!(
+                                "tsmd: embedder crashed {MAX_EMBEDDER_RESTARTS} times, giving up"
+                            );
+                            embedder_child = None;
+                        }
+                    }
+                }
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
             Err(e) => {
@@ -108,6 +162,14 @@ fn main() -> Result<()> {
 
     // Cleanup
     eprintln!("tsmd: shutting down");
+
+    // Stop embedder child
+    if let Some(mut child) = embedder_child {
+        eprintln!("tsmd: stopping embedder (PID {})...", child.id());
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
     let _ = std::fs::remove_file(&socket_path);
     let _ = std::fs::remove_file(&pid_path);
     status::update(&data_dir, |s| {
@@ -115,6 +177,45 @@ fn main() -> Result<()> {
     });
 
     Ok(())
+}
+
+/// Start the embedder as a child process with idle timeout disabled.
+fn start_embedder() -> Result<Child> {
+    let embedder_socket = Path::new(config::SOCKET_PATH);
+
+    // Clean up stale embedder socket
+    if embedder_socket.exists() {
+        let _ = std::fs::remove_file(embedder_socket);
+    }
+
+    // Find the tsm binary (same directory as tsmd)
+    let exe_dir = std::env::current_exe()?
+        .parent()
+        .context("executable has no parent directory")?
+        .to_path_buf();
+    let tsm_path = exe_dir.join("tsm");
+
+    let child = Command::new(&tsm_path)
+        .arg("embedder-start")
+        .env("TSM_EMBEDDER_IDLE_TIMEOUT", "0") // disable idle timeout
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit()) // inherit stderr for embedder logs
+        .spawn()
+        .context("Failed to spawn embedder process")?;
+
+    // Wait for embedder socket to appear (max 60s for model loading)
+    let start = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(60);
+    while start.elapsed() < timeout {
+        if embedder_socket.exists() {
+            return Ok(child);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+
+    eprintln!("tsmd: warning: embedder socket not ready after 60s, continuing anyway");
+    Ok(child)
 }
 
 fn handle_client(

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -122,35 +122,8 @@ fn main() -> Result<()> {
                 });
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                // Check embedder health periodically (every 100ms poll)
-                if let Some(ref mut child) = embedder_child {
-                    if let Ok(Some(_exit)) = child.try_wait() {
-                        if embedder_restarts < MAX_EMBEDDER_RESTARTS {
-                            embedder_restarts += 1;
-                            eprintln!(
-                                "tsmd: embedder exited, restarting ({embedder_restarts}/{MAX_EMBEDDER_RESTARTS})..."
-                            );
-                            match start_embedder() {
-                                Ok(new_child) => {
-                                    eprintln!(
-                                        "tsmd: embedder restarted (PID {})",
-                                        new_child.id()
-                                    );
-                                    *child = new_child;
-                                }
-                                Err(e) => {
-                                    eprintln!("tsmd: failed to restart embedder: {e}");
-                                    embedder_child = None;
-                                }
-                            }
-                        } else {
-                            eprintln!(
-                                "tsmd: embedder crashed {MAX_EMBEDDER_RESTARTS} times, giving up"
-                            );
-                            embedder_child = None;
-                        }
-                    }
-                }
+                // Check embedder health on each idle poll (every 100ms)
+                maybe_restart_embedder(&mut embedder_child, &mut embedder_restarts, MAX_EMBEDDER_RESTARTS);
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
             Err(e) => {
@@ -179,6 +152,39 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+/// Check if the embedder child has exited and restart it if within the retry limit.
+/// Sets `child` to `None` once the limit is exhausted or when a restart fails to spawn.
+fn maybe_restart_embedder(child: &mut Option<Child>, restarts: &mut u32, max: u32) {
+    let exited = match child {
+        Some(c) => matches!(c.try_wait(), Ok(Some(_))),
+        None => return,
+    };
+
+    if !exited {
+        return;
+    }
+
+    if *restarts >= max {
+        eprintln!("tsmd: embedder crashed {max} times, giving up");
+        *child = None;
+        return;
+    }
+
+    *restarts += 1;
+    eprintln!("tsmd: embedder exited, restarting ({restarts}/{max})...");
+    match start_embedder() {
+        Ok(new_child) => {
+            eprintln!("tsmd: embedder restarted (PID {})", new_child.id());
+            *child = Some(new_child);
+            *restarts = 0; // reset on successful restart
+        }
+        Err(e) => {
+            eprintln!("tsmd: failed to restart embedder: {e}");
+            *child = None;
+        }
+    }
+}
+
 /// Start the embedder as a child process with idle timeout disabled.
 fn start_embedder() -> Result<Child> {
     let embedder_socket = Path::new(config::SOCKET_PATH);
@@ -204,17 +210,9 @@ fn start_embedder() -> Result<Child> {
         .spawn()
         .context("Failed to spawn embedder process")?;
 
-    // Wait for embedder socket to appear (max 60s for model loading)
-    let start = std::time::Instant::now();
-    let timeout = std::time::Duration::from_secs(60);
-    while start.elapsed() < timeout {
-        if embedder_socket.exists() {
-            return Ok(child);
-        }
-        std::thread::sleep(std::time::Duration::from_millis(200));
-    }
-
-    eprintln!("tsmd: warning: embedder socket not ready after 60s, continuing anyway");
+    // Don't block waiting for embedder socket — model loading can take tens of seconds.
+    // The accept loop starts immediately; embed_via_socket returns None until ready,
+    // and backfill handles missing vectors later.
     Ok(child)
 }
 

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -393,49 +393,9 @@ fn handle_client(mut stream: UnixStream, embedder: &Embedder) -> Result<()> {
 // ─── Client ────────────────────────────────────────────────────────
 
 /// Send texts to the embedder daemon and get embeddings back.
-/// Auto-starts the daemon if not running. Returns None if startup fails.
+/// Returns None if the embedder is not running.
 pub fn embed_via_socket(texts: &[String]) -> Option<Vec<Vec<f32>>> {
-    let socket_path = Path::new(config::SOCKET_PATH);
-    if !socket_path.exists() && !auto_start_daemon() {
-        return None;
-    }
-    embed_via_socket_at(socket_path, texts)
-}
-
-/// Spawn the embedder daemon as a background subprocess.
-/// Waits up to 30 seconds for the socket to appear.
-fn auto_start_daemon() -> bool {
-    let exe = match std::env::current_exe() {
-        Ok(p) => p,
-        Err(_) => return false,
-    };
-    let socket_path = Path::new(config::SOCKET_PATH);
-
-    eprintln!("Auto-starting embedder daemon...");
-    match Command::new(exe)
-        .arg("embedder-start")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(_) => {
-            // Wait for socket to appear
-            for _ in 0..300 {
-                if socket_path.exists() {
-                    eprintln!("Embedder daemon ready.");
-                    return true;
-                }
-                std::thread::sleep(Duration::from_millis(100));
-            }
-            eprintln!("Embedder daemon did not start in time.");
-            false
-        }
-        Err(e) => {
-            eprintln!("Failed to start embedder daemon: {e}");
-            false
-        }
-    }
+    embed_via_socket_at(Path::new(config::SOCKET_PATH), texts)
 }
 
 /// Send texts to the embedder daemon at a specific socket path.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -355,7 +355,7 @@ pub fn index_session(conn: &Connection, jsonl_path: &Path) -> anyhow::Result<boo
 
     // Insert vectors only if embedder is already running (don't auto-start).
     // Backfill will handle missing vectors later.
-    insert_vectors_no_autostart(conn, &chunk_entries);
+    insert_vectors(conn, &chunk_entries);
 
     // Learn synonyms from human messages in the session (wrapped in transaction)
     learn_from_session_jsonl(conn, jsonl_path);
@@ -458,33 +458,6 @@ fn insert_vectors(conn: &Connection, chunk_entries: &[(i64, String)]) {
     }
 }
 
-/// Insert vectors only if the embedder daemon is already running.
-/// Does NOT auto-start the daemon — lets backfill handle missing vectors later.
-fn insert_vectors_no_autostart(conn: &Connection, chunk_entries: &[(i64, String)]) {
-    if chunk_entries.is_empty() {
-        return;
-    }
-    if !db::has_vec_table(conn) {
-        return;
-    }
-    // Only proceed if the socket already exists (embedder is running)
-    if !std::path::Path::new(config::SOCKET_PATH).exists() {
-        return;
-    }
-
-    let texts: Vec<String> = chunk_entries.iter().map(|(_, text)| text.clone()).collect();
-    let embeddings = match embedder::embed_via_socket_at(
-        std::path::Path::new(config::SOCKET_PATH),
-        &texts,
-    ) {
-        Some(e) => e,
-        None => return,
-    };
-
-    for ((chunk_id, _), emb) in chunk_entries.iter().zip(embeddings.iter()) {
-        write_vec_row(conn, *chunk_id, emb);
-    }
-}
 
 pub use crate::config::BACKFILL_BATCH_SIZE;
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -353,8 +353,7 @@ pub fn index_session(conn: &Connection, jsonl_path: &Path) -> anyhow::Result<boo
     }
     tx.commit()?;
 
-    // Insert vectors only if embedder is already running (don't auto-start).
-    // Backfill will handle missing vectors later.
+    // Insert vectors if embedder is running; backfill handles the rest.
     insert_vectors(conn, &chunk_entries);
 
     // Learn synonyms from human messages in the session (wrapped in transaction)
@@ -446,6 +445,10 @@ fn insert_vectors(conn: &Connection, chunk_entries: &[(i64, String)]) {
     if !db::has_vec_table(conn) {
         return;
     }
+    // Skip socket I/O if embedder is not running
+    if !std::path::Path::new(config::SOCKET_PATH).exists() {
+        return;
+    }
 
     let texts: Vec<String> = chunk_entries.iter().map(|(_, text)| text.clone()).collect();
     let embeddings = match embedder::embed_via_socket(&texts) {
@@ -457,7 +460,6 @@ fn insert_vectors(conn: &Connection, chunk_entries: &[(i64, String)]) {
         write_vec_row(conn, *chunk_id, emb);
     }
 }
-
 
 pub use crate::config::BACKFILL_BATCH_SIZE;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,11 +388,21 @@ fn cmd_start() -> anyhow::Result<()> {
         );
     }
 
-    // Spawn tsmd in a new session (detached)
+    // Spawn tsmd in a new session (detached), stderr to log file
+    let log_path = config::data_dir().join("tsmd.log");
+    let log_file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .ok();
+    let stderr_cfg = match log_file {
+        Some(f) => std::process::Stdio::from(f),
+        None => std::process::Stdio::null(),
+    };
     let mut cmd = std::process::Command::new(&tsmd_path);
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
+        .stderr(stderr_cfg);
     unsafe {
         cmd.pre_exec(|| {
             libc::setsid();

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,8 @@ enum Commands {
         /// Path to the JSONL file
         session_file: PathBuf,
     },
-    /// Start the embedder daemon
+    /// Internal: start the embedder daemon (managed by tsmd)
+    #[command(hide = true)]
     EmbedderStart,
     /// Download model files from HuggingFace Hub
     Setup,
@@ -151,7 +152,7 @@ fn main() -> anyhow::Result<()> {
             cli::cmd_dict_update(threshold, yes, format.into())?;
         }
 
-        // ── Daemon-routed with direct fallback ──
+        // ── Daemon-routed (auto-starts tsmd if needed) ──
         Commands::Search {
             query,
             top_k,
@@ -163,42 +164,20 @@ fn main() -> anyhow::Result<()> {
             year,
         } => {
             let req = DaemonRequest::Search {
-                query: query.clone(),
+                query,
                 top_k,
                 format: format.clone(),
                 include_content,
-                after: after.clone(),
-                before: before.clone(),
-                recent: recent.clone(),
+                after,
+                before,
+                recent,
                 year,
             };
-            if let Some(resp) = try_daemon(&req)? {
-                render_search(resp, &format)?;
-            } else {
-                cli::cmd_search(cli::SearchOptions {
-                    query: &query,
-                    top_k,
-                    format: &format,
-                    include_content,
-                    after: after.as_deref(),
-                    before: before.as_deref(),
-                    recent: recent.as_deref(),
-                    year,
-                })?;
-            }
+            render_search(send_to_daemon(&req)?, &format)?;
         }
 
         Commands::Index { files_from_stdin } => {
-            if !files_from_stdin {
-                // Full index — try daemon first
-                let req = DaemonRequest::Index { files: vec![] };
-                if let Some(resp) = try_daemon(&req)? {
-                    render_index(resp)?;
-                } else {
-                    cli::cmd_index(false)?;
-                }
-            } else {
-                // stdin paths — collect first, then route
+            let req = if files_from_stdin {
                 let project_root = config::project_root();
                 let paths = cli::read_paths_from_stdin(&project_root);
                 let rel_paths: Vec<String> = paths
@@ -206,64 +185,36 @@ fn main() -> anyhow::Result<()> {
                     .filter_map(|p| p.strip_prefix(&project_root).ok())
                     .map(|p| p.to_string_lossy().to_string())
                     .collect();
-
-                let req = DaemonRequest::Index { files: rel_paths };
-                if let Some(resp) = try_daemon(&req)? {
-                    render_index(resp)?;
-                } else {
-                    let stats = cli::run_index(
-                        &the_space_memory::db::get_connection(&config::db_path())?,
-                        &paths,
-                        &project_root,
-                    )?;
-                    eprintln!(
-                        "Indexed: {}, Skipped: {}, Removed: {}",
-                        stats.indexed, stats.skipped, stats.removed
-                    );
-                }
-            }
+                DaemonRequest::Index { files: rel_paths }
+            } else {
+                DaemonRequest::Index { files: vec![] }
+            };
+            render_index(send_to_daemon(&req)?)?;
         }
 
         Commands::IngestSession { session_file } => {
             let req = DaemonRequest::IngestSession {
                 session_file: session_file.to_string_lossy().to_string(),
             };
-            if let Some(resp) = try_daemon(&req)? {
-                render_ingest(resp, &session_file)?;
-            } else {
-                cli::cmd_ingest_session(&session_file)?;
-            }
+            render_ingest(send_to_daemon(&req)?, &session_file)?;
         }
 
         Commands::Status => {
-            let req = DaemonRequest::Status;
-            if let Some(resp) = try_daemon(&req)? {
-                render_status(resp)?;
-            } else {
-                cli::cmd_status()?;
-            }
+            render_status(send_to_daemon(&DaemonRequest::Status)?)?;
         }
 
         Commands::Doctor { format } => {
             let req = DaemonRequest::Doctor {
                 format: format.clone(),
             };
-            if let Some(resp) = try_daemon(&req)? {
-                render_doctor(resp, &format)?;
-            } else {
-                cli::cmd_doctor(&format)?;
-            }
+            render_doctor(send_to_daemon(&req)?, &format)?;
         }
 
         Commands::ImportWordnet { wordnet_db } => {
             let req = DaemonRequest::ImportWordnet {
                 wordnet_db: wordnet_db.to_string_lossy().to_string(),
             };
-            if let Some(resp) = try_daemon(&req)? {
-                render_import_wordnet(resp)?;
-            } else {
-                cli::cmd_import_wordnet(&wordnet_db)?;
-            }
+            render_import_wordnet(send_to_daemon(&req)?)?;
         }
     }
     Ok(())
@@ -271,19 +222,24 @@ fn main() -> anyhow::Result<()> {
 
 // ─── Daemon routing helpers ───────────────────────────────────────
 
-/// Try to send a request to the daemon.
-/// Returns `Ok(Some(resp))` if daemon handled it.
-/// Returns `Ok(None)` if daemon is not running (fallback to direct).
-/// Returns `Err` if daemon is running but communication failed (no fallback — could cause double execution).
-fn try_daemon(req: &DaemonRequest) -> anyhow::Result<Option<DaemonResponse>> {
+/// Send a request to the daemon, auto-starting it if necessary.
+fn send_to_daemon(req: &DaemonRequest) -> anyhow::Result<DaemonResponse> {
     let socket = config::daemon_socket_path();
+
+    // First attempt
     match daemon_protocol::try_send_request(&socket, req) {
-        Some(Ok(resp)) => Ok(Some(resp)),
+        Some(Ok(resp)) => return Ok(resp),
         Some(Err(e)) => {
             anyhow::bail!("Daemon communication error: {e}\nRun `tsm stop` and retry.")
         }
-        None => Ok(None), // daemon not running, direct fallback is safe
+        None => {} // daemon not running, auto-start below
     }
+
+    // Auto-start tsmd
+    cmd_start()?;
+
+    // Retry after start
+    daemon_protocol::send_request(&socket, req)
 }
 
 /// Guard: error if the daemon is running (for commands that can't coexist).


### PR DESCRIPTION
## Summary

- tsmd spawns and manages embedder as a child process
- CLI commands auto-start tsmd if not running (no more fallback)
- `tsm embedder-start` hidden (managed by tsmd internally)

## Changes

### tsmd child process management (`src/bin/tsmd.rs`)
- Spawns embedder on startup with idle timeout disabled
- Monitors embedder health in accept loop, restarts on crash (max 3)
- Kills embedder on daemon shutdown
- `--no-embedder` flag to skip embedder

### Auto-start (`src/main.rs`)
- `send_to_daemon()` replaces `try_daemon()` — auto-starts tsmd if not running
- No more direct DB fallback for daemon-routed commands
- `EmbedderStart` command hidden (internal use by tsmd)

### Embedder simplification (`src/embedder.rs`)
- Removed `auto_start_daemon()` — tsmd manages the lifecycle
- `embed_via_socket()` simplified to delegate to `embed_via_socket_at()`

### Indexer cleanup (`src/indexer.rs`)
- Merged `insert_vectors_no_autostart()` into `insert_vectors()`

### Hook update (`hooks/scripts/search.sh`)
- Removed manual embedder startup logic — tsmd handles it

## Test plan

- [x] 362 tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` zero warnings
- [ ] Manual: `tsm search` without tsmd → auto-starts tsmd + embedder
- [ ] Manual: `tsm stop` → embedder also stops
- [ ] Manual: kill embedder → tsmd restarts it