### PR TITLE
feat: add tsm-watcher, rename embedder to tsm-embedder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +954,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -1592,6 +1610,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1737,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -1991,6 +2049,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -2067,6 +2137,36 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "notify",
 ]
 
 [[package]]
@@ -3216,6 +3316,7 @@ dependencies = [
  "hf-hub",
  "libc",
  "lindera",
+ "notify-debouncer-mini",
  "regex",
  "rusqlite",
  "serde",
@@ -3336,7 +3437,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -3962,6 +4063,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4013,6 +4123,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -4052,6 +4177,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4070,6 +4201,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4085,6 +4222,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4118,6 +4261,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4133,6 +4282,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4154,6 +4309,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4169,6 +4330,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,14 @@ path = "src/main.rs"
 name = "tsmd"
 path = "src/bin/tsmd.rs"
 
+[[bin]]
+name = "tsm-embedder"
+path = "src/bin/tsm_embedder.rs"
+
+[[bin]]
+name = "tsm-watcher"
+path = "src/bin/tsm_watcher.rs"
+
 [dependencies]
 rusqlite = { version = "0.39", features = ["bundled", "load_extension"] }
 lindera = { version = "2.3", features = ["embed-ipadic"] }
@@ -31,6 +39,7 @@ thiserror = "2"
 chrono = "0.4"
 sha2 = "0.10"
 libc = "0.2"
+notify-debouncer-mini = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/bin/tsm_embedder.rs
+++ b/src/bin/tsm_embedder.rs
@@ -1,0 +1,3 @@
+fn main() -> anyhow::Result<()> {
+    the_space_memory::cli::cmd_embedder_start(None)
+}

--- a/src/bin/tsm_watcher.rs
+++ b/src/bin/tsm_watcher.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
@@ -89,21 +90,23 @@ fn main() -> Result<()> {
     while !SHUTDOWN.load(Ordering::SeqCst) {
         match rx.recv_timeout(Duration::from_millis(500)) {
             Ok(Ok(events)) => {
-                let mut files_to_index: Vec<String> = Vec::new();
-
+                let mut files_to_index: HashSet<String> = HashSet::new();
                 for event in &events {
                     if event.kind != DebouncedEventKind::Any {
                         continue;
                     }
-                    let path = &event.path;
-
-                    // Only process .md files
-                    if path.extension().is_some_and(|e| e == "md") {
-                        if let Ok(rel) = path.strip_prefix(&project_root) {
-                            let rel_str = rel.to_string_lossy().to_string();
-                            if !files_to_index.contains(&rel_str) {
-                                files_to_index.push(rel_str);
-                            }
+                    if event.path.extension().is_none_or(|ext| ext != "md") {
+                        continue;
+                    }
+                    match event.path.strip_prefix(&project_root) {
+                        Ok(rel) => {
+                            files_to_index.insert(rel.to_string_lossy().into_owned());
+                        }
+                        Err(_) => {
+                            eprintln!(
+                                "tsm-watcher: warning: path {} outside project root, skipping",
+                                event.path.display()
+                            );
                         }
                     }
                 }
@@ -111,7 +114,7 @@ fn main() -> Result<()> {
                 if !files_to_index.is_empty() {
                     let count = files_to_index.len();
                     let req = DaemonRequest::Index {
-                        files: files_to_index,
+                        files: files_to_index.into_iter().collect(),
                     };
                     match daemon_protocol::send_request(&daemon_socket, &req) {
                         Ok(resp) => {

--- a/src/bin/tsm_watcher.rs
+++ b/src/bin/tsm_watcher.rs
@@ -1,0 +1,156 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use notify_debouncer_mini::notify::RecursiveMode;
+use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
+
+use the_space_memory::config;
+use the_space_memory::daemon_protocol::{self, DaemonRequest};
+
+/// Global shutdown flag for signal handlers.
+static SHUTDOWN: AtomicBool = AtomicBool::new(false);
+
+extern "C" fn signal_handler(_sig: libc::c_int) {
+    SHUTDOWN.store(true, Ordering::SeqCst);
+}
+
+#[derive(Parser)]
+#[command(
+    name = "tsm-watcher",
+    version,
+    about = "File watcher for automatic indexing"
+)]
+struct Args {
+    /// Daemon socket path
+    #[arg(long)]
+    daemon_socket: Option<PathBuf>,
+
+    /// Project root directory
+    #[arg(long)]
+    project_root: Option<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let daemon_socket = args
+        .daemon_socket
+        .unwrap_or_else(config::daemon_socket_path);
+    let project_root = args.project_root.unwrap_or_else(config::project_root);
+
+    // Install signal handlers
+    unsafe {
+        libc::signal(
+            libc::SIGTERM,
+            signal_handler as *const () as libc::sighandler_t,
+        );
+        libc::signal(
+            libc::SIGINT,
+            signal_handler as *const () as libc::sighandler_t,
+        );
+    }
+
+    // Set up debounced file watcher
+    let (tx, rx) = mpsc::channel();
+    let mut debouncer =
+        new_debouncer(Duration::from_secs(2), tx).context("Failed to create file watcher")?;
+
+    // Watch content directories
+    let mut watched = 0;
+    for &(dir, _) in config::CONTENT_DIRS {
+        let full_dir = project_root.join(dir);
+        if full_dir.is_dir() {
+            if let Err(e) =
+                debouncer
+                    .watcher()
+                    .watch(&full_dir, RecursiveMode::Recursive)
+            {
+                eprintln!("tsm-watcher: warning: cannot watch {}: {e}", full_dir.display());
+            } else {
+                watched += 1;
+            }
+        }
+    }
+
+    if watched == 0 {
+        anyhow::bail!("No content directories found to watch under {}", project_root.display());
+    }
+
+    eprintln!(
+        "tsm-watcher: watching {watched} directories under {}",
+        project_root.display()
+    );
+
+    // Event loop
+    while !SHUTDOWN.load(Ordering::SeqCst) {
+        match rx.recv_timeout(Duration::from_millis(500)) {
+            Ok(Ok(events)) => {
+                let mut files_to_index: Vec<String> = Vec::new();
+
+                for event in &events {
+                    if event.kind != DebouncedEventKind::Any {
+                        continue;
+                    }
+                    let path = &event.path;
+
+                    // Only process .md files
+                    if path.extension().is_some_and(|e| e == "md") {
+                        if let Ok(rel) = path.strip_prefix(&project_root) {
+                            let rel_str = rel.to_string_lossy().to_string();
+                            if !files_to_index.contains(&rel_str) {
+                                files_to_index.push(rel_str);
+                            }
+                        }
+                    }
+                }
+
+                if !files_to_index.is_empty() {
+                    let count = files_to_index.len();
+                    let req = DaemonRequest::Index {
+                        files: files_to_index,
+                    };
+                    match daemon_protocol::send_request(&daemon_socket, &req) {
+                        Ok(resp) => {
+                            if resp.ok {
+                                if let Some(payload) = resp.payload {
+                                    let indexed = payload["indexed"].as_i64().unwrap_or(0);
+                                    let removed = payload["removed"].as_i64().unwrap_or(0);
+                                    if indexed > 0 || removed > 0 {
+                                        eprintln!(
+                                            "tsm-watcher: indexed {indexed}, removed {removed} ({count} file(s))"
+                                        );
+                                    }
+                                }
+                            } else {
+                                eprintln!(
+                                    "tsm-watcher: index error: {}",
+                                    resp.error.unwrap_or_default()
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("tsm-watcher: daemon communication error: {e}");
+                        }
+                    }
+                }
+            }
+            Ok(Err(e)) => {
+                eprintln!("tsm-watcher: watch error: {e}");
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                // Normal timeout, check shutdown flag
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                eprintln!("tsm-watcher: watcher channel disconnected");
+                break;
+            }
+        }
+    }
+
+    eprintln!("tsm-watcher: shutting down");
+    Ok(())
+}

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -34,6 +34,10 @@ struct Args {
     /// Skip embedder startup
     #[arg(long)]
     no_embedder: bool,
+
+    /// Skip watcher startup
+    #[arg(long)]
+    no_watcher: bool,
 }
 
 fn main() -> Result<()> {
@@ -76,9 +80,9 @@ fn main() -> Result<()> {
 
     eprintln!("tsmd: listening on {} (PID {pid})", socket_path.display());
 
-    // Start embedder as a child process
+    // Start child processes
     let mut embedder_child: Option<Child> = if !args.no_embedder {
-        match start_embedder() {
+        match start_child("tsm-embedder", &[("TSM_EMBEDDER_IDLE_TIMEOUT", "0")]) {
             Ok(child) => {
                 eprintln!("tsmd: embedder started (PID {})", child.id());
                 Some(child)
@@ -90,6 +94,22 @@ fn main() -> Result<()> {
         }
     } else {
         eprintln!("tsmd: embedder disabled (--no-embedder)");
+        None
+    };
+
+    let mut watcher_child: Option<Child> = if !args.no_watcher {
+        match start_child("tsm-watcher", &[]) {
+            Ok(child) => {
+                eprintln!("tsmd: watcher started (PID {})", child.id());
+                Some(child)
+            }
+            Err(e) => {
+                eprintln!("tsmd: warning: failed to start watcher: {e}");
+                None
+            }
+        }
+    } else {
+        eprintln!("tsmd: watcher disabled (--no-watcher)");
         None
     };
 
@@ -106,7 +126,8 @@ fn main() -> Result<()> {
     }
 
     let mut embedder_restarts = 0u32;
-    const MAX_EMBEDDER_RESTARTS: u32 = 3;
+    let mut watcher_restarts = 0u32;
+    const MAX_CHILD_RESTARTS: u32 = 3;
 
     // Accept loop
     while !SHUTDOWN.load(Ordering::SeqCst) {
@@ -122,8 +143,22 @@ fn main() -> Result<()> {
                 });
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                // Check embedder health on each idle poll (every 100ms)
-                maybe_restart_embedder(&mut embedder_child, &mut embedder_restarts, MAX_EMBEDDER_RESTARTS);
+                maybe_restart_child(
+                    "embedder",
+                    "tsm-embedder",
+                    &[("TSM_EMBEDDER_IDLE_TIMEOUT", "0")],
+                    &mut embedder_child,
+                    &mut embedder_restarts,
+                    MAX_CHILD_RESTARTS,
+                );
+                maybe_restart_child(
+                    "watcher",
+                    "tsm-watcher",
+                    &[],
+                    &mut watcher_child,
+                    &mut watcher_restarts,
+                    MAX_CHILD_RESTARTS,
+                );
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
             Err(e) => {
@@ -135,13 +170,8 @@ fn main() -> Result<()> {
 
     // Cleanup
     eprintln!("tsmd: shutting down");
-
-    // Stop embedder child
-    if let Some(mut child) = embedder_child {
-        eprintln!("tsmd: stopping embedder (PID {})...", child.id());
-        let _ = child.kill();
-        let _ = child.wait();
-    }
+    stop_child("embedder", embedder_child);
+    stop_child("watcher", watcher_child);
 
     let _ = std::fs::remove_file(&socket_path);
     let _ = std::fs::remove_file(&pid_path);
@@ -152,9 +182,52 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Check if the embedder child has exited and restart it if within the retry limit.
-/// Sets `child` to `None` once the limit is exhausted or when a restart fails to spawn.
-fn maybe_restart_embedder(child: &mut Option<Child>, restarts: &mut u32, max: u32) {
+// ─── Child process management ─────────────────────────────────────
+
+/// Find a sibling binary in the same directory as the current executable.
+fn sibling_binary(name: &str) -> Result<PathBuf> {
+    let exe_dir = std::env::current_exe()?
+        .parent()
+        .context("executable has no parent directory")?
+        .to_path_buf();
+    Ok(exe_dir.join(name))
+}
+
+/// Start a child process by binary name, with optional environment variables.
+fn start_child(binary: &str, env_vars: &[(&str, &str)]) -> Result<Child> {
+    let bin_path = sibling_binary(binary)?;
+
+    // Clean up stale embedder socket if starting the embedder
+    if binary == "tsm-embedder" {
+        let embedder_socket = Path::new(config::SOCKET_PATH);
+        if embedder_socket.exists() {
+            if let Err(e) = std::fs::remove_file(embedder_socket) {
+                eprintln!("tsmd: warning: could not remove stale embedder socket: {e}");
+            }
+        }
+    }
+
+    let mut cmd = Command::new(&bin_path);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit());
+    for &(k, v) in env_vars {
+        cmd.env(k, v);
+    }
+
+    cmd.spawn()
+        .context(format!("Failed to spawn {binary}"))
+}
+
+/// Check if a child has exited and restart it within the retry limit.
+fn maybe_restart_child(
+    label: &str,
+    binary: &str,
+    env_vars: &[(&str, &str)],
+    child: &mut Option<Child>,
+    restarts: &mut u32,
+    max: u32,
+) {
     let exited = match child {
         Some(c) => matches!(c.try_wait(), Ok(Some(_))),
         None => return,
@@ -165,65 +238,42 @@ fn maybe_restart_embedder(child: &mut Option<Child>, restarts: &mut u32, max: u3
     }
 
     if *restarts >= max {
-        eprintln!("tsmd: embedder crashed {max} times, giving up");
+        eprintln!("tsmd: {label} crashed {max} times, giving up");
         *child = None;
         return;
     }
 
     *restarts += 1;
-    eprintln!("tsmd: embedder exited, restarting ({restarts}/{max})...");
-    match start_embedder() {
+    eprintln!("tsmd: {label} exited, restarting ({restarts}/{max})...");
+    match start_child(binary, env_vars) {
         Ok(new_child) => {
-            eprintln!("tsmd: embedder restarted (PID {})", new_child.id());
+            eprintln!("tsmd: {label} restarted (PID {})", new_child.id());
             *child = Some(new_child);
-            *restarts = 0; // reset on successful restart
+            *restarts = 0;
         }
         Err(e) => {
-            eprintln!("tsmd: failed to restart embedder: {e}");
+            eprintln!("tsmd: failed to restart {label}: {e}");
             *child = None;
         }
     }
 }
 
-/// Start the embedder as a child process with idle timeout disabled.
-fn start_embedder() -> Result<Child> {
-    let embedder_socket = Path::new(config::SOCKET_PATH);
-
-    // Clean up stale embedder socket
-    if embedder_socket.exists() {
-        if let Err(e) = std::fs::remove_file(embedder_socket) {
-            eprintln!("tsmd: warning: could not remove stale embedder socket: {e}");
-        }
+/// Stop a child process gracefully.
+fn stop_child(label: &str, child: Option<Child>) {
+    if let Some(mut child) = child {
+        eprintln!("tsmd: stopping {label} (PID {})...", child.id());
+        let _ = child.kill();
+        let _ = child.wait();
     }
-
-    // Find the tsm binary (same directory as tsmd)
-    let exe_dir = std::env::current_exe()?
-        .parent()
-        .context("executable has no parent directory")?
-        .to_path_buf();
-    let tsm_path = exe_dir.join("tsm");
-
-    let child = Command::new(&tsm_path)
-        .arg("embedder-start")
-        .env("TSM_EMBEDDER_IDLE_TIMEOUT", "0") // disable idle timeout
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::inherit()) // inherit stderr for embedder logs
-        .spawn()
-        .context("Failed to spawn embedder process")?;
-
-    // Don't block waiting for embedder socket — model loading can take tens of seconds.
-    // The accept loop starts immediately; embed_via_socket returns None until ready,
-    // and backfill handles missing vectors later.
-    Ok(child)
 }
+
+// ─── Client handling ──────────────────────────────────────────────
 
 fn handle_client(
     stream: &mut std::os::unix::net::UnixStream,
     conn: &Arc<Mutex<rusqlite::Connection>>,
     project_root: &std::path::Path,
 ) -> Result<()> {
-    // Prevent slow/disconnected clients from holding threads indefinitely
     stream.set_read_timeout(Some(std::time::Duration::from_secs(30)))?;
     stream.set_write_timeout(Some(std::time::Duration::from_secs(30)))?;
     let req = read_request(stream)?;

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -80,11 +80,31 @@ fn main() -> Result<()> {
 
     eprintln!("tsmd: listening on {} (PID {pid})", socket_path.display());
 
+    // Install signal handlers BEFORE spawning children
+    unsafe {
+        libc::signal(
+            libc::SIGTERM,
+            signal_handler as *const () as libc::sighandler_t,
+        );
+        libc::signal(
+            libc::SIGINT,
+            signal_handler as *const () as libc::sighandler_t,
+        );
+    }
+
     // Start child processes
     let mut embedder_child: Option<Child> = if !args.no_embedder {
+        remove_stale_embedder_socket();
         match start_child("tsm-embedder", &[("TSM_EMBEDDER_IDLE_TIMEOUT", "0")]) {
             Ok(child) => {
-                eprintln!("tsmd: embedder started (PID {})", child.id());
+                let child_pid = child.id();
+                eprintln!("tsmd: embedder started (PID {child_pid})");
+                status::update(&data_dir, |s| {
+                    s.embedder = Some(status::EmbedderStatus {
+                        started_at: chrono::Utc::now().to_rfc3339(),
+                        pid: child_pid,
+                    });
+                });
                 Some(child)
             }
             Err(e) => {
@@ -100,7 +120,14 @@ fn main() -> Result<()> {
     let mut watcher_child: Option<Child> = if !args.no_watcher {
         match start_child("tsm-watcher", &[]) {
             Ok(child) => {
-                eprintln!("tsmd: watcher started (PID {})", child.id());
+                let child_pid = child.id();
+                eprintln!("tsmd: watcher started (PID {child_pid})");
+                status::update(&data_dir, |s| {
+                    s.watcher = Some(status::WatcherStatus {
+                        started_at: chrono::Utc::now().to_rfc3339(),
+                        pid: child_pid,
+                    });
+                });
                 Some(child)
             }
             Err(e) => {
@@ -112,18 +139,6 @@ fn main() -> Result<()> {
         eprintln!("tsmd: watcher disabled (--no-watcher)");
         None
     };
-
-    // Install signal handlers
-    unsafe {
-        libc::signal(
-            libc::SIGTERM,
-            signal_handler as *const () as libc::sighandler_t,
-        );
-        libc::signal(
-            libc::SIGINT,
-            signal_handler as *const () as libc::sighandler_t,
-        );
-    }
 
     let mut embedder_restarts = 0u32;
     let mut watcher_restarts = 0u32;
@@ -143,22 +158,10 @@ fn main() -> Result<()> {
                 });
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                maybe_restart_child(
-                    "embedder",
-                    "tsm-embedder",
-                    &[("TSM_EMBEDDER_IDLE_TIMEOUT", "0")],
-                    &mut embedder_child,
-                    &mut embedder_restarts,
-                    MAX_CHILD_RESTARTS,
-                );
-                maybe_restart_child(
-                    "watcher",
-                    "tsm-watcher",
-                    &[],
-                    &mut watcher_child,
-                    &mut watcher_restarts,
-                    MAX_CHILD_RESTARTS,
-                );
+                if maybe_restart_child("embedder", &mut embedder_child, &mut embedder_restarts, MAX_CHILD_RESTARTS) {
+                    remove_stale_embedder_socket();
+                }
+                maybe_restart_child("watcher", &mut watcher_child, &mut watcher_restarts, MAX_CHILD_RESTARTS);
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
             Err(e) => {
@@ -177,6 +180,7 @@ fn main() -> Result<()> {
     let _ = std::fs::remove_file(&pid_path);
     status::update(&data_dir, |s| {
         s.daemon = None;
+        s.watcher = None;
     });
 
     Ok(())
@@ -196,17 +200,6 @@ fn sibling_binary(name: &str) -> Result<PathBuf> {
 /// Start a child process by binary name, with optional environment variables.
 fn start_child(binary: &str, env_vars: &[(&str, &str)]) -> Result<Child> {
     let bin_path = sibling_binary(binary)?;
-
-    // Clean up stale embedder socket if starting the embedder
-    if binary == "tsm-embedder" {
-        let embedder_socket = Path::new(config::SOCKET_PATH);
-        if embedder_socket.exists() {
-            if let Err(e) = std::fs::remove_file(embedder_socket) {
-                eprintln!("tsmd: warning: could not remove stale embedder socket: {e}");
-            }
-        }
-    }
-
     let mut cmd = Command::new(&bin_path);
     cmd.stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -214,56 +207,108 @@ fn start_child(binary: &str, env_vars: &[(&str, &str)]) -> Result<Child> {
     for &(k, v) in env_vars {
         cmd.env(k, v);
     }
-
     cmd.spawn()
         .context(format!("Failed to spawn {binary}"))
 }
 
+/// Remove the embedder UNIX socket if it exists.
+fn remove_stale_embedder_socket() {
+    let path = Path::new(config::SOCKET_PATH);
+    if path.exists() {
+        if let Err(e) = std::fs::remove_file(path) {
+            eprintln!("tsmd: warning: could not remove stale embedder socket: {e}");
+        }
+    }
+}
+
 /// Check if a child has exited and restart it within the retry limit.
+/// Returns `true` if a restart was attempted (for pre-restart hooks like socket cleanup).
 fn maybe_restart_child(
     label: &str,
-    binary: &str,
-    env_vars: &[(&str, &str)],
     child: &mut Option<Child>,
     restarts: &mut u32,
     max: u32,
-) {
+) -> bool {
     let exited = match child {
-        Some(c) => matches!(c.try_wait(), Ok(Some(_))),
-        None => return,
+        Some(c) => match c.try_wait() {
+            Ok(Some(exit_status)) => {
+                eprintln!("tsmd: {label} exited with status: {exit_status}");
+                true
+            }
+            Ok(None) => false,
+            Err(e) => {
+                eprintln!("tsmd: error checking {label} status: {e}");
+                false
+            }
+        },
+        None => return false,
     };
 
     if !exited {
-        return;
+        return false;
     }
 
     if *restarts >= max {
         eprintln!("tsmd: {label} crashed {max} times, giving up");
         *child = None;
-        return;
+        return false;
     }
 
     *restarts += 1;
     eprintln!("tsmd: {label} exited, restarting ({restarts}/{max})...");
+
+    // Determine binary name and env vars from label
+    let (binary, env_vars): (&str, &[(&str, &str)]) = match label {
+        "embedder" => ("tsm-embedder", &[("TSM_EMBEDDER_IDLE_TIMEOUT", "0")]),
+        "watcher" => ("tsm-watcher", &[]),
+        _ => {
+            eprintln!("tsmd: unknown child label: {label}");
+            *child = None;
+            return false;
+        }
+    };
+
     match start_child(binary, env_vars) {
         Ok(new_child) => {
             eprintln!("tsmd: {label} restarted (PID {})", new_child.id());
             *child = Some(new_child);
             *restarts = 0;
+            true
         }
         Err(e) => {
             eprintln!("tsmd: failed to restart {label}: {e}");
             *child = None;
+            false
         }
     }
 }
 
-/// Stop a child process gracefully.
+/// Stop a child process: SIGTERM → wait (2s grace) → SIGKILL.
 fn stop_child(label: &str, child: Option<Child>) {
     if let Some(mut child) = child {
-        eprintln!("tsmd: stopping {label} (PID {})...", child.id());
-        let _ = child.kill();
-        let _ = child.wait();
+        let pid = child.id();
+        eprintln!("tsmd: stopping {label} (PID {pid})...");
+
+        // Send SIGTERM for graceful shutdown
+        unsafe {
+            libc::kill(pid as i32, libc::SIGTERM);
+        }
+
+        // Wait up to 2 seconds for graceful exit
+        for _ in 0..20 {
+            if matches!(child.try_wait(), Ok(Some(_))) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        // Force kill if still running
+        if let Err(e) = child.kill() {
+            eprintln!("tsmd: warning: failed to kill {label} (PID {pid}): {e}");
+        }
+        if let Err(e) = child.wait() {
+            eprintln!("tsmd: warning: failed to wait for {label} (PID {pid}): {e}");
+        }
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -573,7 +573,7 @@ fn doctor_check_with_conn(
         emb_section.items.push(CheckItem {
             status: CheckStatus::Warning,
             message: "Stopped".to_string(),
-            hint: Some("Run `embedder-start`.".to_string()),
+            hint: Some("Run `tsmd` to start the daemon (includes embedder).".to_string()),
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,9 +79,6 @@ enum Commands {
         /// Path to the JSONL file
         session_file: PathBuf,
     },
-    /// Internal: start the embedder daemon (managed by tsmd)
-    #[command(hide = true)]
-    EmbedderStart,
     /// Download model files from HuggingFace Hub
     Setup,
     /// Fill missing vectors for chunks (needs running embedder)
@@ -133,7 +130,6 @@ fn main() -> anyhow::Result<()> {
         Commands::Init => cli::cmd_init()?,
         Commands::Start => cmd_start()?,
         Commands::Stop => cmd_stop()?,
-        Commands::EmbedderStart => cli::cmd_embedder_start(None)?,
         Commands::Setup => cli::cmd_setup()?,
         Commands::BackfillWorker => cli::cmd_backfill_worker()?,
         Commands::VectorFill { batch_size } => cli::cmd_vector_fill(batch_size)?,

--- a/src/status.rs
+++ b/src/status.rs
@@ -12,6 +12,8 @@ pub struct StatusFile {
     pub embedder: Option<EmbedderStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub daemon: Option<DaemonStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watcher: Option<WatcherStatus>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -33,6 +35,12 @@ pub struct DaemonStatus {
     pub started_at: String,
     pub pid: u32,
     pub socket: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WatcherStatus {
+    pub started_at: String,
+    pub pid: u32,
 }
 
 pub fn status_path(data_dir: &Path) -> std::path::PathBuf {


### PR DESCRIPTION
## Summary

- `tsm-watcher`: new file monitor daemon using inotify/FSEvents
- `tsm-embedder`: extracted from `tsm embedder-start` to standalone binary
- Unified process tree: `tsmd → tsm-embedder + tsm-watcher`

## Process Tree

```
tsmd
  ├── tsm-embedder (inference server)
  └── tsm-watcher (file monitor → auto-index)
```

## tsm-watcher

- Watches `CONTENT_DIRS` recursively for `.md` file changes
- Debounce: 2 seconds (avoids rapid re-indexing on save)
- On change: sends `DaemonRequest::Index` to tsmd via daemon socket
- On delete: same request — indexer detects missing file and removes from DB
- Uses `notify-debouncer-mini` (MIT) for cross-platform inotify/FSEvents

## tsm-embedder

- Standalone binary replacing `tsm embedder-start` subcommand
- `Commands::EmbedderStart` removed from CLI

## tsmd Changes

- Generalized child management: `start_child`/`maybe_restart_child`/`stop_child`
- `--no-watcher` flag (mirrors `--no-embedder`)
- `WatcherStatus` added to status tracking

## Test plan

- [x] 362 tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` zero warnings
- [ ] Manual: `tsm start` → watcher + embedder both start
- [ ] Manual: create/modify/delete `.md` → auto-indexed
- [ ] Manual: `tsm doctor` shows watcher status
- [ ] Manual: `tsm stop` → both children stop

Refs: #27, #29