### PR TITLE
feat: migrate eprintln! to log + flexi_logger structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "flexi_logger"
+version = "0.29.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a5a6882b2e137c4f2664562995865084eb5a00611fba30c582ef10354c4ad8"
+dependencies = [
+ "chrono",
+ "log",
+ "nu-ansi-term",
+ "regex",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "float8"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2183,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,9 +3335,11 @@ dependencies = [
  "candle-transformers",
  "chrono",
  "clap",
+ "flexi_logger",
  "hf-hub",
  "libc",
  "lindera",
+ "log",
  "notify-debouncer-mini",
  "regex",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ thiserror = "2"
 chrono = "0.4"
 sha2 = "0.10"
 libc = "0.2"
+log = "0.4"
+flexi_logger = { version = "0.29", features = ["colors"] }
 notify-debouncer-mini = "0.4"
 
 [dev-dependencies]

--- a/src/bin/tsm_embedder.rs
+++ b/src/bin/tsm_embedder.rs
@@ -1,3 +1,4 @@
 fn main() -> anyhow::Result<()> {
+    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsm-embedder" })?;
     the_space_memory::cli::cmd_embedder_start(None)
 }

--- a/src/bin/tsm_watcher.rs
+++ b/src/bin/tsm_watcher.rs
@@ -36,6 +36,7 @@ struct Args {
 }
 
 fn main() -> Result<()> {
+    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsm-watcher" })?;
     let args = Args::parse();
 
     let daemon_socket = args
@@ -70,7 +71,7 @@ fn main() -> Result<()> {
                     .watcher()
                     .watch(&full_dir, RecursiveMode::Recursive)
             {
-                eprintln!("tsm-watcher: warning: cannot watch {}: {e}", full_dir.display());
+                log::warn!("cannot watch {}: {e}", full_dir.display());
             } else {
                 watched += 1;
             }
@@ -81,8 +82,8 @@ fn main() -> Result<()> {
         anyhow::bail!("No content directories found to watch under {}", project_root.display());
     }
 
-    eprintln!(
-        "tsm-watcher: watching {watched} directories under {}",
+    log::info!(
+        "watching {watched} directories under {}",
         project_root.display()
     );
 
@@ -103,8 +104,8 @@ fn main() -> Result<()> {
                             files_to_index.insert(rel.to_string_lossy().into_owned());
                         }
                         Err(_) => {
-                            eprintln!(
-                                "tsm-watcher: warning: path {} outside project root, skipping",
+                            log::warn!(
+                                "path {} outside project root, skipping",
                                 event.path.display()
                             );
                         }
@@ -123,37 +124,37 @@ fn main() -> Result<()> {
                                     let indexed = payload["indexed"].as_i64().unwrap_or(0);
                                     let removed = payload["removed"].as_i64().unwrap_or(0);
                                     if indexed > 0 || removed > 0 {
-                                        eprintln!(
-                                            "tsm-watcher: indexed {indexed}, removed {removed} ({count} file(s))"
+                                        log::info!(
+                                            "indexed {indexed}, removed {removed} ({count} file(s))"
                                         );
                                     }
                                 }
                             } else {
-                                eprintln!(
-                                    "tsm-watcher: index error: {}",
+                                log::warn!(
+                                    "index error: {}",
                                     resp.error.unwrap_or_default()
                                 );
                             }
                         }
                         Err(e) => {
-                            eprintln!("tsm-watcher: daemon communication error: {e}");
+                            log::warn!("daemon communication error: {e}");
                         }
                     }
                 }
             }
             Ok(Err(e)) => {
-                eprintln!("tsm-watcher: watch error: {e}");
+                log::warn!("watch error: {e}");
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 // Normal timeout, check shutdown flag
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => {
-                eprintln!("tsm-watcher: watcher channel disconnected");
+                log::warn!("watcher channel disconnected");
                 break;
             }
         }
     }
 
-    eprintln!("tsm-watcher: shutting down");
+    log::info!("shutting down");
     Ok(())
 }

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -41,6 +41,7 @@ struct Args {
 }
 
 fn main() -> Result<()> {
+    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsmd" })?;
     let args = Args::parse();
 
     let socket_path = args.socket.unwrap_or_else(config::daemon_socket_path);
@@ -78,7 +79,7 @@ fn main() -> Result<()> {
         });
     });
 
-    eprintln!("tsmd: listening on {} (PID {pid})", socket_path.display());
+    log::info!("listening on {} (PID {pid})", socket_path.display());
 
     // Install signal handlers BEFORE spawning children
     unsafe {
@@ -98,7 +99,7 @@ fn main() -> Result<()> {
         match start_child("tsm-embedder", &[("TSM_EMBEDDER_IDLE_TIMEOUT", "0")]) {
             Ok(child) => {
                 let child_pid = child.id();
-                eprintln!("tsmd: embedder started (PID {child_pid})");
+                log::info!("embedder started (PID {child_pid})");
                 status::update(&data_dir, |s| {
                     s.embedder = Some(status::EmbedderStatus {
                         started_at: chrono::Utc::now().to_rfc3339(),
@@ -108,12 +109,12 @@ fn main() -> Result<()> {
                 Some(child)
             }
             Err(e) => {
-                eprintln!("tsmd: warning: failed to start embedder: {e}");
+                log::warn!("failed to start embedder: {e}");
                 None
             }
         }
     } else {
-        eprintln!("tsmd: embedder disabled (--no-embedder)");
+        log::info!("embedder disabled (--no-embedder)");
         None
     };
 
@@ -121,7 +122,7 @@ fn main() -> Result<()> {
         match start_child("tsm-watcher", &[]) {
             Ok(child) => {
                 let child_pid = child.id();
-                eprintln!("tsmd: watcher started (PID {child_pid})");
+                log::info!("watcher started (PID {child_pid})");
                 status::update(&data_dir, |s| {
                     s.watcher = Some(status::WatcherStatus {
                         started_at: chrono::Utc::now().to_rfc3339(),
@@ -131,12 +132,12 @@ fn main() -> Result<()> {
                 Some(child)
             }
             Err(e) => {
-                eprintln!("tsmd: warning: failed to start watcher: {e}");
+                log::warn!("failed to start watcher: {e}");
                 None
             }
         }
     } else {
-        eprintln!("tsmd: watcher disabled (--no-watcher)");
+        log::info!("watcher disabled (--no-watcher)");
         None
     };
 
@@ -153,7 +154,7 @@ fn main() -> Result<()> {
 
                 std::thread::spawn(move || {
                     if let Err(e) = handle_client(&mut stream, &conn, &project_root) {
-                        eprintln!("tsmd: client error: {e}");
+                        log::warn!("client error: {e}");
                     }
                 });
             }
@@ -165,14 +166,14 @@ fn main() -> Result<()> {
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
             Err(e) => {
-                eprintln!("tsmd: fatal accept error: {e}");
+                log::error!("fatal accept error: {e}");
                 break;
             }
         }
     }
 
     // Cleanup
-    eprintln!("tsmd: shutting down");
+    log::info!("shutting down");
     stop_child("embedder", embedder_child);
     stop_child("watcher", watcher_child);
 
@@ -201,9 +202,10 @@ fn sibling_binary(name: &str) -> Result<PathBuf> {
 fn start_child(binary: &str, env_vars: &[(&str, &str)]) -> Result<Child> {
     let bin_path = sibling_binary(binary)?;
     let mut cmd = Command::new(&bin_path);
+    // Child processes manage their own log files via flexi_logger
     cmd.stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::inherit());
+        .stderr(Stdio::null());
     for &(k, v) in env_vars {
         cmd.env(k, v);
     }
@@ -216,7 +218,7 @@ fn remove_stale_embedder_socket() {
     let path = Path::new(config::SOCKET_PATH);
     if path.exists() {
         if let Err(e) = std::fs::remove_file(path) {
-            eprintln!("tsmd: warning: could not remove stale embedder socket: {e}");
+            log::warn!("could not remove stale embedder socket: {e}");
         }
     }
 }
@@ -232,12 +234,12 @@ fn maybe_restart_child(
     let exited = match child {
         Some(c) => match c.try_wait() {
             Ok(Some(exit_status)) => {
-                eprintln!("tsmd: {label} exited with status: {exit_status}");
+                log::info!("{label} exited with status: {exit_status}");
                 true
             }
             Ok(None) => false,
             Err(e) => {
-                eprintln!("tsmd: error checking {label} status: {e}");
+                log::warn!("error checking {label} status: {e}");
                 false
             }
         },
@@ -249,20 +251,20 @@ fn maybe_restart_child(
     }
 
     if *restarts >= max {
-        eprintln!("tsmd: {label} crashed {max} times, giving up");
+        log::error!("{label} crashed {max} times, giving up");
         *child = None;
         return false;
     }
 
     *restarts += 1;
-    eprintln!("tsmd: {label} exited, restarting ({restarts}/{max})...");
+    log::warn!("{label} exited, restarting ({restarts}/{max})...");
 
     // Determine binary name and env vars from label
     let (binary, env_vars): (&str, &[(&str, &str)]) = match label {
         "embedder" => ("tsm-embedder", &[("TSM_EMBEDDER_IDLE_TIMEOUT", "0")]),
         "watcher" => ("tsm-watcher", &[]),
         _ => {
-            eprintln!("tsmd: unknown child label: {label}");
+            log::error!("unknown child label: {label}");
             *child = None;
             return false;
         }
@@ -270,13 +272,13 @@ fn maybe_restart_child(
 
     match start_child(binary, env_vars) {
         Ok(new_child) => {
-            eprintln!("tsmd: {label} restarted (PID {})", new_child.id());
+            log::info!("{label} restarted (PID {})", new_child.id());
             *child = Some(new_child);
             *restarts = 0;
             true
         }
         Err(e) => {
-            eprintln!("tsmd: failed to restart {label}: {e}");
+            log::error!("failed to restart {label}: {e}");
             *child = None;
             false
         }
@@ -287,7 +289,7 @@ fn maybe_restart_child(
 fn stop_child(label: &str, child: Option<Child>) {
     if let Some(mut child) = child {
         let pid = child.id();
-        eprintln!("tsmd: stopping {label} (PID {pid})...");
+        log::info!("stopping {label} (PID {pid})...");
 
         // Send SIGTERM for graceful shutdown
         unsafe {
@@ -304,10 +306,10 @@ fn stop_child(label: &str, child: Option<Child>) {
 
         // Force kill if still running
         if let Err(e) = child.kill() {
-            eprintln!("tsmd: warning: failed to kill {label} (PID {pid}): {e}");
+            log::warn!("failed to kill {label} (PID {pid}): {e}");
         }
         if let Err(e) = child.wait() {
-            eprintln!("tsmd: warning: failed to wait for {label} (PID {pid}): {e}");
+            log::warn!("failed to wait for {label} (PID {pid}): {e}");
         }
     }
 }

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -109,7 +109,7 @@ fn main() -> Result<()> {
                 Some(child)
             }
             Err(e) => {
-                log::warn!("failed to start embedder: {e}");
+                log::error!("failed to start embedder: {e}");
                 None
             }
         }
@@ -132,7 +132,7 @@ fn main() -> Result<()> {
                 Some(child)
             }
             Err(e) => {
-                log::warn!("failed to start watcher: {e}");
+                log::error!("failed to start watcher: {e}");
                 None
             }
         }
@@ -202,10 +202,10 @@ fn sibling_binary(name: &str) -> Result<PathBuf> {
 fn start_child(binary: &str, env_vars: &[(&str, &str)]) -> Result<Child> {
     let bin_path = sibling_binary(binary)?;
     let mut cmd = Command::new(&bin_path);
-    // Child processes manage their own log files via flexi_logger
+    // Keep stderr inherited so pre-logger startup errors are visible
     cmd.stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stderr(Stdio::inherit());
     for &(k, v) in env_vars {
         cmd.env(k, v);
     }
@@ -234,7 +234,11 @@ fn maybe_restart_child(
     let exited = match child {
         Some(c) => match c.try_wait() {
             Ok(Some(exit_status)) => {
-                log::info!("{label} exited with status: {exit_status}");
+                if exit_status.success() {
+                    log::info!("{label} exited with status: {exit_status}");
+                } else {
+                    log::warn!("{label} exited with non-zero status: {exit_status}");
+                }
                 true
             }
             Ok(None) => false,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -969,9 +969,10 @@ pub fn cmd_dict_update(
         return Ok(());
     }
 
-    log::info!("=== Dictionary Update Candidates ===\n");
+    // Interactive TUI output — bypass log system for clean display
+    eprintln!("=== Dictionary Update Candidates ===\n");
     for c in &candidates {
-        log::info!(
+        eprintln!(
             "  {:<20} {:>3} hits  (first: {}, last: {})",
             c.surface,
             c.frequency,
@@ -979,7 +980,7 @@ pub fn cmd_dict_update(
             &c.last_seen[..10.min(c.last_seen.len())]
         );
     }
-    log::info!(
+    eprintln!(
         "\n{} word(s) will be added to user_dict.csv.",
         candidates.len()
     );

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ use crate::user_dict;
 pub fn cmd_init() -> anyhow::Result<()> {
     let db_path = config::db_path();
     db::init_db(&db_path)?;
-    eprintln!("Database initialized at {}", db_path.display());
+    log::info!("Database initialized at {}", db_path.display());
     Ok(())
 }
 
@@ -36,7 +36,7 @@ pub fn cmd_index(files_from_stdin: bool) -> anyhow::Result<()> {
     };
 
     let stats = run_index(&conn, &file_paths, &project_root)?;
-    eprintln!(
+    log::info!(
         "Indexed: {}, Skipped: {}, Removed: {}",
         stats.indexed, stats.skipped, stats.removed
     );
@@ -232,9 +232,9 @@ pub fn cmd_ingest_session(session_file: &Path) -> anyhow::Result<()> {
         .unwrap_or_default()
         .to_string_lossy();
     if indexed {
-        eprintln!("Session indexed: {name}");
+        log::info!("Session indexed: {name}");
     } else {
-        eprintln!("Session unchanged: {name}");
+        log::info!("Session unchanged: {name}");
     }
     Ok(())
 }
@@ -302,9 +302,9 @@ pub fn run_vector_fill(conn: &rusqlite::Connection, batch_size: usize) -> anyhow
 
         if stats.errors == 0 {
             if stats.filled > 0 {
-                eprintln!("Backfilled {} vectors.", stats.filled);
+                log::info!("Backfilled {} vectors.", stats.filled);
             } else {
-                eprintln!("No missing vectors.");
+                log::info!("No missing vectors.");
             }
             break;
         }
@@ -312,7 +312,7 @@ pub fn run_vector_fill(conn: &rusqlite::Connection, batch_size: usize) -> anyhow
         // Worker may have crashed — check and restart
         if !worker.borrow_mut().is_alive() {
             if restarts >= config::MAX_WORKER_RESTARTS {
-                eprintln!(
+                log::error!(
                     "Worker crashed {} times. {} errors remain.",
                     restarts + 1,
                     stats.errors
@@ -320,7 +320,7 @@ pub fn run_vector_fill(conn: &rusqlite::Connection, batch_size: usize) -> anyhow
                 break;
             }
             restarts += 1;
-            eprintln!(
+            log::warn!(
                 "Worker crashed. Restarting ({restarts}/{})...",
                 config::MAX_WORKER_RESTARTS
             );
@@ -329,7 +329,7 @@ pub fn run_vector_fill(conn: &rusqlite::Connection, batch_size: usize) -> anyhow
             // Next iteration will pick up remaining unchunked vectors
         } else {
             // Worker alive but had encode errors — don't retry
-            eprintln!("Done: {} filled, {} errors.", stats.filled, stats.errors);
+            log::info!("Done: {} filled, {} errors.", stats.filled, stats.errors);
             break;
         }
     }
@@ -353,12 +353,12 @@ pub fn cmd_import_wordnet(wordnet_db: &Path) -> anyhow::Result<()> {
     let conn = db::get_connection(&db_path)?;
 
     let count = crate::synonyms::import_wordnet(&conn, wordnet_db)?;
-    eprintln!("Imported {count} synonym pairs from WordNet.");
+    log::info!("Imported {count} synonym pairs from WordNet.");
 
     let total: i64 = conn
         .query_row("SELECT COUNT(*) FROM synonyms", [], |r| r.get(0))
         .unwrap_or(0);
-    eprintln!("Total synonyms: {total}");
+    log::info!("Total synonyms: {total}");
     Ok(())
 }
 
@@ -372,10 +372,10 @@ pub fn cmd_setup() -> anyhow::Result<()> {
     let config_path = repo.get("config.json")?;
     let tokenizer_path = repo.get("tokenizer.json")?;
     let weights_path = repo.get("model.safetensors")?;
-    eprintln!("Model files downloaded:");
-    eprintln!("  config:    {}", config_path.display());
-    eprintln!("  tokenizer: {}", tokenizer_path.display());
-    eprintln!("  weights:   {}", weights_path.display());
+    log::info!("Model files downloaded:");
+    log::info!("  config:    {}", config_path.display());
+    log::info!("  tokenizer: {}", tokenizer_path.display());
+    log::info!("  weights:   {}", weights_path.display());
     Ok(())
 }
 
@@ -965,13 +965,13 @@ pub fn cmd_dict_update(
 
     let candidates = user_dict::get_threshold_candidates(&conn, threshold);
     if candidates.is_empty() {
-        eprintln!("No candidates meet the threshold (freq >= {threshold}).");
+        log::info!("No candidates meet the threshold (freq >= {threshold}).");
         return Ok(());
     }
 
-    eprintln!("=== Dictionary Update Candidates ===\n");
+    log::info!("=== Dictionary Update Candidates ===\n");
     for c in &candidates {
-        eprintln!(
+        log::info!(
             "  {:<20} {:>3} hits  (first: {}, last: {})",
             c.surface,
             c.frequency,
@@ -979,7 +979,7 @@ pub fn cmd_dict_update(
             &c.last_seen[..10.min(c.last_seen.len())]
         );
     }
-    eprintln!(
+    log::info!(
         "\n{} word(s) will be added to user_dict.csv.",
         candidates.len()
     );
@@ -989,7 +989,7 @@ pub fn cmd_dict_update(
         let mut input = String::new();
         std::io::stdin().read_line(&mut input)?;
         if input.trim().to_lowercase() != "y" {
-            eprintln!("Cancelled.");
+            log::info!("Cancelled.");
             return Ok(());
         }
     }
@@ -998,17 +998,17 @@ pub fn cmd_dict_update(
     let csv_path = config::user_dict_path();
     let exported = user_dict::export_candidates_to_csv(&conn, &csv_path, threshold, format)?;
     let count = exported.len();
-    eprintln!("Wrote {count} word(s) to {}", csv_path.display());
+    log::info!("Wrote {count} word(s) to {}", csv_path.display());
 
     if count == 0 {
-        eprintln!("All candidates were already in the dict file. Nothing to do.");
+        log::info!("All candidates were already in the dict file. Nothing to do.");
         return Ok(());
     }
 
     drop(conn);
 
     // Rebuild
-    eprintln!("\nRebuilding index...");
+    log::info!("\nRebuilding index...");
     cmd_rebuild(true)?;
 
     // Save current branch to return to later
@@ -1055,7 +1055,7 @@ pub fn cmd_dict_update(
         "gh",
         &["pr", "create", "--title", &pr_title, "--body", &pr_body],
     ) {
-        eprintln!("Warning: `gh pr create` failed ({e}). Push succeeded — create the PR manually.");
+        log::warn!("`gh pr create` failed ({e}). Push succeeded — create the PR manually.");
     }
 
     // Return to original branch
@@ -1094,7 +1094,7 @@ fn spawn_background_backfill() {
     let exe = match std::env::current_exe() {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("Cannot determine executable path: {e}");
+            log::error!("Cannot determine executable path: {e}");
             return;
         }
     };
@@ -1112,7 +1112,7 @@ fn spawn_background_backfill() {
     }
     match cmd.spawn() {
         Ok(_) => {}
-        Err(e) => eprintln!("Failed to start background backfill: {e}"),
+        Err(e) => log::error!("Failed to start background backfill: {e}"),
     }
 }
 
@@ -1122,43 +1122,43 @@ pub fn cmd_rebuild(force: bool) -> anyhow::Result<()> {
     let socket = Path::new(config::SOCKET_PATH);
 
     if !socket.exists() {
-        eprintln!("Warning: Embedder is not running. Rebuilding without vectors.");
+        log::warn!("Embedder is not running. Rebuilding without vectors.");
         if !force {
             anyhow::bail!("Use --force to proceed without embedder.");
         }
     } else {
-        eprintln!("Embedder: running");
+        log::info!("Embedder: running");
     }
 
     // Backup
     if db_path.exists() {
         let backup = db_path.with_extension("db.bak");
         std::fs::copy(&db_path, &backup)?;
-        eprintln!("Backup: {}", backup.display());
+        log::info!("Backup: {}", backup.display());
         std::fs::remove_file(&db_path)?;
-        eprintln!("Deleted: {}", db_path.display());
+        log::info!("Deleted: {}", db_path.display());
     }
 
     // Init
     db::init_db(&db_path)?;
-    eprintln!("DB initialized");
+    log::info!("DB initialized");
 
     // Full index (synchronous, with progress)
     let conn = db::get_connection(&db_path)?;
     let file_paths = collect_content_files(&project_root);
     let total = file_paths.len();
-    eprintln!("Indexing {total} files...");
+    log::info!("Indexing {total} files...");
 
     let progress = |current: usize, total: usize, path: &Path| {
         let rel = path
             .strip_prefix(&project_root)
             .unwrap_or(path)
             .display();
-        eprintln!("  [{current}/{total}] {rel}");
+        log::debug!("  [{current}/{total}] {rel}");
     };
     let stats =
         indexer::index_all_with_progress(&conn, &file_paths, &project_root, Some(&progress))?;
-    eprintln!(
+    log::info!(
         "Done: Indexed: {}, Skipped: {}, Removed: {}",
         stats.indexed, stats.skipped, stats.removed
     );
@@ -1173,18 +1173,18 @@ pub fn cmd_rebuild(force: bool) -> anyhow::Result<()> {
     drop(conn);
 
     if vecs >= chunks {
-        eprintln!("Vectors: {vecs} (matches all chunks)");
+        log::info!("Vectors: {vecs} (matches all chunks)");
     } else if socket.exists() && chunks > 0 {
         let current_status = crate::status::read(&config::data_dir());
         if current_status.backfill.is_some() {
-            eprintln!("Vectors: {vecs} / {chunks} — backfill already in progress");
+            log::info!("Vectors: {vecs} / {chunks} — backfill already in progress");
         } else {
-            eprintln!("Vectors: {vecs} / {chunks} — starting backfill in background...");
+            log::info!("Vectors: {vecs} / {chunks} — starting backfill in background...");
             spawn_background_backfill();
         }
-        eprintln!("Run `tsm doctor` to check progress.");
+        log::info!("Run `tsm doctor` to check progress.");
     } else if chunks > 0 {
-        eprintln!("Vectors: {vecs} / {chunks} — embedder not running, skipping backfill");
+        log::warn!("Vectors: {vecs} / {chunks} — embedder not running, skipping backfill");
     }
 
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,14 @@ pub fn data_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data")
 }
 
+/// Resolve log directory: TSM_LOG_DIR env > default (.tsm/logs in CWD)
+pub fn log_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("TSM_LOG_DIR") {
+        return PathBuf::from(dir);
+    }
+    PathBuf::from(".tsm/logs")
+}
+
 /// Resolve project_root: TSM_PROJECT_ROOT env > config file > default
 pub fn project_root() -> PathBuf {
     if let Ok(root) = std::env::var("TSM_PROJECT_ROOT") {

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -468,7 +468,7 @@ impl WorkerHandle {
                 match stderr.read_line(&mut line) {
                     Ok(0) => break, // EOF
                     Ok(_) => {
-                        log::debug!("[worker] {}", line.trim_end());
+                        log::info!("[worker] {}", line.trim_end());
                         if line.trim() == "READY" {
                             let _ = tx.send(true);
                             // Continue forwarding stderr
@@ -476,7 +476,7 @@ impl WorkerHandle {
                                 line.clear();
                                 match stderr.read_line(&mut line) {
                                     Ok(0) => break,
-                                    Ok(_) => log::debug!("[worker] {}", line.trim_end()),
+                                    Ok(_) => log::info!("[worker] {}", line.trim_end()),
                                     Err(_) => break,
                                 }
                             }

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -183,9 +183,9 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
         std::fs::remove_file(socket_path)?;
     }
 
-    eprintln!("Loading model...");
+    log::info!("Loading model...");
     let embedder = Embedder::load(&Device::Cpu)?;
-    eprintln!("Model loaded.");
+    log::info!("Model loaded.");
 
     // Backfill via worker subprocess in background (crash-isolated)
     {
@@ -193,7 +193,7 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
         if db_path.exists() {
             std::thread::spawn(move || {
                 if let Err(e) = crate::cli::backfill_with_worker(&db_path) {
-                    eprintln!("Backfill warning: {e}");
+                    log::warn!("Backfill warning: {e}");
                 }
             });
         }
@@ -207,7 +207,7 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
         });
     });
 
-    eprintln!("Listening on {}", socket_path.display());
+    log::info!("Listening on {}", socket_path.display());
 
     let listener = UnixListener::bind(socket_path)?;
     listener.set_nonblocking(true)?;
@@ -225,7 +225,7 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
             watchdog(&running, &last_activity, &socket_path, idle_timeout_secs);
         });
     } else {
-        eprintln!("Idle timeout disabled.");
+        log::info!("Idle timeout disabled.");
     }
 
     // Periodic backfill thread (skipped when interval is 0)
@@ -242,7 +242,7 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
             Ok((stream, _)) => {
                 *last_activity.lock().unwrap() = Instant::now();
                 if let Err(e) = handle_client(stream, &embedder) {
-                    eprintln!("Client error: {e}");
+                    log::warn!("Client error: {e}");
                 }
                 *last_activity.lock().unwrap() = Instant::now();
             }
@@ -251,13 +251,13 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
             }
             Err(e) => {
                 if running.load(Ordering::Relaxed) {
-                    eprintln!("Accept error: {e}");
+                    log::warn!("Accept error: {e}");
                 }
             }
         }
     }
 
-    eprintln!("Shutting down (idle timeout).");
+    log::info!("Shutting down (idle timeout).");
     crate::status::update(&crate::config::data_dir(), |s| {
         s.embedder = None;
     });
@@ -279,7 +279,7 @@ fn watchdog(
         }
         let elapsed = last_activity.lock().unwrap().elapsed();
         if elapsed >= timeout {
-            eprintln!("Idle timeout reached ({timeout_secs}s). Stopping.");
+            log::info!("Idle timeout reached ({timeout_secs}s). Stopping.");
             running.store(false, Ordering::Relaxed);
             // Poke the listener to unblock accept
             let _ = UnixStream::connect(socket_path);
@@ -319,9 +319,9 @@ fn periodic_backfill(running: &AtomicBool, interval_secs: u64) {
 
                 if chunks > vecs {
                     let missing = chunks - vecs;
-                    eprintln!("Periodic backfill: {missing} vectors missing. Starting backfill.");
+                    log::debug!("Periodic backfill: {missing} vectors missing. Starting backfill.");
                     if let Err(e) = crate::cli::backfill_with_worker(&db_path) {
-                        eprintln!("Periodic backfill warning: {e}");
+                        log::warn!("Periodic backfill warning: {e}");
                     }
                 }
             }
@@ -359,7 +359,7 @@ fn handle_client(mut stream: UnixStream, embedder: &Embedder) -> Result<()> {
     let embeddings = match encode_result {
         Ok(Ok(emb)) => emb,
         Ok(Err(e)) => {
-            eprintln!("Encode error: {e}");
+            log::error!("Encode error: {e}");
             let err_resp = serde_json::json!({ "error": format!("{e}") });
             let err_bytes = serde_json::to_vec(&err_resp)?;
             write_message(&mut stream, &err_bytes)?;
@@ -374,7 +374,7 @@ fn handle_client(mut stream: UnixStream, embedder: &Embedder) -> Result<()> {
             } else {
                 "unknown panic".to_string()
             };
-            eprintln!("PANIC in encode: {msg}");
+            log::error!("PANIC in encode: {msg}");
             let err_resp = serde_json::json!({ "error": format!("panic: {msg}") });
             let err_bytes = serde_json::to_vec(&err_resp)?;
             write_message(&mut stream, &err_bytes)?;
@@ -468,7 +468,7 @@ impl WorkerHandle {
                 match stderr.read_line(&mut line) {
                     Ok(0) => break, // EOF
                     Ok(_) => {
-                        eprint!("[worker] {line}");
+                        log::debug!("[worker] {}", line.trim_end());
                         if line.trim() == "READY" {
                             let _ = tx.send(true);
                             // Continue forwarding stderr
@@ -476,7 +476,7 @@ impl WorkerHandle {
                                 line.clear();
                                 match stderr.read_line(&mut line) {
                                     Ok(0) => break,
-                                    Ok(_) => eprint!("[worker] {line}"),
+                                    Ok(_) => log::debug!("[worker] {}", line.trim_end()),
                                     Err(_) => break,
                                 }
                             }
@@ -581,10 +581,10 @@ impl Drop for WorkerHandle {
 /// Entry point for the `tsm backfill-worker` subprocess.
 /// Loads the model, signals READY, then processes encode requests on stdin/stdout.
 pub fn run_backfill_worker() -> Result<()> {
-    eprintln!("Loading model...");
+    log::info!("Loading model...");
     let embedder = Embedder::load(&Device::Cpu)?;
-    eprintln!("Model loaded.");
-    eprintln!("READY");
+    log::info!("Model loaded.");
+    eprintln!("READY"); // IPC protocol signal — must NOT use log macro
 
     let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout().lock();
@@ -621,7 +621,7 @@ pub fn run_backfill_worker() -> Result<()> {
         let response = match encode_result {
             Ok(Ok(emb)) => serde_json::json!({ "embeddings": emb }),
             Ok(Err(e)) => {
-                eprintln!("Encode error: {e}");
+                log::error!("Encode error: {e}");
                 serde_json::json!({ "error": format!("{e}") })
             }
             Err(panic_info) => {
@@ -632,7 +632,7 @@ pub fn run_backfill_worker() -> Result<()> {
                 } else {
                     "unknown panic".to_string()
                 };
-                eprintln!("PANIC in encode: {msg}");
+                log::error!("PANIC in encode: {msg}");
                 serde_json::json!({ "error": format!("panic: {msg}") })
             }
         };
@@ -641,7 +641,7 @@ pub fn run_backfill_worker() -> Result<()> {
         write_message(&mut stdout, &response_bytes)?;
     }
 
-    eprintln!("Worker exiting.");
+    log::info!("Worker exiting.");
     Ok(())
 }
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -76,13 +76,13 @@ fn get_custom_terms() -> &'static [CompiledTerm] {
 fn load_custom_terms_from_file() -> Vec<CompiledTerm> {
     let path = crate::config::custom_terms_path();
     if !path.exists() {
-        eprintln!("Info: custom terms file not found at {}", path.display());
+        log::info!("custom terms file not found at {}", path.display());
         return Vec::new();
     }
     match std::fs::read_to_string(&path) {
         Ok(content) => compile_custom_terms(&parse_custom_terms(&content)),
         Err(e) => {
-            eprintln!("Warning: failed to read custom terms: {e}");
+            log::warn!("failed to read custom terms: {e}");
             Vec::new()
         }
     }
@@ -93,7 +93,7 @@ pub fn parse_custom_terms(content: &str) -> Vec<Entity> {
     let file: CustomTermsFile = match toml::from_str(content) {
         Ok(f) => f,
         Err(e) => {
-            eprintln!("Warning: failed to parse custom terms TOML: {e}");
+            log::warn!("failed to parse custom terms TOML: {e}");
             return Vec::new();
         }
     };

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -323,7 +323,7 @@ pub fn index_file(
                 if e.to_string().contains("no such table") { Ok(0) } else { Err(e) }
             })?;
         if let Err(e) = entity::insert_entities(&tx, doc_id, &diff.all_chunk_entries, &fm.tags) {
-            eprintln!("entity extraction warning: {e}");
+            log::warn!("entity extraction warning: {e}");
         }
 
         // Rebuild document links
@@ -554,7 +554,7 @@ fn learn_from_session_jsonl(conn: &Connection, jsonl_path: &Path) {
         user_dict::collect_from_text(&tx, content, "session");
     }
     if let Err(e) = tx.commit() {
-        eprintln!("learn_from_session_jsonl: transaction commit failed: {e}");
+        log::error!("learn_from_session_jsonl: transaction commit failed: {e}");
     }
 }
 
@@ -621,7 +621,7 @@ fn mark_chunk_skip(conn: &Connection, chunk_id: i64, reason: &str) -> bool {
     ) {
         Ok(_) => true,
         Err(e) => {
-            eprintln!("    WARNING: failed to write skip record for chunk {chunk_id}: {e} — chunk will be retried next run");
+            log::warn!("failed to write skip record for chunk {chunk_id}: {e} — chunk will be retried next run");
             false
         }
     }
@@ -642,24 +642,24 @@ fn retry_individually(
                 if write_vec_row(conn, *chunk_id, &embeddings[0]) {
                     stats.filled += 1;
                 } else {
-                    eprintln!("    chunk {chunk_id} ({file_path}): insert error — skipping");
+                    log::warn!("chunk {chunk_id} ({file_path}): insert error — skipping");
                     mark_chunk_skip(conn, *chunk_id, "insert_error");
                     stats.errors += 1;
                 }
             }
             Ok(Ok(_)) => {
-                eprintln!("    chunk {chunk_id} ({file_path}): empty embedding — skipping");
+                log::warn!("chunk {chunk_id} ({file_path}): empty embedding — skipping");
                 mark_chunk_skip(conn, *chunk_id, "empty_embedding");
                 stats.errors += 1;
             }
             Ok(Err(e)) => {
-                eprintln!("    chunk {chunk_id} ({file_path}): error ({e}) — skipping");
+                log::warn!("chunk {chunk_id} ({file_path}): error ({e}) — skipping");
                 mark_chunk_skip(conn, *chunk_id, "encode_error");
                 stats.errors += 1;
             }
             Err(panic_info) => {
                 let msg = panic_message(&panic_info);
-                eprintln!("    chunk {chunk_id} ({file_path}): PANIC ({msg}) — skipping");
+                log::error!("chunk {chunk_id} ({file_path}): PANIC ({msg}) — skipping");
                 mark_chunk_skip(conn, *chunk_id, "panic");
                 stats.panics += 1;
                 stats.errors += 1;
@@ -697,7 +697,7 @@ pub fn backfill_vectors(
         return Ok(BackfillStats::default());
     }
 
-    eprintln!("Backfilling {total} chunks...");
+    log::info!("Backfilling {total} chunks...");
     if let Some(cb) = &progress_cb {
         cb(total, 0, 0);
     }
@@ -730,7 +730,7 @@ pub fn backfill_vectors(
         let files: Vec<&str> = batch.iter().map(|(_, _, f)| f.as_str()).collect();
         let batch_start_id = batch.first().unwrap().0;
         let batch_end_id = last_id;
-        eprintln!("  batch {batch_start_id}..{batch_end_id}: {:?}", files);
+        log::debug!("batch {batch_start_id}..{batch_end_id}: {:?}", files);
 
         let texts: Vec<String> = batch
             .iter()
@@ -744,7 +744,7 @@ pub fn backfill_vectors(
                     if write_vec_row(&tx, *chunk_id, emb) {
                         stats.filled += 1;
                     } else {
-                        eprintln!("Insert error for chunk {chunk_id} — skipping");
+                        log::warn!("Insert error for chunk {chunk_id} — skipping");
                         mark_chunk_skip(conn, *chunk_id, "insert_error");
                         stats.errors += 1;
                     }
@@ -752,13 +752,13 @@ pub fn backfill_vectors(
                 tx.commit()?;
             }
             Ok(Ok(embeddings)) => {
-                eprintln!(
+                log::warn!(
                     "Embedding count mismatch (got {}, expected {}) for batch {batch_start_id}..{batch_end_id}",
                     embeddings.len(),
                     batch.len()
                 );
                 if batch.len() > 1 {
-                    eprintln!("  Retrying {} chunks individually...", batch.len());
+                    log::warn!("Retrying {} chunks individually...", batch.len());
                     retry_individually(&batch, encode_fn, conn, &mut stats);
                 } else {
                     let chunk_id = batch[0].0;
@@ -767,27 +767,27 @@ pub fn backfill_vectors(
                 }
             }
             Ok(Err(e)) => {
-                eprintln!("Batch error (chunks {batch_start_id}..{batch_end_id}): {e}");
+                log::warn!("Batch error (chunks {batch_start_id}..{batch_end_id}): {e}");
                 if batch.len() > 1 {
-                    eprintln!("  Retrying {} chunks individually...", batch.len());
+                    log::warn!("Retrying {} chunks individually...", batch.len());
                     retry_individually(&batch, encode_fn, conn, &mut stats);
                 } else {
                     let chunk_id = batch[0].0;
-                    eprintln!("  chunk {chunk_id}: failed individually — skipping");
+                    log::warn!("chunk {chunk_id}: failed individually — skipping");
                     mark_chunk_skip(conn, chunk_id, "encode_error");
                     stats.errors += 1;
                 }
             }
             Err(panic_info) => {
                 let msg = panic_message(&panic_info);
-                eprintln!("PANIC in encode (chunks {batch_start_id}..{batch_end_id}): {msg}");
+                log::error!("PANIC in encode (chunks {batch_start_id}..{batch_end_id}): {msg}");
                 stats.panics += 1;
                 if batch.len() > 1 {
-                    eprintln!("  Retrying {} chunks individually...", batch.len());
+                    log::warn!("Retrying {} chunks individually...", batch.len());
                     retry_individually(&batch, encode_fn, conn, &mut stats);
                 } else {
                     let chunk_id = batch[0].0;
-                    eprintln!("  chunk {chunk_id}: failed individually — skipping");
+                    log::warn!("chunk {chunk_id}: failed individually — skipping");
                     mark_chunk_skip(conn, chunk_id, "panic");
                     stats.errors += 1;
                 }
@@ -795,7 +795,7 @@ pub fn backfill_vectors(
         }
 
         let processed = stats.filled + stats.errors;
-        eprintln!("  {processed}/{total}");
+        log::debug!("{processed}/{total}");
 
         if let Some(cb) = &progress_cb {
             cb(total, stats.filled, stats.errors);
@@ -803,12 +803,12 @@ pub fn backfill_vectors(
     }
 
     if stats.panics > 0 {
-        eprintln!(
+        log::info!(
             "Backfill complete: {} filled, {} errors, {} panics.",
             stats.filled, stats.errors, stats.panics
         );
     } else {
-        eprintln!(
+        log::info!(
             "Backfill complete: {} filled, {} errors.",
             stats.filled, stats.errors
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod entity;
 pub mod frontmatter;
 pub mod indexer;
 pub mod ipc;
+pub mod logging;
 pub mod searcher;
 pub mod session_chunker;
 pub mod status;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -15,23 +15,26 @@ pub enum LogMode {
     Daemon { name: &'static str },
 }
 
-static LOGGER_INIT: OnceLock<()> = OnceLock::new();
+static LOGGER_INIT: OnceLock<Result<(), String>> = OnceLock::new();
 
 /// Initialize the logger. Safe to call multiple times (idempotent via OnceLock).
 pub fn init_logger(mode: LogMode) -> anyhow::Result<()> {
-    LOGGER_INIT.get_or_init(|| {
-        let logger = Logger::try_with_env_or_str("info").unwrap();
+    let result = LOGGER_INIT.get_or_init(|| {
+        let logger = Logger::try_with_env_or_str("info")
+            .map_err(|e| format!("failed to parse log spec: {e}"))?;
         match mode {
             LogMode::Stderr => {
                 logger
                     .log_to_stderr()
                     .format(tsm_log_format)
                     .start()
-                    .ok();
+                    .map(|_| ())
+                    .map_err(|e| format!("failed to start stderr logger: {e}"))
             }
             LogMode::Daemon { name } => {
                 let dir = config::log_dir();
-                std::fs::create_dir_all(&dir).ok();
+                std::fs::create_dir_all(&dir)
+                    .map_err(|e| format!("failed to create log dir {}: {e}", dir.display()))?;
                 logger
                     .log_to_file(
                         FileSpec::default()
@@ -47,11 +50,15 @@ pub fn init_logger(mode: LogMode) -> anyhow::Result<()> {
                     )
                     .format(tsm_log_format)
                     .start()
-                    .ok();
+                    .map(|_| ())
+                    .map_err(|e| format!("failed to start file logger: {e}"))
             }
         }
     });
-    Ok(())
+    result
+        .as_ref()
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 fn tsm_log_format(

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,102 @@
+use std::io::Write;
+use std::sync::OnceLock;
+
+use flexi_logger::{
+    Age, Cleanup, Criterion, DeferredNow, Duplicate, FileSpec, Logger, Naming,
+};
+use log::Record;
+
+use crate::config;
+
+pub enum LogMode {
+    /// CLI (tsm) — log to stderr only
+    Stderr,
+    /// Daemon (tsmd, tsm-embedder, tsm-watcher) — log to file with daily rotation
+    Daemon { name: &'static str },
+}
+
+static LOGGER_INIT: OnceLock<()> = OnceLock::new();
+
+/// Initialize the logger. Safe to call multiple times (idempotent via OnceLock).
+pub fn init_logger(mode: LogMode) -> anyhow::Result<()> {
+    LOGGER_INIT.get_or_init(|| {
+        let logger = Logger::try_with_env_or_str("info").unwrap();
+        match mode {
+            LogMode::Stderr => {
+                logger
+                    .log_to_stderr()
+                    .format(tsm_log_format)
+                    .start()
+                    .ok();
+            }
+            LogMode::Daemon { name } => {
+                let dir = config::log_dir();
+                std::fs::create_dir_all(&dir).ok();
+                logger
+                    .log_to_file(
+                        FileSpec::default()
+                            .directory(dir)
+                            .basename(name)
+                            .suffix("log"),
+                    )
+                    .duplicate_to_stderr(Duplicate::Warn)
+                    .rotate(
+                        Criterion::Age(Age::Day),
+                        Naming::Timestamps,
+                        Cleanup::KeepLogFiles(7),
+                    )
+                    .format(tsm_log_format)
+                    .start()
+                    .ok();
+            }
+        }
+    });
+    Ok(())
+}
+
+fn tsm_log_format(
+    w: &mut dyn Write,
+    now: &mut DeferredNow,
+    record: &Record,
+) -> std::io::Result<()> {
+    let module = short_module(record.module_path().unwrap_or("?"));
+    write!(
+        w,
+        "[{}] [{:5}] [{}] {}",
+        now.format("%Y-%m-%dT%H:%M:%SZ"),
+        record.level(),
+        module,
+        record.args()
+    )
+}
+
+fn short_module(path: &str) -> &str {
+    path.split("::").last().unwrap_or("?")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_short_module_nested() {
+        assert_eq!(short_module("the_space_memory::indexer::backfill_vectors"), "backfill_vectors");
+    }
+
+    #[test]
+    fn test_short_module_single() {
+        assert_eq!(short_module("tsm"), "tsm");
+    }
+
+    #[test]
+    fn test_short_module_empty() {
+        assert_eq!(short_module("?"), "?");
+    }
+
+    #[test]
+    fn test_init_logger_stderr_does_not_panic() {
+        // OnceLock makes this idempotent — safe even if another test already initialized
+        let result = init_logger(LogMode::Stderr);
+        assert!(result.is_ok());
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -21,7 +21,8 @@ static LOGGER_INIT: OnceLock<Result<(), String>> = OnceLock::new();
 pub fn init_logger(mode: LogMode) -> anyhow::Result<()> {
     let result = LOGGER_INIT.get_or_init(|| {
         let logger = Logger::try_with_env_or_str("info")
-            .map_err(|e| format!("failed to parse log spec: {e}"))?;
+            .map_err(|e| format!("failed to parse log spec: {e}"))?
+            .use_utc();
         match mode {
             LogMode::Stderr => {
                 logger

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,11 +386,11 @@ fn cmd_start() -> anyhow::Result<()> {
     }
 
     // Spawn tsmd in a new session (detached)
-    // tsmd manages its own log file via flexi_logger, so stderr goes to null
+    // Keep stderr inherited so pre-logger startup errors are visible
     let mut cmd = std::process::Command::new(&tsmd_path);
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
+        .stderr(std::process::Stdio::inherit());
     unsafe {
         cmd.pre_exec(|| {
             libc::setsid();

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,7 @@ enum Commands {
 }
 
 fn main() -> anyhow::Result<()> {
+    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Stderr)?;
     let args = Cli::parse();
     match args.command {
         // ── Always direct ──
@@ -293,7 +294,7 @@ fn render_index(resp: DaemonResponse) -> anyhow::Result<()> {
         let indexed = payload["indexed"].as_i64().unwrap_or(0);
         let skipped = payload["skipped"].as_i64().unwrap_or(0);
         let removed = payload["removed"].as_i64().unwrap_or(0);
-        eprintln!("Indexed: {indexed}, Skipped: {skipped}, Removed: {removed}");
+        log::info!("indexed: {indexed}, skipped: {skipped}, removed: {removed}");
     }
     Ok(())
 }
@@ -306,9 +307,9 @@ fn render_ingest(resp: DaemonResponse, session_file: &std::path::Path) -> anyhow
         .to_string_lossy();
     if let Some(payload) = resp.payload {
         if payload["indexed"].as_bool().unwrap_or(false) {
-            eprintln!("Session indexed: {name}");
+            log::info!("session indexed: {name}");
         } else {
-            eprintln!("Session unchanged: {name}");
+            log::info!("session unchanged: {name}");
         }
     }
     Ok(())
@@ -347,7 +348,7 @@ fn render_import_wordnet(resp: DaemonResponse) -> anyhow::Result<()> {
     check_resp(&resp)?;
     if let Some(payload) = resp.payload {
         let count = payload["imported"].as_i64().unwrap_or(0);
-        eprintln!("Imported {count} synonym pairs from WordNet.");
+        log::info!("imported {count} synonym pairs from WordNet");
     }
     Ok(())
 }
@@ -362,7 +363,7 @@ fn cmd_start() -> anyhow::Result<()> {
     if socket_path.exists() {
         if let Ok(resp) = daemon_protocol::send_request(&socket_path, &DaemonRequest::Ping) {
             if resp.ok {
-                eprintln!("tsmd is already running.");
+                log::info!("tsmd is already running");
                 return Ok(());
             }
         }
@@ -384,21 +385,12 @@ fn cmd_start() -> anyhow::Result<()> {
         );
     }
 
-    // Spawn tsmd in a new session (detached), stderr to log file
-    let log_path = config::data_dir().join("tsmd.log");
-    let log_file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)
-        .ok();
-    let stderr_cfg = match log_file {
-        Some(f) => std::process::Stdio::from(f),
-        None => std::process::Stdio::null(),
-    };
+    // Spawn tsmd in a new session (detached)
+    // tsmd manages its own log file via flexi_logger, so stderr goes to null
     let mut cmd = std::process::Command::new(&tsmd_path);
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(stderr_cfg);
+        .stderr(std::process::Stdio::null());
     unsafe {
         cmd.pre_exec(|| {
             libc::setsid();
@@ -416,7 +408,7 @@ fn cmd_start() -> anyhow::Result<()> {
         if socket_path.exists() {
             if let Ok(resp) = daemon_protocol::send_request(&socket_path, &DaemonRequest::Ping) {
                 if resp.ok {
-                    eprintln!("tsmd started.");
+                    log::info!("tsmd started");
                     return Ok(());
                 }
             }
@@ -433,25 +425,25 @@ fn cmd_stop() -> anyhow::Result<()> {
     let socket_path = config::daemon_socket_path();
 
     if !socket_path.exists() {
-        eprintln!("tsmd is not running.");
+        log::info!("tsmd is not running");
         return Ok(());
     }
 
     match daemon_protocol::send_request(&socket_path, &DaemonRequest::Shutdown) {
         Ok(resp) => {
             if resp.ok {
-                eprintln!("tsmd stopped.");
+                log::info!("tsmd stopped");
             } else {
-                eprintln!(
+                log::warn!(
                     "tsmd reported error: {}",
                     resp.error.unwrap_or_default()
                 );
             }
         }
         Err(e) => {
-            eprintln!("Could not connect to tsmd: {e}");
+            log::warn!("could not connect to tsmd: {e}");
             let _ = std::fs::remove_file(&socket_path);
-            eprintln!("Removed stale socket.");
+            log::info!("removed stale socket");
         }
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -55,10 +55,7 @@ pub fn read(data_dir: &Path) -> StatusFile {
     match serde_json::from_str(&s) {
         Ok(sf) => sf,
         Err(e) => {
-            eprintln!(
-                "warning: failed to parse status file ({}): {e}",
-                path.display()
-            );
+            log::warn!("failed to parse status file ({}): {e}", path.display());
             StatusFile::default()
         }
     }
@@ -81,9 +78,9 @@ pub fn update(data_dir: &Path, f: impl FnOnce(&mut StatusFile)) {
     match serde_json::to_string_pretty(&status) {
         Ok(json) => {
             if let Err(e) = write_atomic(&path, json.as_bytes()) {
-                eprintln!("warning: failed to write status file: {e}");
+                log::warn!("failed to write status file: {e}");
             }
         }
-        Err(e) => eprintln!("warning: failed to serialize status: {e}"),
+        Err(e) => log::warn!("failed to serialize status: {e}"),
     }
 }

--- a/src/synonyms.rs
+++ b/src/synonyms.rs
@@ -183,7 +183,7 @@ pub fn import_wordnet(conn: &Connection, wordnet_path: &std::path::Path) -> anyh
         .collect();
 
     let total = pairs.len();
-    eprintln!("Importing {total} synonym pairs from WordNet...");
+    log::info!("importing {total} synonym pairs from WordNet...");
 
     let batch_size = 1000;
     let mut imported = 0;
@@ -204,7 +204,7 @@ pub fn import_wordnet(conn: &Connection, wordnet_path: &std::path::Path) -> anyh
         }
     }
 
-    eprintln!("\r  {imported}/{total} done.");
+    log::info!("{imported}/{total} synonym pairs imported.");
     Ok(imported)
 }
 
@@ -296,7 +296,7 @@ pub fn cleanup_stale(conn: &Connection) {
         .unwrap_or(0);
 
     if deleted > 0 {
-        eprintln!("Cleaned up {deleted} stale synonym pairs.");
+        log::info!("cleaned up {deleted} stale synonym pairs");
     }
 }
 

--- a/src/synonyms.rs
+++ b/src/synonyms.rs
@@ -204,6 +204,7 @@ pub fn import_wordnet(conn: &Connection, wordnet_path: &std::path::Path) -> anyh
         }
     }
 
+    eprint!("\r                              \r"); // clear progress line
     log::info!("{imported}/{total} synonym pairs imported.");
     Ok(imported)
 }

--- a/src/user_dict.rs
+++ b/src/user_dict.rs
@@ -99,7 +99,7 @@ fn get_existing_surfaces() -> &'static HashSet<String> {
     EXISTING_SURFACES.get_or_init(|| match load_existing_surfaces(&config::user_dict_path()) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("Warning: could not read user dict: {e}");
+            log::warn!("could not read user dict: {e}");
             HashSet::new()
         }
     })
@@ -151,7 +151,7 @@ fn extract_raw_candidates(text: &str) -> Vec<RawCandidate> {
     let mut tokens = match segmenter.segment(std::borrow::Cow::Borrowed(text)) {
         Ok(t) => t,
         Err(e) => {
-            eprintln!("Warning: segmentation failed: {e}");
+            log::warn!("segmentation failed: {e}");
             return Vec::new();
         }
     };
@@ -245,7 +245,7 @@ pub fn collect_from_text(conn: &Connection, text: &str, source: &str) {
                      THEN ?4 ELSE dictionary_candidates.last_seen END",
             rusqlite::params![c.surface, c.pos.as_str(), source, now],
         ) {
-            eprintln!("Warning: failed to upsert dictionary candidate '{}': {e}", c.surface);
+            log::warn!("failed to upsert dictionary candidate '{}': {e}", c.surface);
             break; // DB likely in bad state, stop trying
         }
     }


### PR DESCRIPTION
## Summary

- Replace all 117 `eprintln!` calls with `log` macros (`error!`/`warn!`/`info!`/`debug!`)
- Add `flexi_logger` for structured output: stderr for CLI, file output with daily rotation for daemons
- Separate log files per daemon: `tsmd.log`, `tsm-embedder.log`, `tsm-watcher.log` in `.tsm/logs/`
- `RUST_LOG` environment variable for level control (default: `info`)

Closes #31

## Changes

- `Cargo.toml`: Add `log` + `flexi_logger` dependencies
- `src/logging.rs` (new): `LogMode` enum, `init_logger()`, custom format function
- `src/config.rs`: Add `log_dir()` → `.tsm/logs/` (overridable via `TSM_LOG_DIR`)
- All 4 binaries: Logger initialization at entry point
- `src/main.rs`: Remove stderr→file redirect for tsmd (daemons manage own logs)
- `src/bin/tsmd.rs`: Remove `Stdio::inherit()` for children (same reason)
- 9 source files: `eprintln!` → appropriate log level

## Preserved exceptions

| File | Line | Reason |
|---|---|---|
| `embedder.rs` | `eprintln!("READY")` | IPC protocol signal |
| `synonyms.rs` | `eprint!("\r ...")` | Terminal progress animation |
| `cli.rs` | `eprint!("Proceed...")` | Interactive prompt |

## Test plan

- [x] `cargo test` — 375 passed, 0 failed
- [x] `cargo clippy` — clean
- [ ] Manual: `RUST_LOG=debug tsm search -q "test"` — debug messages visible
- [ ] Manual: `tsm start && ls .tsm/logs/` — log files created
- [ ] Manual: `RUST_LOG=warn tsm index` — info messages suppressed