### PR TITLE
feat: unify config into ConfigFile struct with OnceLock singleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,10 @@
 # Built binary (use Docker build to generate)
 /tsm
 
-# Data & models (runtime-generated)
+# Runtime directory (workspace-local)
+.tsm/
+
+# Legacy data directory
 /data/
 !/data/stopwords.txt
 /models/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3335,6 +3344,7 @@ dependencies = [
  "candle-transformers",
  "chrono",
  "clap",
+ "directories",
  "flexi_logger",
  "hf-hub",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = "1"
 toml = "0.8"
 regex = "1"
 clap = { version = "4", features = ["derive"] }
+directories = "6"
 anyhow = "1"
 thiserror = "2"
 chrono = "0.4"

--- a/src/bin/tsm_embedder.rs
+++ b/src/bin/tsm_embedder.rs
@@ -1,5 +1,5 @@
 fn main() -> anyhow::Result<()> {
-    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsm-embedder" })?;
     the_space_memory::config::ensure_model_cache_env();
+    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsm-embedder" })?;
     the_space_memory::cli::cmd_embedder_start(None)
 }

--- a/src/bin/tsm_embedder.rs
+++ b/src/bin/tsm_embedder.rs
@@ -1,4 +1,5 @@
 fn main() -> anyhow::Result<()> {
     the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsm-embedder" })?;
+    the_space_memory::config::ensure_model_cache_env();
     the_space_memory::cli::cmd_embedder_start(None)
 }

--- a/src/bin/tsm_watcher.rs
+++ b/src/bin/tsm_watcher.rs
@@ -37,6 +37,7 @@ struct Args {
 
 fn main() -> Result<()> {
     the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsm-watcher" })?;
+    config::ensure_model_cache_env();
     let args = Args::parse();
 
     let daemon_socket = args

--- a/src/bin/tsm_watcher.rs
+++ b/src/bin/tsm_watcher.rs
@@ -36,8 +36,8 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsm-watcher" })?;
     config::ensure_model_cache_env();
+    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsm-watcher" })?;
     let args = Args::parse();
 
     let daemon_socket = args

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -41,8 +41,8 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsmd" })?;
     config::ensure_model_cache_env();
+    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsmd" })?;
     let args = Args::parse();
 
     let socket_path = args.socket.unwrap_or_else(config::daemon_socket_path);

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -1,5 +1,5 @@
 use std::os::unix::net::UnixListener;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -42,6 +42,7 @@ struct Args {
 
 fn main() -> Result<()> {
     the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsmd" })?;
+    config::ensure_model_cache_env();
     let args = Args::parse();
 
     let socket_path = args.socket.unwrap_or_else(config::daemon_socket_path);
@@ -215,7 +216,7 @@ fn start_child(binary: &str, env_vars: &[(&str, &str)]) -> Result<Child> {
 
 /// Remove the embedder UNIX socket if it exists.
 fn remove_stale_embedder_socket() {
-    let path = Path::new(config::SOCKET_PATH);
+    let path = config::embedder_socket_path();
     if path.exists() {
         if let Err(e) = std::fs::remove_file(path) {
             log::warn!("could not remove stale embedder socket: {e}");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -240,7 +240,8 @@ pub fn cmd_ingest_session(session_file: &Path) -> anyhow::Result<()> {
 }
 
 pub fn cmd_embedder_start(socket_path: Option<&Path>) -> anyhow::Result<()> {
-    let path = socket_path.unwrap_or(Path::new(config::SOCKET_PATH));
+    let default_path = config::embedder_socket_path();
+    let path = socket_path.unwrap_or(&default_path);
     embedder::run_daemon(path)
 }
 
@@ -556,7 +557,7 @@ fn doctor_check_with_conn(
         items: Vec::new(),
     };
 
-    let socket = Path::new(config::SOCKET_PATH);
+    let socket = config::embedder_socket_path();
     let timeout = config::embedder_idle_timeout_secs();
     if socket.exists() {
         let timeout_info = if timeout == 0 {
@@ -800,7 +801,7 @@ pub fn run_status(conn: Option<&rusqlite::Connection>) -> StatusInfo {
     let daemon_pid = sf.daemon.as_ref().map(|d| d.pid);
     let daemon_socket = sf.daemon.as_ref().map(|d| d.socket.clone());
 
-    let socket = Path::new(config::SOCKET_PATH);
+    let socket = config::embedder_socket_path();
     let embedder_running = socket.exists();
     let embedder_pid = sf.embedder.as_ref().map(|e| e.pid);
     let embedder_since = sf.embedder.as_ref().map(|e| e.started_at.clone());
@@ -1120,7 +1121,7 @@ fn spawn_background_backfill() {
 pub fn cmd_rebuild(force: bool) -> anyhow::Result<()> {
     let db_path = config::db_path();
     let project_root = config::project_root();
-    let socket = Path::new(config::SOCKET_PATH);
+    let socket = config::embedder_socket_path();
 
     if !socket.exists() {
         log::warn!("Embedder is not running. Rebuilding without vectors.");

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,11 +50,11 @@ pub const SESSION_WEIGHT: f64 = 0.3;
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(default)]
 struct ConfigFile {
-    data_dir: Option<String>,
-    project_root: Option<String>,
-    embedder_socket_path: Option<String>,
-    daemon_socket_path: Option<String>,
-    log_dir: Option<String>,
+    data_dir: Option<PathBuf>,
+    project_root: Option<PathBuf>,
+    embedder_socket_path: Option<PathBuf>,
+    daemon_socket_path: Option<PathBuf>,
+    log_dir: Option<PathBuf>,
     embedder_idle_timeout_secs: Option<u64>,
     embedder_backfill_interval_secs: Option<u64>,
 }
@@ -66,21 +66,34 @@ fn cfg() -> &'static ConfigFile {
     CONFIG.get_or_init(|| load_config_from(&config_file_candidates()))
 }
 
-/// Load and merge config files.
-/// Priority (first wins per field): TSM_CONFIG env > ./tsm.toml > XDG config
+/// Merge config values from `candidates` in order; first non-None value for each field wins.
 fn load_config_from(candidates: &[PathBuf]) -> ConfigFile {
+    // Determine which path was explicitly requested via TSM_CONFIG (if any)
+    let explicit_config = std::env::var_os("TSM_CONFIG").map(PathBuf::from);
+
     let mut merged = ConfigFile::default();
 
     // Iterate in priority order (highest first); `.or()` keeps first-seen value
     for path in candidates {
         let content = match std::fs::read_to_string(path) {
             Ok(c) => c,
-            Err(_) => continue,
+            Err(e) => {
+                if explicit_config.as_deref() == Some(path.as_path()) {
+                    log::error!(
+                        "Cannot read TSM_CONFIG file '{}': {e}",
+                        path.display()
+                    );
+                }
+                continue;
+            }
         };
         let file: ConfigFile = match toml::from_str(&content) {
             Ok(f) => f,
             Err(e) => {
-                log::warn!("Failed to parse {}: {e}", path.display());
+                log::warn!(
+                    "Config file '{}' has a parse error and will be ignored: {e}",
+                    path.display()
+                );
                 continue;
             }
         };
@@ -115,7 +128,7 @@ pub fn data_dir() -> PathBuf {
         return PathBuf::from(dir);
     }
     if let Some(ref dir) = cfg().data_dir {
-        return PathBuf::from(dir);
+        return dir.clone();
     }
     PathBuf::from(DEFAULT_DATA_DIR)
 }
@@ -126,7 +139,7 @@ pub fn project_root() -> PathBuf {
         return PathBuf::from(root);
     }
     if let Some(ref root) = cfg().project_root {
-        return PathBuf::from(root);
+        return root.clone();
     }
     PathBuf::from(DEFAULT_PROJECT_ROOT)
 }
@@ -137,7 +150,7 @@ pub fn embedder_socket_path() -> PathBuf {
         return PathBuf::from(p);
     }
     if let Some(ref p) = cfg().embedder_socket_path {
-        return PathBuf::from(p);
+        return p.clone();
     }
     data_dir().join("embedder.sock")
 }
@@ -148,7 +161,7 @@ pub fn daemon_socket_path() -> PathBuf {
         return PathBuf::from(p);
     }
     if let Some(ref p) = cfg().daemon_socket_path {
-        return PathBuf::from(p);
+        return p.clone();
     }
     data_dir().join("daemon.sock")
 }
@@ -159,7 +172,7 @@ pub fn log_dir() -> PathBuf {
         return PathBuf::from(dir);
     }
     if let Some(ref dir) = cfg().log_dir {
-        return PathBuf::from(dir);
+        return dir.clone();
     }
     data_dir().join("logs")
 }
@@ -168,8 +181,11 @@ pub fn log_dir() -> PathBuf {
 /// TSM_EMBEDDER_IDLE_TIMEOUT env > config file > default (600s). 0 = disable.
 pub fn embedder_idle_timeout_secs() -> u64 {
     if let Ok(val) = std::env::var("TSM_EMBEDDER_IDLE_TIMEOUT") {
-        if let Ok(n) = val.parse::<u64>() {
-            return n;
+        match val.parse::<u64>() {
+            Ok(n) => return n,
+            Err(e) => log::warn!(
+                "TSM_EMBEDDER_IDLE_TIMEOUT='{val}' is not a valid integer ({e}); using default"
+            ),
         }
     }
     if let Some(n) = cfg().embedder_idle_timeout_secs {
@@ -182,8 +198,11 @@ pub fn embedder_idle_timeout_secs() -> u64 {
 /// TSM_EMBEDDER_BACKFILL_INTERVAL env > config file > default (300s). 0 = disable.
 pub fn embedder_backfill_interval_secs() -> u64 {
     if let Ok(val) = std::env::var("TSM_EMBEDDER_BACKFILL_INTERVAL") {
-        if let Ok(n) = val.parse::<u64>() {
-            return n;
+        match val.parse::<u64>() {
+            Ok(n) => return n,
+            Err(e) => log::warn!(
+                "TSM_EMBEDDER_BACKFILL_INTERVAL='{val}' is not a valid integer ({e}); using default"
+            ),
         }
     }
     if let Some(n) = cfg().embedder_backfill_interval_secs {
@@ -228,12 +247,14 @@ pub fn model_cache_dir() -> PathBuf {
 
 /// Set HF_HUB_CACHE env var if not already set so hf_hub uses XDG cache.
 ///
-/// SAFETY: Must be called from main() before any threads are spawned.
-/// `std::env::set_var` is not thread-safe.
+/// # Safety
+/// Must be called before any threads are spawned (including the logger).
+/// `std::env::set_var` is unsound if concurrent reads or writes to the
+/// environment exist. Call this as the very first thing in `main()`.
 pub fn ensure_model_cache_env() {
     if std::env::var_os("HF_HUB_CACHE").is_none() {
         let cache_dir = model_cache_dir();
-        // Safe: called single-threaded at startup
+        // SAFETY: called single-threaded before init_logger() and any thread spawn
         unsafe { std::env::set_var("HF_HUB_CACHE", cache_dir) };
     }
 }
@@ -550,8 +571,8 @@ embedder_idle_timeout_secs = 1200
         .unwrap();
 
         let cfg = load_config_from(&[config_path]);
-        assert_eq!(cfg.data_dir.as_deref(), Some("/custom/data"));
-        assert_eq!(cfg.project_root.as_deref(), Some("/custom/root"));
+        assert_eq!(cfg.data_dir, Some(PathBuf::from("/custom/data")));
+        assert_eq!(cfg.project_root, Some(PathBuf::from("/custom/root")));
         assert_eq!(cfg.embedder_idle_timeout_secs, Some(1200));
         assert!(cfg.daemon_socket_path.is_none());
     }
@@ -575,9 +596,9 @@ project_root = "/low-root"
 
         // High-priority file is first in the list
         let cfg = load_config_from(&[high, low]);
-        assert_eq!(cfg.data_dir.as_deref(), Some("/high"));
+        assert_eq!(cfg.data_dir, Some(PathBuf::from("/high")));
         // project_root only in low-priority file, still picked up
-        assert_eq!(cfg.project_root.as_deref(), Some("/low-root"));
+        assert_eq!(cfg.project_root, Some(PathBuf::from("/low-root")));
     }
 
     #[test]
@@ -599,5 +620,39 @@ project_root = "/low-root"
         std::env::set_var("TSM_DATA_DIR", "/env/data");
         assert_eq!(data_dir(), PathBuf::from("/env/data"));
         std::env::remove_var("TSM_DATA_DIR");
+    }
+
+    #[test]
+    fn test_load_config_malformed_file_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let malformed = dir.path().join("bad.toml");
+        std::fs::write(&malformed, "this is not valid toml [[[").unwrap();
+
+        let valid = dir.path().join("good.toml");
+        std::fs::write(&valid, r#"data_dir = "/good""#).unwrap();
+
+        // Malformed file is higher priority but skipped; valid file still used
+        let cfg = load_config_from(&[malformed, valid]);
+        assert_eq!(cfg.data_dir, Some(PathBuf::from("/good")));
+    }
+
+    #[test]
+    fn test_ensure_model_cache_env_sets_when_absent() {
+        std::env::remove_var("HF_HUB_CACHE");
+        ensure_model_cache_env();
+        assert!(std::env::var_os("HF_HUB_CACHE").is_some());
+        std::env::remove_var("HF_HUB_CACHE");
+    }
+
+    #[test]
+    fn test_ensure_model_cache_env_preserves_existing() {
+        std::env::set_var("HF_HUB_CACHE", "/my/custom/cache");
+        ensure_model_cache_env();
+        assert_eq!(
+            std::env::var("HF_HUB_CACHE").unwrap(),
+            "/my/custom/cache"
+        );
+        std::env::remove_var("HF_HUB_CACHE");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,79 +1,31 @@
 use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use directories::ProjectDirs;
+
+// ─── Internal constants (not user-configurable) ──────────────────
 
 pub const MAX_CHUNK_CHARS: usize = 800;
 pub const RRF_K: f64 = 60.0;
 pub const SCORE_THRESHOLD: f64 = 0.005;
 pub const MAX_RESULTS: usize = 5;
 pub const EMBEDDING_DIM: usize = 256;
-pub const SOCKET_PATH: &str = "/tmp/tsm-embedder.sock";
 pub const DEFAULT_HALF_LIFE_DAYS: f64 = 90.0;
 pub const SNIPPET_MAX_CHARS: usize = 200;
 pub const MIN_SESSION_MESSAGE_LEN: usize = 10;
 pub const BACKFILL_BATCH_SIZE: usize = 8;
 pub const MAX_QUERY_EXPANSIONS: usize = 5;
 pub const RECENT_DAYS: i64 = 30;
-pub const EMBEDDER_IDLE_TIMEOUT_SECS: u64 = 600;
-
-/// Load embedder idle timeout from config.
-/// TSM_EMBEDDER_IDLE_TIMEOUT env > config file > default (600s). 0 = disable.
-pub fn embedder_idle_timeout_secs() -> u64 {
-    if let Ok(val) = std::env::var("TSM_EMBEDDER_IDLE_TIMEOUT") {
-        if let Ok(n) = val.parse::<u64>() {
-            return n;
-        }
-    }
-    if let Some(val) = load_config_value("embedder_idle_timeout_secs") {
-        if let Ok(n) = val.parse::<u64>() {
-            return n;
-        }
-    }
-    EMBEDDER_IDLE_TIMEOUT_SECS
-}
-
-pub const EMBEDDER_BACKFILL_INTERVAL_SECS: u64 = 300;
-
-/// Load embedder backfill interval from config.
-/// TSM_EMBEDDER_BACKFILL_INTERVAL env > config file > default (300s). 0 = disable.
-pub fn embedder_backfill_interval_secs() -> u64 {
-    if let Ok(val) = std::env::var("TSM_EMBEDDER_BACKFILL_INTERVAL") {
-        if let Ok(n) = val.parse::<u64>() {
-            return n;
-        }
-    }
-    if let Some(val) = load_config_value("embedder_backfill_interval_secs") {
-        if let Ok(n) = val.parse::<u64>() {
-            return n;
-        }
-    }
-    EMBEDDER_BACKFILL_INTERVAL_SECS
-}
-
-pub const DAEMON_SOCKET_PATH: &str = "/tmp/tsm-daemon.sock";
-pub const DAEMON_PID_FILENAME: &str = "tsmd.pid";
-
-/// Load daemon socket path from config.
-/// TSM_DAEMON_SOCKET env > config file > default.
-pub fn daemon_socket_path() -> PathBuf {
-    if let Ok(p) = std::env::var("TSM_DAEMON_SOCKET") {
-        return PathBuf::from(p);
-    }
-    if let Some(p) = load_config_value("daemon_socket_path") {
-        return PathBuf::from(p);
-    }
-    PathBuf::from(DAEMON_SOCKET_PATH)
-}
-
-pub fn daemon_pid_path() -> PathBuf {
-    data_dir().join(DAEMON_PID_FILENAME)
-}
-
 pub const DICT_CANDIDATE_FREQ_THRESHOLD: i64 = 5;
 pub const WORKER_ENCODE_TIMEOUT_PER_ITEM_SECS: u64 = 5;
 pub const WORKER_ENCODE_TIMEOUT_BASE_SECS: u64 = 10;
 pub const MAX_WORKER_RESTARTS: usize = 3;
+pub const MIN_QUERY_KEYWORDS: usize = 1;
 
+const DEFAULT_DATA_DIR: &str = ".tsm";
 const DEFAULT_PROJECT_ROOT: &str = "/workspaces";
-const DEFAULT_DB_NAME: &str = "tsm.db";
+const DEFAULT_EMBEDDER_IDLE_TIMEOUT_SECS: u64 = 600;
+const DEFAULT_EMBEDDER_BACKFILL_INTERVAL_SECS: u64 = 300;
 
 /// Content directories with score weights. (directory, weight)
 pub const CONTENT_DIRS: &[(&str, f64)] = &[
@@ -92,38 +44,158 @@ pub const CONTENT_DIRS: &[(&str, f64)] = &[
 ];
 pub const SESSION_WEIGHT: f64 = 0.3;
 
-/// Resolve data_dir: TSM_DATA_DIR env > config file > CARGO_MANIFEST_DIR/data
+// ─── Config struct ───────────────────────────────────────────────
+
+/// Shape of tsm.toml — all fields optional for partial config files.
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(default)]
+struct ConfigFile {
+    data_dir: Option<String>,
+    project_root: Option<String>,
+    embedder_socket_path: Option<String>,
+    daemon_socket_path: Option<String>,
+    log_dir: Option<String>,
+    embedder_idle_timeout_secs: Option<u64>,
+    embedder_backfill_interval_secs: Option<u64>,
+}
+
+static CONFIG: OnceLock<ConfigFile> = OnceLock::new();
+
+/// Get the lazily-loaded config singleton.
+fn cfg() -> &'static ConfigFile {
+    CONFIG.get_or_init(|| load_config_from(&config_file_candidates()))
+}
+
+/// Load and merge config files.
+/// Priority (first wins per field): TSM_CONFIG env > ./tsm.toml > XDG config
+fn load_config_from(candidates: &[PathBuf]) -> ConfigFile {
+    let mut merged = ConfigFile::default();
+
+    // Iterate in priority order (highest first); `.or()` keeps first-seen value
+    for path in candidates {
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let file: ConfigFile = match toml::from_str(&content) {
+            Ok(f) => f,
+            Err(e) => {
+                log::warn!("Failed to parse {}: {e}", path.display());
+                continue;
+            }
+        };
+        merged.data_dir = merged.data_dir.or(file.data_dir);
+        merged.project_root = merged.project_root.or(file.project_root);
+        merged.embedder_socket_path = merged.embedder_socket_path.or(file.embedder_socket_path);
+        merged.daemon_socket_path = merged.daemon_socket_path.or(file.daemon_socket_path);
+        merged.log_dir = merged.log_dir.or(file.log_dir);
+        merged.embedder_idle_timeout_secs = merged.embedder_idle_timeout_secs.or(file.embedder_idle_timeout_secs);
+        merged.embedder_backfill_interval_secs = merged.embedder_backfill_interval_secs.or(file.embedder_backfill_interval_secs);
+    }
+    merged
+}
+
+fn config_file_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Ok(path) = std::env::var("TSM_CONFIG") {
+        candidates.push(PathBuf::from(path));
+    }
+    candidates.push(PathBuf::from("tsm.toml"));
+    if let Some(dirs) = ProjectDirs::from("", "", "tsm") {
+        candidates.push(dirs.config_dir().join("config.toml"));
+    }
+    candidates
+}
+
+// ─── Accessor functions (env var > config file > default) ────────
+
+/// Resolve data_dir: TSM_DATA_DIR env > config file > .tsm/
 pub fn data_dir() -> PathBuf {
     if let Ok(dir) = std::env::var("TSM_DATA_DIR") {
         return PathBuf::from(dir);
     }
-    if let Some(dir) = load_config_value("data_dir") {
+    if let Some(ref dir) = cfg().data_dir {
         return PathBuf::from(dir);
     }
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data")
+    PathBuf::from(DEFAULT_DATA_DIR)
 }
 
-/// Resolve log directory: TSM_LOG_DIR env > default (.tsm/logs in CWD)
-pub fn log_dir() -> PathBuf {
-    if let Ok(dir) = std::env::var("TSM_LOG_DIR") {
-        return PathBuf::from(dir);
-    }
-    PathBuf::from(".tsm/logs")
-}
-
-/// Resolve project_root: TSM_PROJECT_ROOT env > config file > default
+/// Resolve project_root: TSM_PROJECT_ROOT env > config file > /workspaces
 pub fn project_root() -> PathBuf {
     if let Ok(root) = std::env::var("TSM_PROJECT_ROOT") {
         return PathBuf::from(root);
     }
-    if let Some(root) = load_config_value("project_root") {
+    if let Some(ref root) = cfg().project_root {
         return PathBuf::from(root);
     }
     PathBuf::from(DEFAULT_PROJECT_ROOT)
 }
 
+/// Resolve embedder socket path: TSM_EMBEDDER_SOCKET env > config file > .tsm/embedder.sock
+pub fn embedder_socket_path() -> PathBuf {
+    if let Ok(p) = std::env::var("TSM_EMBEDDER_SOCKET") {
+        return PathBuf::from(p);
+    }
+    if let Some(ref p) = cfg().embedder_socket_path {
+        return PathBuf::from(p);
+    }
+    data_dir().join("embedder.sock")
+}
+
+/// Resolve daemon socket path: TSM_DAEMON_SOCKET env > config file > .tsm/daemon.sock
+pub fn daemon_socket_path() -> PathBuf {
+    if let Ok(p) = std::env::var("TSM_DAEMON_SOCKET") {
+        return PathBuf::from(p);
+    }
+    if let Some(ref p) = cfg().daemon_socket_path {
+        return PathBuf::from(p);
+    }
+    data_dir().join("daemon.sock")
+}
+
+/// Resolve log directory: TSM_LOG_DIR env > config file > .tsm/logs
+pub fn log_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("TSM_LOG_DIR") {
+        return PathBuf::from(dir);
+    }
+    if let Some(ref dir) = cfg().log_dir {
+        return PathBuf::from(dir);
+    }
+    data_dir().join("logs")
+}
+
+/// Load embedder idle timeout.
+/// TSM_EMBEDDER_IDLE_TIMEOUT env > config file > default (600s). 0 = disable.
+pub fn embedder_idle_timeout_secs() -> u64 {
+    if let Ok(val) = std::env::var("TSM_EMBEDDER_IDLE_TIMEOUT") {
+        if let Ok(n) = val.parse::<u64>() {
+            return n;
+        }
+    }
+    if let Some(n) = cfg().embedder_idle_timeout_secs {
+        return n;
+    }
+    DEFAULT_EMBEDDER_IDLE_TIMEOUT_SECS
+}
+
+/// Load embedder backfill interval.
+/// TSM_EMBEDDER_BACKFILL_INTERVAL env > config file > default (300s). 0 = disable.
+pub fn embedder_backfill_interval_secs() -> u64 {
+    if let Ok(val) = std::env::var("TSM_EMBEDDER_BACKFILL_INTERVAL") {
+        if let Ok(n) = val.parse::<u64>() {
+            return n;
+        }
+    }
+    if let Some(n) = cfg().embedder_backfill_interval_secs {
+        return n;
+    }
+    DEFAULT_EMBEDDER_BACKFILL_INTERVAL_SECS
+}
+
+// ─── Derived paths ───────────────────────────────────────────────
+
 pub fn db_path() -> PathBuf {
-    data_dir().join(DEFAULT_DB_NAME)
+    data_dir().join("tsm.db")
 }
 
 pub fn user_dict_path() -> PathBuf {
@@ -138,41 +210,35 @@ pub fn stopwords_path() -> PathBuf {
     data_dir().join("stopwords.txt")
 }
 
-/// Minimum number of meaningful keyword tokens for a query to be searchable.
-pub const MIN_QUERY_KEYWORDS: usize = 1;
-
-/// Load a value from config file.
-/// Search order: TSM_CONFIG env > ./tsm.toml > ~/.config/tsm/config.toml
-fn load_config_value(key: &str) -> Option<String> {
-    let candidates = config_file_candidates();
-    for path in candidates {
-        if let Ok(content) = std::fs::read_to_string(&path) {
-            if let Ok(table) = content.parse::<toml::Table>() {
-                if let Some(val) = table.get(key) {
-                    // Handle both string and non-string TOML values
-                    let s = match val.as_str() {
-                        Some(s) => s.to_string(),
-                        None => val.to_string(),
-                    };
-                    return Some(s);
-                }
-            }
-        }
-    }
-    None
+pub fn daemon_pid_path() -> PathBuf {
+    data_dir().join("tsmd.pid")
 }
 
-fn config_file_candidates() -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
-    if let Ok(path) = std::env::var("TSM_CONFIG") {
-        candidates.push(PathBuf::from(path));
+// ─── Model cache (XDG) ──────────────────────────────────────────
+
+/// Resolve model cache directory: HF_HUB_CACHE env > $XDG_CACHE_HOME/tsm/models/
+pub fn model_cache_dir() -> PathBuf {
+    if let Ok(p) = std::env::var("HF_HUB_CACHE") {
+        return PathBuf::from(p);
     }
-    candidates.push(PathBuf::from("tsm.toml"));
-    if let Ok(home) = std::env::var("HOME") {
-        candidates.push(PathBuf::from(home).join(".config/tsm/config.toml"));
-    }
-    candidates
+    ProjectDirs::from("", "", "tsm")
+        .map(|d| d.cache_dir().join("models"))
+        .unwrap_or_else(|| PathBuf::from(".tsm/cache/models"))
 }
+
+/// Set HF_HUB_CACHE env var if not already set so hf_hub uses XDG cache.
+///
+/// SAFETY: Must be called from main() before any threads are spawned.
+/// `std::env::set_var` is not thread-safe.
+pub fn ensure_model_cache_env() {
+    if std::env::var_os("HF_HUB_CACHE").is_none() {
+        let cache_dir = model_cache_dir();
+        // Safe: called single-threaded at startup
+        unsafe { std::env::set_var("HF_HUB_CACHE", cache_dir) };
+    }
+}
+
+// ─── Pure functions (no config dependency) ───────────────────────
 
 pub fn status_penalty(status: Option<&str>) -> f64 {
     match status {
@@ -317,11 +383,8 @@ mod tests {
     }
 
     #[test]
-    fn test_project_root_default() {
-        std::env::remove_var("TSM_PROJECT_ROOT");
-        std::env::remove_var("TSM_CONFIG");
-        let root = project_root();
-        assert_eq!(root, PathBuf::from(DEFAULT_PROJECT_ROOT));
+    fn test_project_root_default_constant() {
+        assert_eq!(DEFAULT_PROJECT_ROOT, "/workspaces");
     }
 
     #[test]
@@ -346,11 +409,8 @@ mod tests {
     }
 
     #[test]
-    fn test_embedder_idle_timeout_default() {
-        std::env::remove_var("TSM_EMBEDDER_IDLE_TIMEOUT");
-        std::env::remove_var("TSM_CONFIG");
-        let timeout = embedder_idle_timeout_secs();
-        assert_eq!(timeout, EMBEDDER_IDLE_TIMEOUT_SECS);
+    fn test_embedder_idle_timeout_default_constant() {
+        assert_eq!(DEFAULT_EMBEDDER_IDLE_TIMEOUT_SECS, 600);
     }
 
     #[test]
@@ -370,11 +430,8 @@ mod tests {
     }
 
     #[test]
-    fn test_embedder_backfill_interval_default() {
-        std::env::remove_var("TSM_EMBEDDER_BACKFILL_INTERVAL");
-        std::env::remove_var("TSM_CONFIG");
-        let interval = embedder_backfill_interval_secs();
-        assert_eq!(interval, EMBEDDER_BACKFILL_INTERVAL_SECS);
+    fn test_embedder_backfill_interval_default_constant() {
+        assert_eq!(DEFAULT_EMBEDDER_BACKFILL_INTERVAL_SECS, 300);
     }
 
     #[test]
@@ -403,14 +460,6 @@ mod tests {
     }
 
     #[test]
-    fn test_daemon_socket_path_default() {
-        std::env::remove_var("TSM_DAEMON_SOCKET");
-        std::env::remove_var("TSM_CONFIG");
-        let path = daemon_socket_path();
-        assert_eq!(path, PathBuf::from(DAEMON_SOCKET_PATH));
-    }
-
-    #[test]
     fn test_daemon_socket_path_env() {
         std::env::set_var("TSM_DAEMON_SOCKET", "/tmp/custom-daemon.sock");
         let path = daemon_socket_path();
@@ -423,6 +472,132 @@ mod tests {
         std::env::set_var("TSM_DATA_DIR", "/tmp/tsm-pid-test");
         let path = daemon_pid_path();
         assert_eq!(path, PathBuf::from("/tmp/tsm-pid-test/tsmd.pid"));
+        std::env::remove_var("TSM_DATA_DIR");
+    }
+
+    #[test]
+    fn test_embedder_socket_path_env() {
+        std::env::set_var("TSM_EMBEDDER_SOCKET", "/tmp/custom-embedder.sock");
+        let path = embedder_socket_path();
+        assert_eq!(path, PathBuf::from("/tmp/custom-embedder.sock"));
+        std::env::remove_var("TSM_EMBEDDER_SOCKET");
+    }
+
+    #[test]
+    fn test_embedder_socket_path_uses_data_dir() {
+        std::env::set_var("TSM_DATA_DIR", "/tmp/tsm-sock-test");
+        std::env::remove_var("TSM_EMBEDDER_SOCKET");
+        let path = embedder_socket_path();
+        assert_eq!(path, PathBuf::from("/tmp/tsm-sock-test/embedder.sock"));
+        std::env::remove_var("TSM_DATA_DIR");
+    }
+
+    #[test]
+    fn test_log_dir_env() {
+        std::env::set_var("TSM_LOG_DIR", "/tmp/tsm-logs");
+        let dir = log_dir();
+        assert_eq!(dir, PathBuf::from("/tmp/tsm-logs"));
+        std::env::remove_var("TSM_LOG_DIR");
+    }
+
+    #[test]
+    fn test_log_dir_uses_data_dir() {
+        std::env::set_var("TSM_DATA_DIR", "/tmp/tsm-log-test");
+        std::env::remove_var("TSM_LOG_DIR");
+        let dir = log_dir();
+        assert_eq!(dir, PathBuf::from("/tmp/tsm-log-test/logs"));
+        std::env::remove_var("TSM_DATA_DIR");
+    }
+
+    #[test]
+    fn test_model_cache_dir_env() {
+        std::env::set_var("HF_HUB_CACHE", "/tmp/hf-cache");
+        let dir = model_cache_dir();
+        assert_eq!(dir, PathBuf::from("/tmp/hf-cache"));
+        std::env::remove_var("HF_HUB_CACHE");
+    }
+
+    #[test]
+    fn test_config_file_candidates_includes_xdg() {
+        std::env::remove_var("TSM_CONFIG");
+        let candidates = config_file_candidates();
+        // Should have at least ./tsm.toml and XDG path
+        assert!(candidates.len() >= 2);
+        assert_eq!(candidates[0], PathBuf::from("tsm.toml"));
+        assert!(candidates[1].to_string_lossy().contains("tsm"));
+    }
+
+    #[test]
+    fn test_config_file_candidates_with_env() {
+        std::env::set_var("TSM_CONFIG", "/tmp/custom-config.toml");
+        let candidates = config_file_candidates();
+        assert_eq!(candidates[0], PathBuf::from("/tmp/custom-config.toml"));
+        std::env::remove_var("TSM_CONFIG");
+    }
+
+    #[test]
+    fn test_load_config_from_single_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("test-config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+data_dir = "/custom/data"
+project_root = "/custom/root"
+embedder_idle_timeout_secs = 1200
+"#,
+        )
+        .unwrap();
+
+        let cfg = load_config_from(&[config_path]);
+        assert_eq!(cfg.data_dir.as_deref(), Some("/custom/data"));
+        assert_eq!(cfg.project_root.as_deref(), Some("/custom/root"));
+        assert_eq!(cfg.embedder_idle_timeout_secs, Some(1200));
+        assert!(cfg.daemon_socket_path.is_none());
+    }
+
+    #[test]
+    fn test_load_config_merge_priority() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let high = dir.path().join("high.toml");
+        std::fs::write(&high, r#"data_dir = "/high""#).unwrap();
+
+        let low = dir.path().join("low.toml");
+        std::fs::write(
+            &low,
+            r#"
+data_dir = "/low"
+project_root = "/low-root"
+"#,
+        )
+        .unwrap();
+
+        // High-priority file is first in the list
+        let cfg = load_config_from(&[high, low]);
+        assert_eq!(cfg.data_dir.as_deref(), Some("/high"));
+        // project_root only in low-priority file, still picked up
+        assert_eq!(cfg.project_root.as_deref(), Some("/low-root"));
+    }
+
+    #[test]
+    fn test_load_config_empty_candidates() {
+        let cfg = load_config_from(&[]);
+        assert!(cfg.data_dir.is_none());
+        assert!(cfg.project_root.is_none());
+    }
+
+    #[test]
+    fn test_load_config_missing_file_skipped() {
+        let cfg = load_config_from(&[PathBuf::from("/nonexistent/tsm.toml")]);
+        assert!(cfg.data_dir.is_none());
+    }
+
+    #[test]
+    fn test_env_var_overrides_config_file() {
+        // Even if OnceLock has a cached config, env var always wins
+        std::env::set_var("TSM_DATA_DIR", "/env/data");
+        assert_eq!(data_dir(), PathBuf::from("/env/data"));
         std::env::remove_var("TSM_DATA_DIR");
     }
 }

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -395,7 +395,7 @@ fn handle_client(mut stream: UnixStream, embedder: &Embedder) -> Result<()> {
 /// Send texts to the embedder daemon and get embeddings back.
 /// Returns None if the embedder is not running.
 pub fn embed_via_socket(texts: &[String]) -> Option<Vec<Vec<f32>>> {
-    embed_via_socket_at(Path::new(config::SOCKET_PATH), texts)
+    embed_via_socket_at(&config::embedder_socket_path(), texts)
 }
 
 /// Send texts to the embedder daemon at a specific socket path.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -580,7 +580,7 @@ fn insert_vectors(conn: &Connection, chunk_entries: &[(i64, String)]) {
         return;
     }
     // Skip socket I/O if embedder is not running
-    if !std::path::Path::new(config::SOCKET_PATH).exists() {
+    if !config::embedder_socket_path().exists() {
         return;
     }
 
@@ -1219,7 +1219,7 @@ mod tests {
         let encode_mismatch = |texts: &[String]| -> anyhow::Result<Vec<Vec<f32>>> {
             if texts.len() > 1 {
                 // Return only 1 embedding for a batch of N
-                mock_encode(&texts[..1].to_vec())
+                mock_encode(&texts[..1])
             } else {
                 mock_encode(texts)
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,8 +124,8 @@ enum Commands {
 }
 
 fn main() -> anyhow::Result<()> {
-    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Stderr)?;
     config::ensure_model_cache_env();
+    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Stderr)?;
     let args = Cli::parse();
     match args.command {
         // ── Always direct ──

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,7 @@ enum Commands {
 
 fn main() -> anyhow::Result<()> {
     the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Stderr)?;
+    config::ensure_model_cache_env();
     let args = Cli::parse();
     match args.command {
         // ── Always direct ──


### PR DESCRIPTION
## Summary

- Replace per-field `load_config_value()` with `ConfigFile` struct loaded once via `OnceLock` singleton
- Move default runtime paths from `/tmp/` to workspace-local `.tsm/` directory (embedder.sock, daemon.sock, logs)
- Add XDG Base Directory support via `directories` crate for global config and model cache
- Replace `SOCKET_PATH` const with `embedder_socket_path()` function across all call sites

## Config priority

`env var > ./tsm.toml > $XDG_CONFIG_HOME/tsm/config.toml > compiled default`

## Files changed

| File | Change |
|---|---|
| `src/config.rs` | `ConfigFile` struct, `OnceLock`, `.or()` merge, new accessors |
| `Cargo.toml` | Add `directories = "6"` (MIT) |
| `src/cli.rs` | `SOCKET_PATH` → `embedder_socket_path()` (4 sites) |
| `src/indexer.rs` | `SOCKET_PATH` → `embedder_socket_path()` + clippy fix |
| `src/embedder.rs` | `SOCKET_PATH` → `embedder_socket_path()` |
| `src/bin/tsmd.rs` | `SOCKET_PATH` → `embedder_socket_path()`, `ensure_model_cache_env()` |
| `src/bin/tsm_embedder.rs` | `ensure_model_cache_env()` |
| `src/bin/tsm_watcher.rs` | `ensure_model_cache_env()` |
| `src/main.rs` | `ensure_model_cache_env()` |
| `.gitignore` | Add `.tsm/` |

## Test plan

- [x] 386 tests pass (`cargo test -- --test-threads=1`)
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] Manual: `tsm doctor` shows `.tsm/` paths after migration
- [ ] Manual: existing `tsm.toml` with `data_dir` override still works

Closes #32