### PR TITLE
fix: remove auto-restart to prevent OOM crash loops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/tsm /usr/local/bin/tsm
+COPY --from=builder /app/target/release/tsmd /usr/local/bin/tsmd
+COPY --from=builder /app/target/release/tsm-embedder /usr/local/bin/tsm-embedder
+COPY --from=builder /app/target/release/tsm-watcher /usr/local/bin/tsm-watcher
 ENTRYPOINT ["tsm"]

--- a/src/bin/tsm_embedder.rs
+++ b/src/bin/tsm_embedder.rs
@@ -1,4 +1,15 @@
 fn main() -> anyhow::Result<()> {
+    // When spawned as a backfill-worker subprocess (via WorkerHandle::spawn
+    // which calls `current_exe() backfill-worker`), dispatch to the worker
+    // entry point instead of starting a full embedder server.
+    if std::env::args_os().nth(1).is_some_and(|a| a == "backfill-worker") {
+        the_space_memory::config::ensure_model_cache_env();
+        the_space_memory::logging::init_logger(
+            the_space_memory::logging::LogMode::Daemon { name: "tsm-embedder" },
+        )?;
+        return the_space_memory::cli::cmd_backfill_worker();
+    }
+
     the_space_memory::config::ensure_model_cache_env();
     the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsm-embedder" })?;
     the_space_memory::cli::cmd_embedder_start(None)

--- a/src/bin/tsm_embedder.rs
+++ b/src/bin/tsm_embedder.rs
@@ -4,9 +4,13 @@ fn main() -> anyhow::Result<()> {
     match arg.as_deref().and_then(|a| a.to_str()) {
         Some("backfill-worker") => {
             // Dispatched by WorkerHandle::spawn via `tsm-embedder backfill-worker`.
+            // Use stderr logging — the parent's WorkerHandle reads our stderr
+            // and forwards it as [worker] lines to the parent's file logger.
+            // Using Daemon mode here would compete for the same log file and
+            // trigger spurious rotation.
             the_space_memory::config::ensure_model_cache_env();
             the_space_memory::logging::init_logger(
-                the_space_memory::logging::LogMode::Daemon { name: "tsm-embedder" },
+                the_space_memory::logging::LogMode::Stderr,
             )?;
             the_space_memory::cli::cmd_backfill_worker()
         }

--- a/src/bin/tsm_embedder.rs
+++ b/src/bin/tsm_embedder.rs
@@ -1,16 +1,28 @@
 fn main() -> anyhow::Result<()> {
-    // When spawned as a backfill-worker subprocess (via WorkerHandle::spawn
-    // which calls `current_exe() backfill-worker`), dispatch to the worker
-    // entry point instead of starting a full embedder server.
-    if std::env::args_os().nth(1).is_some_and(|a| a == "backfill-worker") {
-        the_space_memory::config::ensure_model_cache_env();
-        the_space_memory::logging::init_logger(
-            the_space_memory::logging::LogMode::Daemon { name: "tsm-embedder" },
-        )?;
-        return the_space_memory::cli::cmd_backfill_worker();
-    }
+    let arg = std::env::args_os().nth(1);
 
-    the_space_memory::config::ensure_model_cache_env();
-    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon { name: "tsm-embedder" })?;
-    the_space_memory::cli::cmd_embedder_start(None)
+    match arg.as_deref().and_then(|a| a.to_str()) {
+        Some("backfill-worker") => {
+            // Dispatched by WorkerHandle::spawn via `tsm-embedder backfill-worker`.
+            the_space_memory::config::ensure_model_cache_env();
+            the_space_memory::logging::init_logger(
+                the_space_memory::logging::LogMode::Daemon { name: "tsm-embedder" },
+            )?;
+            the_space_memory::cli::cmd_backfill_worker()
+        }
+        None => {
+            // No arguments — start the embedder server.
+            the_space_memory::config::ensure_model_cache_env();
+            the_space_memory::logging::init_logger(
+                the_space_memory::logging::LogMode::Daemon { name: "tsm-embedder" },
+            )?;
+            the_space_memory::cli::cmd_embedder_start(None)
+        }
+        Some(other) => {
+            eprintln!("tsm-embedder: unknown argument '{other}'");
+            eprintln!("Usage: tsm-embedder                  Start the embedder server");
+            eprintln!("       tsm-embedder backfill-worker   Run as a backfill worker (internal)");
+            std::process::exit(1);
+        }
+    }
 }

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -109,21 +109,27 @@ fn main() -> Result<()> {
             let _ = std::fs::remove_file(&embedder_pid_path);
             remove_stale_embedder_socket();
             match start_child("tsm-embedder", &[("TSM_EMBEDDER_IDLE_TIMEOUT", "0")]) {
-                Ok(child) => {
+                Ok(mut child) => {
                     let child_pid = child.id();
                     log::info!("embedder started (PID {child_pid})");
                     if let Err(e) = std::fs::write(&embedder_pid_path, child_pid.to_string()) {
-                        log::warn!("failed to write embedder PID file: {e}");
+                        log::error!(
+                            "failed to write embedder PID file: {e}; \
+                             killing child to prevent unguarded spawn"
+                        );
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        None
                     } else {
                         log::info!("embedder PID file: {}", embedder_pid_path.display());
-                    }
-                    status::update(&data_dir, |s| {
-                        s.embedder = Some(status::EmbedderStatus {
-                            started_at: chrono::Utc::now().to_rfc3339(),
-                            pid: child_pid,
+                        status::update(&data_dir, |s| {
+                            s.embedder = Some(status::EmbedderStatus {
+                                started_at: chrono::Utc::now().to_rfc3339(),
+                                pid: child_pid,
+                            });
                         });
-                    });
-                    Some(child)
+                        Some(child)
+                    }
                 }
                 Err(e) => {
                     log::error!("failed to start embedder: {e}");
@@ -143,21 +149,27 @@ fn main() -> Result<()> {
         } else {
             let _ = std::fs::remove_file(&watcher_pid_path);
             match start_child("tsm-watcher", &[]) {
-                Ok(child) => {
+                Ok(mut child) => {
                     let child_pid = child.id();
                     log::info!("watcher started (PID {child_pid})");
                     if let Err(e) = std::fs::write(&watcher_pid_path, child_pid.to_string()) {
-                        log::warn!("failed to write watcher PID file: {e}");
+                        log::error!(
+                            "failed to write watcher PID file: {e}; \
+                             killing child to prevent unguarded spawn"
+                        );
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        None
                     } else {
                         log::info!("watcher PID file: {}", watcher_pid_path.display());
-                    }
-                    status::update(&data_dir, |s| {
-                        s.watcher = Some(status::WatcherStatus {
-                            started_at: chrono::Utc::now().to_rfc3339(),
-                            pid: child_pid,
+                        status::update(&data_dir, |s| {
+                            s.watcher = Some(status::WatcherStatus {
+                                started_at: chrono::Utc::now().to_rfc3339(),
+                                pid: child_pid,
+                            });
                         });
-                    });
-                    Some(child)
+                        Some(child)
+                    }
                 }
                 Err(e) => {
                     log::error!("failed to start watcher: {e}");

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -112,7 +112,11 @@ fn main() -> Result<()> {
                 Ok(child) => {
                     let child_pid = child.id();
                     log::info!("embedder started (PID {child_pid})");
-                    let _ = std::fs::write(&embedder_pid_path, child_pid.to_string());
+                    if let Err(e) = std::fs::write(&embedder_pid_path, child_pid.to_string()) {
+                        log::warn!("failed to write embedder PID file: {e}");
+                    } else {
+                        log::info!("embedder PID file: {}", embedder_pid_path.display());
+                    }
                     status::update(&data_dir, |s| {
                         s.embedder = Some(status::EmbedderStatus {
                             started_at: chrono::Utc::now().to_rfc3339(),
@@ -142,7 +146,11 @@ fn main() -> Result<()> {
                 Ok(child) => {
                     let child_pid = child.id();
                     log::info!("watcher started (PID {child_pid})");
-                    let _ = std::fs::write(&watcher_pid_path, child_pid.to_string());
+                    if let Err(e) = std::fs::write(&watcher_pid_path, child_pid.to_string()) {
+                        log::warn!("failed to write watcher PID file: {e}");
+                    } else {
+                        log::info!("watcher PID file: {}", watcher_pid_path.display());
+                    }
                     status::update(&data_dir, |s| {
                         s.watcher = Some(status::WatcherStatus {
                             started_at: chrono::Utc::now().to_rfc3339(),

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -1,5 +1,5 @@
 use std::os::unix::net::UnixListener;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -94,24 +94,37 @@ fn main() -> Result<()> {
         );
     }
 
-    // Start child processes
+    // Start child processes.
+    // Each child is guarded by a PID file: if a previous instance is still
+    // alive (orphaned from a prior tsmd), we skip spawning a duplicate.
+    // Children are NOT auto-restarted on crash to prevent OOM restart loops.
+    let embedder_pid_path = data_dir.join("embedder.pid");
+    let watcher_pid_path = data_dir.join("watcher.pid");
+
     let mut embedder_child: Option<Child> = if !args.no_embedder {
-        remove_stale_embedder_socket();
-        match start_child("tsm-embedder", &[("TSM_EMBEDDER_IDLE_TIMEOUT", "0")]) {
-            Ok(child) => {
-                let child_pid = child.id();
-                log::info!("embedder started (PID {child_pid})");
-                status::update(&data_dir, |s| {
-                    s.embedder = Some(status::EmbedderStatus {
-                        started_at: chrono::Utc::now().to_rfc3339(),
-                        pid: child_pid,
+        if is_process_alive(&embedder_pid_path) {
+            log::info!("embedder already running (PID file: {})", embedder_pid_path.display());
+            None
+        } else {
+            let _ = std::fs::remove_file(&embedder_pid_path);
+            remove_stale_embedder_socket();
+            match start_child("tsm-embedder", &[("TSM_EMBEDDER_IDLE_TIMEOUT", "0")]) {
+                Ok(child) => {
+                    let child_pid = child.id();
+                    log::info!("embedder started (PID {child_pid})");
+                    let _ = std::fs::write(&embedder_pid_path, child_pid.to_string());
+                    status::update(&data_dir, |s| {
+                        s.embedder = Some(status::EmbedderStatus {
+                            started_at: chrono::Utc::now().to_rfc3339(),
+                            pid: child_pid,
+                        });
                     });
-                });
-                Some(child)
-            }
-            Err(e) => {
-                log::error!("failed to start embedder: {e}");
-                None
+                    Some(child)
+                }
+                Err(e) => {
+                    log::error!("failed to start embedder: {e}");
+                    None
+                }
             }
         }
     } else {
@@ -120,21 +133,28 @@ fn main() -> Result<()> {
     };
 
     let mut watcher_child: Option<Child> = if !args.no_watcher {
-        match start_child("tsm-watcher", &[]) {
-            Ok(child) => {
-                let child_pid = child.id();
-                log::info!("watcher started (PID {child_pid})");
-                status::update(&data_dir, |s| {
-                    s.watcher = Some(status::WatcherStatus {
-                        started_at: chrono::Utc::now().to_rfc3339(),
-                        pid: child_pid,
+        if is_process_alive(&watcher_pid_path) {
+            log::info!("watcher already running (PID file: {})", watcher_pid_path.display());
+            None
+        } else {
+            let _ = std::fs::remove_file(&watcher_pid_path);
+            match start_child("tsm-watcher", &[]) {
+                Ok(child) => {
+                    let child_pid = child.id();
+                    log::info!("watcher started (PID {child_pid})");
+                    let _ = std::fs::write(&watcher_pid_path, child_pid.to_string());
+                    status::update(&data_dir, |s| {
+                        s.watcher = Some(status::WatcherStatus {
+                            started_at: chrono::Utc::now().to_rfc3339(),
+                            pid: child_pid,
+                        });
                     });
-                });
-                Some(child)
-            }
-            Err(e) => {
-                log::error!("failed to start watcher: {e}");
-                None
+                    Some(child)
+                }
+                Err(e) => {
+                    log::error!("failed to start watcher: {e}");
+                    None
+                }
             }
         }
     } else {
@@ -142,11 +162,7 @@ fn main() -> Result<()> {
         None
     };
 
-    let mut embedder_restarts = 0u32;
-    let mut watcher_restarts = 0u32;
-    const MAX_CHILD_RESTARTS: u32 = 3;
-
-    // Accept loop
+    // Accept loop — children are NOT restarted on crash
     while !SHUTDOWN.load(Ordering::SeqCst) {
         match listener.accept() {
             Ok((mut stream, _)) => {
@@ -160,10 +176,12 @@ fn main() -> Result<()> {
                 });
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                if maybe_restart_child("embedder", &mut embedder_child, &mut embedder_restarts, MAX_CHILD_RESTARTS) {
-                    remove_stale_embedder_socket();
+                if reap_child("embedder", &mut embedder_child, &embedder_pid_path) {
+                    status::update(&data_dir, |s| s.embedder = None);
                 }
-                maybe_restart_child("watcher", &mut watcher_child, &mut watcher_restarts, MAX_CHILD_RESTARTS);
+                if reap_child("watcher", &mut watcher_child, &watcher_pid_path) {
+                    status::update(&data_dir, |s| s.watcher = None);
+                }
                 std::thread::sleep(std::time::Duration::from_millis(100));
             }
             Err(e) => {
@@ -175,13 +193,14 @@ fn main() -> Result<()> {
 
     // Cleanup
     log::info!("shutting down");
-    stop_child("embedder", embedder_child);
-    stop_child("watcher", watcher_child);
+    stop_child("embedder", embedder_child, &embedder_pid_path);
+    stop_child("watcher", watcher_child, &watcher_pid_path);
 
     let _ = std::fs::remove_file(&socket_path);
     let _ = std::fs::remove_file(&pid_path);
     status::update(&data_dir, |s| {
         s.daemon = None;
+        s.embedder = None;
         s.watcher = None;
     });
 
@@ -224,74 +243,43 @@ fn remove_stale_embedder_socket() {
     }
 }
 
-/// Check if a child has exited and restart it within the retry limit.
-/// Returns `true` if a restart was attempted (for pre-restart hooks like socket cleanup).
-fn maybe_restart_child(
-    label: &str,
-    child: &mut Option<Child>,
-    restarts: &mut u32,
-    max: u32,
-) -> bool {
-    let exited = match child {
-        Some(c) => match c.try_wait() {
-            Ok(Some(exit_status)) => {
-                if exit_status.success() {
-                    log::info!("{label} exited with status: {exit_status}");
-                } else {
-                    log::warn!("{label} exited with non-zero status: {exit_status}");
-                }
-                true
-            }
-            Ok(None) => false,
-            Err(e) => {
-                log::warn!("error checking {label} status: {e}");
-                false
-            }
-        },
-        None => return false,
+/// Check if a PID file points to a running process.
+fn is_process_alive(pid_path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(pid_path) else {
+        return false;
     };
-
-    if !exited {
+    let Ok(pid) = content.trim().parse::<i32>() else {
         return false;
-    }
+    };
+    // kill(pid, 0) checks process existence without sending a signal.
+    unsafe { libc::kill(pid, 0) == 0 }
+}
 
-    if *restarts >= max {
-        log::error!("{label} crashed {max} times, giving up");
-        *child = None;
-        return false;
-    }
-
-    *restarts += 1;
-    log::warn!("{label} exited, restarting ({restarts}/{max})...");
-
-    // Determine binary name and env vars from label
-    let (binary, env_vars): (&str, &[(&str, &str)]) = match label {
-        "embedder" => ("tsm-embedder", &[("TSM_EMBEDDER_IDLE_TIMEOUT", "0")]),
-        "watcher" => ("tsm-watcher", &[]),
-        _ => {
-            log::error!("unknown child label: {label}");
+/// Detect child exit. Returns `true` if the child exited.
+/// The child is NOT restarted — this only logs and cleans up the PID file.
+fn reap_child(label: &str, child: &mut Option<Child>, pid_path: &Path) -> bool {
+    let Some(c) = child else { return false };
+    match c.try_wait() {
+        Ok(Some(exit_status)) => {
+            if exit_status.success() {
+                log::info!("{label} exited normally");
+            } else {
+                log::warn!("{label} exited with {exit_status}, not restarting");
+            }
             *child = None;
-            return false;
-        }
-    };
-
-    match start_child(binary, env_vars) {
-        Ok(new_child) => {
-            log::info!("{label} restarted (PID {})", new_child.id());
-            *child = Some(new_child);
-            *restarts = 0;
+            let _ = std::fs::remove_file(pid_path);
             true
         }
+        Ok(None) => false,
         Err(e) => {
-            log::error!("failed to restart {label}: {e}");
-            *child = None;
+            log::warn!("error checking {label}: {e}");
             false
         }
     }
 }
 
-/// Stop a child process: SIGTERM → wait (2s grace) → SIGKILL.
-fn stop_child(label: &str, child: Option<Child>) {
+/// Stop a child process: SIGTERM → wait (2s grace) → SIGKILL. Removes PID file.
+fn stop_child(label: &str, child: Option<Child>, pid_path: &Path) {
     if let Some(mut child) = child {
         let pid = child.id();
         log::info!("stopping {label} (PID {pid})...");
@@ -304,6 +292,7 @@ fn stop_child(label: &str, child: Option<Child>) {
         // Wait up to 2 seconds for graceful exit
         for _ in 0..20 {
             if matches!(child.try_wait(), Ok(Some(_))) {
+                let _ = std::fs::remove_file(pid_path);
                 return;
             }
             std::thread::sleep(std::time::Duration::from_millis(100));
@@ -317,6 +306,7 @@ fn stop_child(label: &str, child: Option<Child>) {
             log::warn!("failed to wait for {label} (PID {pid}): {e}");
         }
     }
+    let _ = std::fs::remove_file(pid_path);
 }
 
 // ─── Client handling ──────────────────────────────────────────────

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -258,6 +258,14 @@ pub fn cmd_backfill_worker() -> anyhow::Result<()> {
 static BACKFILL_RUNNING: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+/// RAII guard that resets `BACKFILL_RUNNING` on drop (including panic unwind).
+struct BackfillGuard;
+impl Drop for BackfillGuard {
+    fn drop(&mut self) {
+        BACKFILL_RUNNING.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
 /// Run backfill via a worker subprocess with default batch size.
 /// Skips if another backfill is already running in this process.
 pub fn backfill_with_worker(db_path: &Path) -> anyhow::Result<()> {
@@ -273,9 +281,8 @@ pub fn backfill_with_worker(db_path: &Path) -> anyhow::Result<()> {
         log::info!("Backfill already running, skipping");
         return Ok(());
     }
-    let result = backfill_with_worker_sized(db_path, indexer::BACKFILL_BATCH_SIZE);
-    BACKFILL_RUNNING.store(false, std::sync::atomic::Ordering::SeqCst);
-    result
+    let _guard = BackfillGuard;
+    backfill_with_worker_sized(db_path, indexer::BACKFILL_BATCH_SIZE)
 }
 
 /// Run vector backfill with an existing connection (daemon-safe).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -254,9 +254,28 @@ pub fn cmd_backfill_worker() -> anyhow::Result<()> {
     embedder::run_backfill_worker()
 }
 
+/// Guard to prevent concurrent backfill runs (startup + periodic).
+static BACKFILL_RUNNING: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// Run backfill via a worker subprocess with default batch size.
+/// Skips if another backfill is already running in this process.
 pub fn backfill_with_worker(db_path: &Path) -> anyhow::Result<()> {
-    backfill_with_worker_sized(db_path, indexer::BACKFILL_BATCH_SIZE)
+    if BACKFILL_RUNNING
+        .compare_exchange(
+            false,
+            true,
+            std::sync::atomic::Ordering::SeqCst,
+            std::sync::atomic::Ordering::SeqCst,
+        )
+        .is_err()
+    {
+        log::info!("Backfill already running, skipping");
+        return Ok(());
+    }
+    let result = backfill_with_worker_sized(db_path, indexer::BACKFILL_BATCH_SIZE);
+    BACKFILL_RUNNING.store(false, std::sync::atomic::Ordering::SeqCst);
+    result
 }
 
 /// Run vector backfill with an existing connection (daemon-safe).

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -192,8 +192,10 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
         let db_path = crate::config::db_path();
         if db_path.exists() {
             std::thread::spawn(move || {
-                if let Err(e) = crate::cli::backfill_with_worker(&db_path) {
-                    log::warn!("Backfill warning: {e}");
+                log::info!("Starting backfill worker...");
+                match crate::cli::backfill_with_worker(&db_path) {
+                    Ok(()) => log::info!("Backfill completed"),
+                    Err(e) => log::warn!("Backfill failed: {e}"),
                 }
             });
         }

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -443,11 +443,20 @@ pub struct WorkerHandle {
 }
 
 impl WorkerHandle {
-    /// Spawn a new `tsm backfill-worker` child process.
+    /// Spawn a new `tsm-embedder backfill-worker` child process.
     /// Blocks until the child reports "READY" on stderr (with timeout).
+    ///
+    /// Always invokes the `tsm-embedder` sibling binary explicitly instead of
+    /// `current_exe()`, so the caller's identity doesn't matter — this is safe
+    /// to call from tsm, tsmd, or tsm-embedder itself.
     pub fn spawn(timeout: Duration) -> Result<Self> {
-        let exe = std::env::current_exe().context("cannot determine executable path")?;
-        let mut child = Command::new(exe)
+        let exe_dir = std::env::current_exe()
+            .context("cannot determine executable path")?
+            .parent()
+            .context("executable has no parent directory")?
+            .to_path_buf();
+        let worker_bin = exe_dir.join("tsm-embedder");
+        let mut child = Command::new(&worker_bin)
             .arg("backfill-worker")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())


### PR DESCRIPTION
## Summary
- tsmd の子プロセス（embedder/watcher）の自動リスタートを廃止
- embedder が OOM kill されても tsmd は死なず、FTS5 フォールバックで検索継続
- PID file ガードで orphan プロセスの重複 spawn を防止
- Docker image に全4バイナリ（tsm, tsmd, tsm-embedder, tsm-watcher）を同梱

## Background
旧実装ではリスタートカウンタが spawn 成功時にリセットされるため、
embedder が OOM → リスタート → OOM の無限ループが発生し、
コンテナ全体がメモリ枯渇で死亡していた。

## Design
- 子プロセスが死んだらログして終わり。リスタートしない
- `.tsm/embedder.pid`, `.tsm/watcher.pid` で PID file ガード
- 明示的な再起動: `tsm stop && tsm start`
- shutdown 時に PID file + socket + status.json をクリーンアップ

## Test plan
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test` 389 passed
- [ ] OOM 環境で embedder が死んでも tsmd が生存することを確認
- [ ] `tsm stop && tsm start` で正常に再起動できることを確認