### PR TITLE
fix: prefer system-installed tsm over plugin-bundled binary in hooks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "the-space-memory",
   "description": "Cross-workspace knowledge search engine with hybrid FTS5 + vector search",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "author": {
     "name": "Mitsukuni Sato"
   },

--- a/commands/scripts/search.sh
+++ b/commands/scripts/search.sh
@@ -6,8 +6,14 @@ QUERY=$(printf '%s' "$*" | tr -d '`$(){}|;&<>!\\'\'' "' | head -c 500)
 
 [ ${#QUERY} -lt 2 ] && echo '[]' && exit 0
 
-TSM="${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")/../..}/tsm"
-[ ! -x "$TSM" ] && echo '[]' && exit 0
+# Prefer system-installed tsm over plugin-bundled one
+if command -v tsm >/dev/null 2>&1; then
+  TSM="tsm"
+elif [ -x "${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")/../..}/tsm" ]; then
+  TSM="${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")/../..}/tsm"
+else
+  echo '[]' && exit 0
+fi
 
 cd "${CLAUDE_PROJECT_DIR:-/workspaces/workspace}"
 

--- a/hooks/scripts/index-file.sh
+++ b/hooks/scripts/index-file.sh
@@ -7,8 +7,14 @@ FILE=$(jq -r '.tool_input.file_path // empty') || exit 0
 # .md ファイルのみ対象
 [[ "$FILE" != *.md ]] && exit 0
 
-TSM="${CLAUDE_PLUGIN_ROOT:-}/tsm"
-[ ! -x "$TSM" ] && exit 0
+# Prefer system-installed tsm over plugin-bundled one
+if command -v tsm >/dev/null 2>&1; then
+  TSM="tsm"
+elif [ -x "${CLAUDE_PLUGIN_ROOT:-}/tsm" ]; then
+  TSM="${CLAUDE_PLUGIN_ROOT:-}/tsm"
+else
+  exit 0
+fi
 
 cd "${CLAUDE_PROJECT_DIR:-/workspaces/workspace}"
 

--- a/hooks/scripts/ingest.sh
+++ b/hooks/scripts/ingest.sh
@@ -7,8 +7,14 @@ SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
 
 [ -z "$SESSION_ID" ] && exit 0
 
-TSM="${CLAUDE_PLUGIN_ROOT:-}/tsm"
-[ ! -x "$TSM" ] && exit 0
+# Prefer system-installed tsm over plugin-bundled one
+if command -v tsm >/dev/null 2>&1; then
+  TSM="tsm"
+elif [ -x "${CLAUDE_PLUGIN_ROOT:-}/tsm" ]; then
+  TSM="${CLAUDE_PLUGIN_ROOT:-}/tsm"
+else
+  exit 0
+fi
 
 cd "${CLAUDE_PROJECT_DIR:-/workspaces/workspace}"
 

--- a/hooks/scripts/search.sh
+++ b/hooks/scripts/search.sh
@@ -16,9 +16,14 @@ if [ ${#QUERY} -lt 3 ]; then
   exit 0
 fi
 
-TSM="${CLAUDE_PLUGIN_ROOT:-}/tsm"
-if [ ! -x "$TSM" ]; then
-  echo "[$(date -Iseconds)] SKIP: tsm not found at $TSM" >> "$LOG"
+# Prefer system-installed tsm over plugin-bundled one
+# (bundled binary may have hardcoded paths from Docker build)
+if command -v tsm >/dev/null 2>&1; then
+  TSM="tsm"
+elif [ -x "${CLAUDE_PLUGIN_ROOT:-}/tsm" ]; then
+  TSM="${CLAUDE_PLUGIN_ROOT:-}/tsm"
+else
+  echo "[$(date -Iseconds)] SKIP: tsm not found" >> "$LOG"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- フック・コマンドスクリプトで `command -v tsm` を優先し、PATH 上の tsm を使う
- プラグイン同梱バイナリは PATH に tsm がない場合のフォールバック

## Background
プラグイン同梱の tsm バイナリは Docker ビルド時のパス (`/app/data/tsm.db`) がハードコードされており、ランタイムで `tsm.toml` を読めない。全フック呼び出しが `unable to open database file` で失敗していた。

## Changed files
- `hooks/scripts/search.sh`
- `hooks/scripts/index-file.sh`
- `hooks/scripts/ingest.sh`
- `commands/scripts/search.sh`