### PR TITLE
feat: error on search when embedder is down (#47)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,6 +91,7 @@ pub struct SearchOptions<'a> {
     pub before: Option<&'a str>,
     pub recent: Option<&'a str>,
     pub year: Option<i32>,
+    pub fallback: Option<&'a str>,
 }
 
 /// Run search and return structured results (no DB open, no output).
@@ -99,6 +100,23 @@ pub fn run_search(
     opts: &SearchOptions,
 ) -> anyhow::Result<Vec<searcher::SearchResult>> {
     use crate::temporal;
+
+    // Resolve fallback policy: CLI flag > config > default (Error)
+    let fallback = match opts.fallback {
+        Some(s) => s
+            .parse::<config::SearchFallback>()
+            .map_err(|e| anyhow::anyhow!("{e}"))?,
+        None => config::search_fallback(),
+    };
+
+    let require_vector = fallback == config::SearchFallback::Error;
+
+    if !require_vector {
+        let embedder_socket = config::embedder_socket_path();
+        if !embedder_socket.exists() {
+            log::warn!("Embedder is not running. Falling back to FTS-only search.");
+        }
+    }
 
     let parsed = temporal::parse_temporal(opts.query);
     let filter = temporal::merge_filters(
@@ -109,7 +127,7 @@ pub fn run_search(
         parsed.filter,
     )?;
     let search_query = &parsed.query;
-    searcher::search(conn, search_query, opts.top_k, filter.as_ref())
+    searcher::search(conn, search_query, opts.top_k, filter.as_ref(), require_vector)
 }
 
 pub fn cmd_search(opts: SearchOptions) -> anyhow::Result<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -127,7 +127,13 @@ pub fn run_search(
         parsed.filter,
     )?;
     let search_query = &parsed.query;
-    searcher::search(conn, search_query, opts.top_k, filter.as_ref(), require_vector)
+    searcher::search(
+        conn,
+        search_query,
+        opts.top_k,
+        filter.as_ref(),
+        require_vector,
+    )
 }
 
 pub fn cmd_search(opts: SearchOptions) -> anyhow::Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
@@ -26,6 +27,55 @@ const DEFAULT_STATE_DIR: &str = ".tsm";
 const DEFAULT_INDEX_ROOT: &str = "/workspaces";
 const DEFAULT_EMBEDDER_IDLE_TIMEOUT_SECS: u64 = 600;
 const DEFAULT_EMBEDDER_BACKFILL_INTERVAL_SECS: u64 = 300;
+
+/// Behavior when the embedder is stopped during search.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
+pub enum SearchFallback {
+    /// Error exit (default) — refuse to search without vector search.
+    #[default]
+    Error,
+    /// Fall back to FTS5-only search with a warning.
+    FtsOnly,
+}
+
+impl<'de> serde::Deserialize<'de> for SearchFallback {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "error" => Ok(SearchFallback::Error),
+            "fts_only" => Ok(SearchFallback::FtsOnly),
+            other => Err(serde::de::Error::custom(format!(
+                "unknown search_fallback value: '{other}' (expected 'error' or 'fts_only')"
+            ))),
+        }
+    }
+}
+
+impl fmt::Display for SearchFallback {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SearchFallback::Error => write!(f, "error"),
+            SearchFallback::FtsOnly => write!(f, "fts_only"),
+        }
+    }
+}
+
+impl std::str::FromStr for SearchFallback {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "error" => Ok(SearchFallback::Error),
+            "fts_only" => Ok(SearchFallback::FtsOnly),
+            other => Err(format!(
+                "unknown search_fallback value: '{other}' (expected 'error' or 'fts_only')"
+            )),
+        }
+    }
+}
 
 /// Content directories with score weights. (directory, weight)
 pub const CONTENT_DIRS: &[(&str, f64)] = &[
@@ -57,6 +107,7 @@ pub(crate) struct ConfigFile {
     log_dir: Option<PathBuf>,
     embedder_idle_timeout_secs: Option<u64>,
     embedder_backfill_interval_secs: Option<u64>,
+    search_fallback: Option<SearchFallback>,
 }
 
 /// Fully resolved configuration — all values determined at startup.
@@ -100,6 +151,11 @@ pub struct ResolvedConfig {
     /// Default: 300.
     /// Env: `TSM_EMBEDDER_BACKFILL_INTERVAL`. Config: `embedder_backfill_interval_secs`.
     pub embedder_backfill_interval_secs: u64,
+
+    /// Behavior when the embedder is stopped during search.
+    /// Default: `Error` (refuse to search without vector search).
+    /// Env: `TSM_SEARCH_FALLBACK`. Config: `search_fallback`.
+    pub search_fallback: SearchFallback,
 }
 
 impl ResolvedConfig {
@@ -142,6 +198,8 @@ impl ResolvedConfig {
         )
         .unwrap_or(DEFAULT_EMBEDDER_BACKFILL_INTERVAL_SECS);
 
+        let search_fallback = env_parse_fallback(file_cfg.search_fallback);
+
         Self {
             state_dir,
             index_root,
@@ -150,6 +208,7 @@ impl ResolvedConfig {
             log_dir,
             embedder_idle_timeout_secs,
             embedder_backfill_interval_secs,
+            search_fallback,
         }
     }
 }
@@ -160,6 +219,17 @@ fn env_or(var: &str, file_val: Option<&PathBuf>) -> Option<PathBuf> {
         return Some(PathBuf::from(val));
     }
     file_val.cloned()
+}
+
+/// Resolve search_fallback: env var > config file > default (Error).
+fn env_parse_fallback(file_val: Option<SearchFallback>) -> SearchFallback {
+    if let Ok(val) = std::env::var("TSM_SEARCH_FALLBACK") {
+        match val.parse::<SearchFallback>() {
+            Ok(f) => return f,
+            Err(e) => log::warn!("TSM_SEARCH_FALLBACK='{val}' is invalid ({e}); using default"),
+        }
+    }
+    file_val.unwrap_or_default()
 }
 
 /// Read an env var as u64, falling back to a config file value.
@@ -219,6 +289,7 @@ fn load_config_from(candidates: &[PathBuf]) -> ConfigFile {
         merged.embedder_backfill_interval_secs = merged
             .embedder_backfill_interval_secs
             .or(file.embedder_backfill_interval_secs);
+        merged.search_fallback = merged.search_fallback.or(file.search_fallback);
     }
     merged
 }
@@ -263,6 +334,10 @@ pub fn embedder_idle_timeout_secs() -> u64 {
 
 pub fn embedder_backfill_interval_secs() -> u64 {
     resolved().embedder_backfill_interval_secs
+}
+
+pub fn search_fallback() -> SearchFallback {
+    resolved().search_fallback
 }
 
 // ─── Derived paths ───────────────────────────────────────────────
@@ -740,5 +815,80 @@ index_root = "/low-root"
         ensure_model_cache_env();
         assert_eq!(std::env::var("HF_HUB_CACHE").unwrap(), "/my/custom/cache");
         std::env::remove_var("HF_HUB_CACHE");
+    }
+
+    // ─── SearchFallback ────────────────────────────────────────────────
+
+    #[test]
+    fn test_search_fallback_default() {
+        assert_eq!(SearchFallback::default(), SearchFallback::Error);
+    }
+
+    #[test]
+    fn test_search_fallback_from_str() {
+        assert_eq!("error".parse::<SearchFallback>().unwrap(), SearchFallback::Error);
+        assert_eq!("fts_only".parse::<SearchFallback>().unwrap(), SearchFallback::FtsOnly);
+        assert!("invalid".parse::<SearchFallback>().is_err());
+    }
+
+    #[test]
+    fn test_search_fallback_display() {
+        assert_eq!(SearchFallback::Error.to_string(), "error");
+        assert_eq!(SearchFallback::FtsOnly.to_string(), "fts_only");
+    }
+
+    #[test]
+    fn test_search_fallback_serde_roundtrip() {
+        let val: SearchFallback = serde_json::from_str("\"error\"").unwrap();
+        assert_eq!(val, SearchFallback::Error);
+        let val: SearchFallback = serde_json::from_str("\"fts_only\"").unwrap();
+        assert_eq!(val, SearchFallback::FtsOnly);
+        assert!(serde_json::from_str::<SearchFallback>("\"bogus\"").is_err());
+    }
+
+    #[test]
+    fn test_search_fallback_toml() {
+        let cfg: ConfigFile = toml::from_str(r#"search_fallback = "fts_only""#).unwrap();
+        assert_eq!(cfg.search_fallback, Some(SearchFallback::FtsOnly));
+
+        let cfg: ConfigFile = toml::from_str(r#"search_fallback = "error""#).unwrap();
+        assert_eq!(cfg.search_fallback, Some(SearchFallback::Error));
+
+        assert!(toml::from_str::<ConfigFile>(r#"search_fallback = "nope""#).is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolved_search_fallback_default() {
+        std::env::remove_var("TSM_SEARCH_FALLBACK");
+        let cfg = resolved_from_toml("");
+        assert_eq!(cfg.search_fallback, SearchFallback::Error);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolved_search_fallback_from_config() {
+        std::env::remove_var("TSM_SEARCH_FALLBACK");
+        let cfg = resolved_from_toml(r#"search_fallback = "fts_only""#);
+        assert_eq!(cfg.search_fallback, SearchFallback::FtsOnly);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolved_search_fallback_env_overrides_config() {
+        std::env::set_var("TSM_SEARCH_FALLBACK", "fts_only");
+        let cfg = resolved_from_toml(r#"search_fallback = "error""#);
+        std::env::remove_var("TSM_SEARCH_FALLBACK");
+        assert_eq!(cfg.search_fallback, SearchFallback::FtsOnly);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolved_search_fallback_invalid_env_falls_back() {
+        std::env::set_var("TSM_SEARCH_FALLBACK", "bogus");
+        let cfg = resolved_from_toml(r#"search_fallback = "fts_only""#);
+        std::env::remove_var("TSM_SEARCH_FALLBACK");
+        // Invalid env → falls back to config file value
+        assert_eq!(cfg.search_fallback, SearchFallback::FtsOnly);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -826,8 +826,14 @@ index_root = "/low-root"
 
     #[test]
     fn test_search_fallback_from_str() {
-        assert_eq!("error".parse::<SearchFallback>().unwrap(), SearchFallback::Error);
-        assert_eq!("fts_only".parse::<SearchFallback>().unwrap(), SearchFallback::FtsOnly);
+        assert_eq!(
+            "error".parse::<SearchFallback>().unwrap(),
+            SearchFallback::Error
+        );
+        assert_eq!(
+            "fts_only".parse::<SearchFallback>().unwrap(),
+            SearchFallback::FtsOnly
+        );
         assert!("invalid".parse::<SearchFallback>().is_err());
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -33,6 +33,7 @@ pub fn handle_request(
             before,
             recent,
             year,
+            fallback,
         } => {
             let opts = cli::SearchOptions {
                 query: &query,
@@ -43,6 +44,7 @@ pub fn handle_request(
                 before: before.as_deref(),
                 recent: recent.as_deref(),
                 year,
+                fallback: fallback.as_deref(),
             };
             match cli::run_search(conn, &opts) {
                 Ok(results) => {
@@ -166,6 +168,7 @@ mod tests {
             before: None,
             recent: None,
             year: None,
+            fallback: Some("fts_only".into()),
         };
         let resp = handle_request(&conn, req, dir.path(), &flag);
         assert!(resp.ok);
@@ -381,6 +384,7 @@ mod tests {
                 before: None,
                 recent: None,
                 year: None,
+                fallback: Some("fts_only".into()),
             },
         )
         .unwrap();

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -24,6 +24,8 @@ pub enum DaemonRequest {
         recent: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         year: Option<i32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        fallback: Option<String>,
     },
     Index {
         files: Vec<String>,
@@ -167,6 +169,7 @@ mod tests {
             before: Some("2026-01-01".into()),
             recent: None,
             year: None,
+            fallback: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let decoded: DaemonRequest = serde_json::from_str(&json).unwrap();
@@ -363,6 +366,7 @@ mod tests {
             before: None,
             recent: None,
             year: None,
+            fallback: None,
         };
         let req_bytes = serde_json::to_vec(&req).unwrap();
         let mut buf = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -18,6 +19,21 @@ impl From<DictFormatArg> for DictFormat {
         match arg {
             DictFormatArg::Simpledic => DictFormat::Simpledic,
             DictFormatArg::Ipadic => DictFormat::Ipadic,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SearchFallbackArg {
+    Error,
+    FtsOnly,
+}
+
+impl fmt::Display for SearchFallbackArg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SearchFallbackArg::Error => write!(f, "error"),
+            SearchFallbackArg::FtsOnly => write!(f, "fts_only"),
         }
     }
 }
@@ -73,6 +89,9 @@ enum Commands {
         /// Filter: documents from a specific year
         #[arg(long)]
         year: Option<i32>,
+        /// Embedder fallback mode: error (default) or fts_only
+        #[arg(long, value_enum)]
+        fallback: Option<SearchFallbackArg>,
     },
     /// Ingest a session JSONL file
     IngestSession {
@@ -118,6 +137,8 @@ enum Commands {
         #[arg(long)]
         force: bool,
     },
+    /// Restart the daemon (stop + start)
+    Restart,
     /// Internal: backfill worker subprocess (do not call directly)
     #[command(hide = true)]
     BackfillWorker,
@@ -132,6 +153,10 @@ fn main() -> anyhow::Result<()> {
         Commands::Init => cli::cmd_init()?,
         Commands::Start => cmd_start()?,
         Commands::Stop => cmd_stop()?,
+        Commands::Restart => {
+            cmd_stop()?;
+            cmd_start()?;
+        }
         Commands::Setup => cli::cmd_setup()?,
         Commands::BackfillWorker => cli::cmd_backfill_worker()?,
         Commands::VectorFill { batch_size } => cli::cmd_vector_fill(batch_size)?,
@@ -160,7 +185,14 @@ fn main() -> anyhow::Result<()> {
             before,
             recent,
             year,
+            fallback,
         } => {
+            // Always resolve fallback so the daemon uses the CLI caller's config
+            let fallback = Some(
+                fallback
+                    .map(|f| f.to_string())
+                    .unwrap_or_else(|| config::search_fallback().to_string()),
+            );
             let req = DaemonRequest::Search {
                 query,
                 top_k,
@@ -170,6 +202,7 @@ fn main() -> anyhow::Result<()> {
                 before,
                 recent,
                 year,
+                fallback,
             };
             render_search(send_to_daemon(&req)?, &format)?;
         }

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -26,11 +26,15 @@ pub struct SearchResult {
 }
 
 /// Search for documents matching the query, with optional time filtering.
+///
+/// When `require_vector` is true, returns an error if vector search is
+/// unavailable (embedder not running or vec table missing).
 pub fn search(
     conn: &Connection,
     query: &str,
     top_k: usize,
     time_filter: Option<&TimeFilter>,
+    require_vector: bool,
 ) -> anyhow::Result<Vec<SearchResult>> {
     // Query preprocessing: extract meaningful keywords, skip noise-only queries
     let keywords = extract_search_keywords(query);
@@ -66,6 +70,12 @@ pub fn search(
         fts_results_raw(conn, &expanded, limit)?
     };
     let vec_ranks = vec_results(conn, query, limit)?;
+    if require_vector && vec_ranks.is_empty() && db::has_vec_table(conn) {
+        anyhow::bail!(
+            "Embedder is not running. Vector search unavailable.\n\
+             Run `tsm restart` to restart, or use `--fallback fts_only` for FTS-only search."
+        );
+    }
     let ent_ranks =
         entity::entity_results_by_ids(conn, &cls.matched_entity_ids, limit).unwrap_or_default();
 
@@ -526,7 +536,7 @@ mod tests {
         indexer::index_file(&conn, &full, dir.path()).unwrap();
 
         // Search should find it
-        let results = search(&conn, "射撃", 5, None).unwrap();
+        let results = search(&conn, "射撃", 5, None, false).unwrap();
         assert!(!results.is_empty());
         assert!(results[0].source_file.contains("shooting"));
         assert!(results[0].score > 0.0);
@@ -536,14 +546,14 @@ mod tests {
     #[test]
     fn test_search_empty_query() {
         let conn = db::get_memory_connection().unwrap();
-        let results = search(&conn, "", 5, None).unwrap();
+        let results = search(&conn, "", 5, None, false).unwrap();
         assert!(results.is_empty());
     }
 
     #[test]
     fn test_search_no_results() {
         let conn = db::get_memory_connection().unwrap();
-        let results = search(&conn, "存在しないキーワード", 5, None).unwrap();
+        let results = search(&conn, "存在しないキーワード", 5, None, false).unwrap();
         assert!(results.is_empty());
     }
 
@@ -568,7 +578,7 @@ mod tests {
             indexer::index_file(&conn, &full, dir.path()).unwrap();
         }
 
-        let results = search(&conn, "テスト", 3, None).unwrap();
+        let results = search(&conn, "テスト", 3, None, false).unwrap();
         assert!(results.len() <= 3);
     }
 
@@ -596,7 +606,7 @@ mod tests {
             after: Some("2020-01-01".to_string()),
             before: Some("2099-01-01".to_string()),
         };
-        let results = search(&conn, "射撃", 5, Some(&filter)).unwrap();
+        let results = search(&conn, "射撃", 5, Some(&filter), false).unwrap();
         assert!(!results.is_empty());
     }
 
@@ -624,7 +634,7 @@ mod tests {
             after: Some("2099-01-01".to_string()),
             before: None,
         };
-        let results = search(&conn, "射撃", 5, Some(&filter)).unwrap();
+        let results = search(&conn, "射撃", 5, Some(&filter), false).unwrap();
         assert!(results.is_empty());
     }
 
@@ -648,7 +658,7 @@ mod tests {
             after: Some("2025-01-01".to_string()),
             before: None,
         };
-        let results = search(&conn, "射撃", 5, Some(&filter)).unwrap();
+        let results = search(&conn, "射撃", 5, Some(&filter), false).unwrap();
         assert!(!results.is_empty());
     }
 
@@ -680,7 +690,7 @@ mod tests {
     fn test_search_noise_query_returns_empty() {
         let conn = db::get_memory_connection().unwrap();
         // Pure interjection/greeting should return empty results
-        let results = search(&conn, "よかったーーー", 5, None).unwrap();
+        let results = search(&conn, "よかったーーー", 5, None, false).unwrap();
         assert!(
             results.is_empty(),
             "Noise query should return empty results"
@@ -690,7 +700,7 @@ mod tests {
     #[test]
     fn test_search_stopword_query_returns_empty() {
         let conn = db::get_memory_connection().unwrap();
-        let results = search(&conn, "なるほど", 5, None).unwrap();
+        let results = search(&conn, "なるほど", 5, None, false).unwrap();
         assert!(
             results.is_empty(),
             "Stopword-only query should return empty results"
@@ -714,7 +724,7 @@ mod tests {
         indexer::index_file(&conn, &full, dir.path()).unwrap();
 
         // A meaningful query should still find results
-        let results = search(&conn, "LoRaモジュール", 5, None).unwrap();
+        let results = search(&conn, "LoRaモジュール", 5, None, false).unwrap();
         assert!(!results.is_empty(), "Meaningful query should find results");
     }
 
@@ -737,7 +747,7 @@ mod tests {
         let _ = conn.execute("DELETE FROM dictionary_candidates", []);
 
         // Search should collect query candidates
-        let _ = search(&conn, "candle framework", 5, None);
+        let _ = search(&conn, "candle framework", 5, None, false);
 
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM dictionary_candidates", [], |r| {


### PR DESCRIPTION
## Summary

- `tsm search` now errors by default when the embedder is not running, instead of silently falling back to FTS-only results
- `search_fallback` config option (`"error"` / `"fts_only"`) in `tsm.toml` with env var `TSM_SEARCH_FALLBACK`
- `--fallback fts_only` CLI flag for per-invocation override
- `tsm restart` command (stop + start shortcut)
- `require_vector` propagated into searcher layer to catch stale sockets (crashed embedder)

Closes #47

## Test plan

- [x] 388 tests pass (379 existing + 9 new)
- [ ] Manual: `tsm search -q "test"` with embedder stopped → error exit
- [ ] Manual: `tsm search -q "test" --fallback fts_only` with embedder stopped → FTS results with warning
- [ ] Manual: `search_fallback = "fts_only"` in tsm.toml → FTS fallback
- [ ] Manual: `tsm restart` → stops and starts daemon
- [ ] Manual: `tsm doctor` → shows embedder warning regardless of fallback mode