### PR TITLE
refactor: move backfill orchestration from embedder to tsmd

### DIFF
--- a/.claude/hooks/lint.sh
+++ b/.claude/hooks/lint.sh
@@ -20,4 +20,5 @@ case "$FILE" in
   *.sh)         command -v shellcheck >/dev/null 2>&1 && shellcheck "$FILE" ;;
   *.yml|*.yaml) command -v yamllint >/dev/null 2>&1 && yamllint "$FILE" ;;
   *.toml)       command -v taplo >/dev/null 2>&1 && taplo check "$FILE" ;;
+  *.rs)         command -v cargo >/dev/null 2>&1 && cargo fmt --manifest-path "$CLAUDE_PROJECT_DIR/Cargo.toml" ;;
 esac

--- a/src/bin/tsm_embedder.rs
+++ b/src/bin/tsm_embedder.rs
@@ -1,30 +1,7 @@
 fn main() -> anyhow::Result<()> {
-    let arg = std::env::args_os().nth(1);
-
-    match arg.as_deref().and_then(|a| a.to_str()) {
-        Some("backfill-worker") => {
-            // Dispatched by WorkerHandle::spawn via `tsm-embedder backfill-worker`.
-            // Use stderr logging — the parent's WorkerHandle reads our stderr
-            // and forwards it as [worker] lines to the parent's file logger.
-            // Using Daemon mode here would compete for the same log file and
-            // trigger spurious rotation.
-            the_space_memory::config::ensure_model_cache_env();
-            the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Stderr)?;
-            the_space_memory::cli::cmd_backfill_worker()
-        }
-        None => {
-            // No arguments — start the embedder server.
-            the_space_memory::config::ensure_model_cache_env();
-            the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon {
-                name: "tsm-embedder",
-            })?;
-            the_space_memory::cli::cmd_embedder_start(None)
-        }
-        Some(other) => {
-            eprintln!("tsm-embedder: unknown argument '{other}'");
-            eprintln!("Usage: tsm-embedder                  Start the embedder server");
-            eprintln!("       tsm-embedder backfill-worker   Run as a backfill worker (internal)");
-            std::process::exit(1);
-        }
-    }
+    the_space_memory::config::ensure_model_cache_env();
+    the_space_memory::logging::init_logger(the_space_memory::logging::LogMode::Daemon {
+        name: "tsm-embedder",
+    })?;
+    the_space_memory::cli::cmd_embedder_start(None)
 }

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -510,7 +510,8 @@ fn periodic_backfill(
             conn.query_row(
                 "SELECT COUNT(*) FROM chunks c
                  LEFT JOIN chunks_vec v ON c.id = v.rowid
-                 WHERE v.rowid IS NULL",
+                 LEFT JOIN chunks_vec_skip s ON c.id = s.chunk_id
+                 WHERE v.rowid IS NULL AND s.chunk_id IS NULL",
                 [],
                 |r| r.get(0),
             )
@@ -537,5 +538,30 @@ fn sleep_interruptible(duration: std::time::Duration) {
         let sleep_for = step.min(remaining);
         std::thread::sleep(sleep_for);
         remaining = remaining.saturating_sub(sleep_for);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_search_active_guard_raii() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        assert_eq!(counter.load(Ordering::Acquire), 0);
+
+        {
+            let _guard = SearchActiveGuard::new(&counter);
+            assert_eq!(counter.load(Ordering::Acquire), 1);
+
+            {
+                let _guard2 = SearchActiveGuard::new(&counter);
+                assert_eq!(counter.load(Ordering::Acquire), 2);
+            }
+            // guard2 dropped
+            assert_eq!(counter.load(Ordering::Acquire), 1);
+        }
+        // guard dropped
+        assert_eq!(counter.load(Ordering::Acquire), 0);
     }
 }

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 
 use the_space_memory::config;
 use the_space_memory::daemon;
-use the_space_memory::daemon_protocol::{read_request, DaemonRequest, write_response};
+use the_space_memory::daemon_protocol::{read_request, write_response, DaemonRequest};
 use the_space_memory::db;
 use the_space_memory::status;
 
@@ -234,9 +234,7 @@ fn main() -> Result<()> {
                 let search_active = Arc::clone(&search_active);
 
                 std::thread::spawn(move || {
-                    if let Err(e) =
-                        handle_client(&mut stream, &conn, &index_root, &search_active)
-                    {
+                    if let Err(e) = handle_client(&mut stream, &conn, &index_root, &search_active) {
                         log::warn!("client error: {e}");
                     }
                 });
@@ -421,10 +419,7 @@ fn handle_client(
 
 /// Run one full backfill pass, releasing the DB lock between batches
 /// so search/index requests can proceed.
-fn run_backfill_pass(
-    conn: &Arc<Mutex<rusqlite::Connection>>,
-    search_active: &Arc<AtomicUsize>,
-) {
+fn run_backfill_pass(conn: &Arc<Mutex<rusqlite::Connection>>, search_active: &Arc<AtomicUsize>) {
     let encode_fn = |texts: &[String]| {
         the_space_memory::embedder::embed_via_socket(texts)
             .ok_or_else(|| anyhow::anyhow!("embedder not available"))

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -1,7 +1,7 @@
 use std::os::unix::net::UnixListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
@@ -9,7 +9,7 @@ use clap::Parser;
 
 use the_space_memory::config;
 use the_space_memory::daemon;
-use the_space_memory::daemon_protocol::{read_request, write_response};
+use the_space_memory::daemon_protocol::{read_request, DaemonRequest, write_response};
 use the_space_memory::db;
 use the_space_memory::status;
 
@@ -190,15 +190,53 @@ fn main() -> Result<()> {
         None
     };
 
+    // Search-active counter: backfill yields when search requests are in-flight.
+    let search_active = Arc::new(AtomicUsize::new(0));
+
+    // Startup backfill — waits for embedder socket then runs one pass.
+    if !args.no_embedder {
+        let conn = Arc::clone(&conn);
+        let search_active = Arc::clone(&search_active);
+        std::thread::spawn(move || {
+            let sock = config::embedder_socket_path();
+            for _ in 0..120 {
+                if SHUTDOWN.load(Ordering::SeqCst) || sock.exists() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(500));
+            }
+            if !sock.exists() || SHUTDOWN.load(Ordering::SeqCst) {
+                log::warn!("embedder socket not ready; skipping startup backfill");
+                return;
+            }
+            log::info!("starting startup backfill...");
+            run_backfill_pass(&conn, &search_active);
+            log::info!("startup backfill complete");
+        });
+    }
+
+    // Periodic backfill thread
+    let backfill_interval_secs = config::embedder_backfill_interval_secs();
+    if backfill_interval_secs > 0 && !args.no_embedder {
+        let conn = Arc::clone(&conn);
+        let search_active = Arc::clone(&search_active);
+        std::thread::spawn(move || {
+            periodic_backfill(&conn, &search_active, backfill_interval_secs);
+        });
+    }
+
     // Accept loop — children are NOT restarted on crash
     while !SHUTDOWN.load(Ordering::SeqCst) {
         match listener.accept() {
             Ok((mut stream, _)) => {
                 let conn = Arc::clone(&conn);
                 let index_root = index_root.clone();
+                let search_active = Arc::clone(&search_active);
 
                 std::thread::spawn(move || {
-                    if let Err(e) = handle_client(&mut stream, &conn, &index_root) {
+                    if let Err(e) =
+                        handle_client(&mut stream, &conn, &index_root, &search_active)
+                    {
                         log::warn!("client error: {e}");
                     }
                 });
@@ -338,18 +376,166 @@ fn stop_child(label: &str, child: Option<Child>, pid_path: &Path) {
 
 // ─── Client handling ──────────────────────────────────────────────
 
+/// RAII guard that increments a counter on creation and decrements on drop.
+struct SearchActiveGuard(Arc<AtomicUsize>);
+
+impl SearchActiveGuard {
+    fn new(counter: &Arc<AtomicUsize>) -> Self {
+        counter.fetch_add(1, Ordering::AcqRel);
+        Self(Arc::clone(counter))
+    }
+}
+
+impl Drop for SearchActiveGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
 fn handle_client(
     stream: &mut std::os::unix::net::UnixStream,
     conn: &Arc<Mutex<rusqlite::Connection>>,
     index_root: &std::path::Path,
+    search_active: &Arc<AtomicUsize>,
 ) -> Result<()> {
     stream.set_read_timeout(Some(std::time::Duration::from_secs(30)))?;
     stream.set_write_timeout(Some(std::time::Duration::from_secs(30)))?;
     let req = read_request(stream)?;
+
+    // Track active search requests so backfill can yield
+    let _guard = if matches!(req, DaemonRequest::Search { .. }) {
+        Some(SearchActiveGuard::new(search_active))
+    } else {
+        None
+    };
+
     let conn = conn
         .lock()
         .map_err(|e| anyhow::anyhow!("DB lock poisoned: {e}"))?;
     let resp = daemon::handle_request(&conn, req, index_root, &SHUTDOWN);
     write_response(stream, &resp)?;
     Ok(())
+}
+
+// ─── Backfill orchestration ──────────────────────────────────────────
+
+/// Run one full backfill pass, releasing the DB lock between batches
+/// so search/index requests can proceed.
+fn run_backfill_pass(
+    conn: &Arc<Mutex<rusqlite::Connection>>,
+    search_active: &Arc<AtomicUsize>,
+) {
+    let encode_fn = |texts: &[String]| {
+        the_space_memory::embedder::embed_via_socket(texts)
+            .ok_or_else(|| anyhow::anyhow!("embedder not available"))
+    };
+
+    let mut last_id: i64 = 0;
+    let mut total_filled: usize = 0;
+    let mut total_errors: usize = 0;
+
+    loop {
+        if SHUTDOWN.load(Ordering::SeqCst) {
+            break;
+        }
+
+        // Yield while search requests are in-flight (no lock held)
+        for _ in 0..200 {
+            if search_active.load(Ordering::Acquire) == 0 {
+                break;
+            }
+            if SHUTDOWN.load(Ordering::SeqCst) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        // Lock DB only for this one batch
+        let Ok(conn) = conn.lock() else { break };
+        let result = the_space_memory::indexer::backfill_next_batch(
+            &conn,
+            &encode_fn,
+            config::BACKFILL_BATCH_SIZE,
+            last_id,
+        );
+        drop(conn); // release lock immediately after batch
+
+        match result {
+            Ok((stats, has_more)) => {
+                total_filled += stats.filled;
+                total_errors += stats.errors;
+                last_id = stats.last_id;
+                if !has_more {
+                    break;
+                }
+            }
+            Err(e) => {
+                log::warn!("backfill batch error: {e}");
+                break;
+            }
+        }
+    }
+
+    if total_filled > 0 || total_errors > 0 {
+        log::info!("backfill: {total_filled} filled, {total_errors} errors");
+    }
+}
+
+/// Run periodic backfill in tsmd, yielding to search requests.
+fn periodic_backfill(
+    conn: &Arc<Mutex<rusqlite::Connection>>,
+    search_active: &Arc<AtomicUsize>,
+    interval_secs: u64,
+) {
+    let interval = std::time::Duration::from_secs(interval_secs);
+
+    // Wait one full interval before first check (startup backfill handles the initial run)
+    sleep_interruptible(interval);
+
+    loop {
+        if SHUTDOWN.load(Ordering::SeqCst) {
+            break;
+        }
+
+        let sock = config::embedder_socket_path();
+        if !sock.exists() {
+            log::debug!("periodic backfill: embedder socket not found, skipping");
+            sleep_interruptible(interval);
+            continue;
+        }
+
+        // Quick count check (short lock)
+        let missing: i64 = {
+            let Ok(conn) = conn.lock() else { break };
+            conn.query_row(
+                "SELECT COUNT(*) FROM chunks c
+                 LEFT JOIN chunks_vec v ON c.id = v.rowid
+                 WHERE v.rowid IS NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0)
+        }; // lock released
+
+        if missing > 0 {
+            log::debug!("periodic backfill: {missing} vectors missing");
+            run_backfill_pass(conn, search_active);
+        }
+
+        sleep_interruptible(interval);
+    }
+}
+
+/// Sleep in small increments, checking the shutdown flag.
+fn sleep_interruptible(duration: std::time::Duration) {
+    let step = std::time::Duration::from_secs(10).min(duration);
+    let mut remaining = duration;
+    while remaining > std::time::Duration::ZERO {
+        if SHUTDOWN.load(Ordering::SeqCst) {
+            return;
+        }
+        let sleep_for = step.min(remaining);
+        std::thread::sleep(sleep_for);
+        remaining = remaining.saturating_sub(sleep_for);
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -317,8 +317,7 @@ pub fn run_vector_fill(conn: &rusqlite::Connection, batch_size: usize) -> anyhow
     };
 
     let encode_fn = |texts: &[String]| {
-        embedder::embed_via_socket(texts)
-            .ok_or_else(|| anyhow::anyhow!("embedder not available"))
+        embedder::embed_via_socket(texts).ok_or_else(|| anyhow::anyhow!("embedder not available"))
     };
 
     let stats = indexer::backfill_vectors(conn, &encode_fn, batch_size, Some(&progress_cb))?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -272,52 +272,26 @@ pub fn cmd_embedder_start(socket_path: Option<&Path>) -> anyhow::Result<()> {
 }
 
 pub fn cmd_vector_fill(batch_size: usize) -> anyhow::Result<()> {
-    let db_path = config::db_path();
-    backfill_with_worker_sized(&db_path, batch_size)
-}
-
-pub fn cmd_backfill_worker() -> anyhow::Result<()> {
-    embedder::run_backfill_worker()
-}
-
-/// Guard to prevent concurrent backfill runs (startup + periodic).
-static BACKFILL_RUNNING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-/// RAII guard that resets `BACKFILL_RUNNING` on drop (including panic unwind).
-struct BackfillGuard;
-impl Drop for BackfillGuard {
-    fn drop(&mut self) {
-        BACKFILL_RUNNING.store(false, std::sync::atomic::Ordering::SeqCst);
-    }
-}
-
-/// Run backfill via a worker subprocess with default batch size.
-/// Skips if another backfill is already running in this process.
-pub fn backfill_with_worker(db_path: &Path) -> anyhow::Result<()> {
-    if BACKFILL_RUNNING
-        .compare_exchange(
-            false,
-            true,
-            std::sync::atomic::Ordering::SeqCst,
-            std::sync::atomic::Ordering::SeqCst,
-        )
-        .is_err()
-    {
-        log::info!("Backfill already running, skipping");
+    // Delegate to tsmd if running
+    let sock = config::daemon_socket_path();
+    if sock.exists() {
+        use crate::daemon_protocol::{send_request, DaemonRequest};
+        let resp = send_request(&sock, &DaemonRequest::VectorFill { batch_size })?;
+        if !resp.ok {
+            anyhow::bail!("{}", resp.error.unwrap_or_default());
+        }
         return Ok(());
     }
-    let _guard = BackfillGuard;
-    backfill_with_worker_sized(db_path, indexer::BACKFILL_BATCH_SIZE)
+    // tsmd not running — run directly
+    let db_path = config::db_path();
+    let conn = db::get_connection(&db_path)?;
+    run_vector_fill(&conn, batch_size)
 }
 
-/// Run vector backfill with an existing connection (daemon-safe).
+/// Run vector backfill via the embedder socket (daemon-safe).
 pub fn run_vector_fill(conn: &rusqlite::Connection, batch_size: usize) -> anyhow::Result<()> {
     use crate::status;
 
-    let worker = std::cell::RefCell::new(embedder::WorkerHandle::spawn(
-        std::time::Duration::from_secs(120),
-    )?);
-    let mut restarts = 0;
     let state_dir = config::state_dir();
     let started_at = chrono::Utc::now().to_rfc3339();
 
@@ -342,48 +316,20 @@ pub fn run_vector_fill(conn: &rusqlite::Connection, batch_size: usize) -> anyhow
         });
     };
 
-    loop {
-        let encode_fn = |texts: &[String]| {
-            let timeout = std::time::Duration::from_secs(
-                config::WORKER_ENCODE_TIMEOUT_BASE_SECS
-                    + config::WORKER_ENCODE_TIMEOUT_PER_ITEM_SECS * texts.len() as u64,
-            );
-            worker.borrow_mut().encode(texts, timeout)
-        };
-        let stats = indexer::backfill_vectors(conn, &encode_fn, batch_size, Some(&progress_cb))?;
+    let encode_fn = |texts: &[String]| {
+        embedder::embed_via_socket(texts)
+            .ok_or_else(|| anyhow::anyhow!("embedder not available"))
+    };
 
-        if stats.errors == 0 {
-            if stats.filled > 0 {
-                log::info!("Backfilled {} vectors.", stats.filled);
-            } else {
-                log::info!("No missing vectors.");
-            }
-            break;
-        }
+    let stats = indexer::backfill_vectors(conn, &encode_fn, batch_size, Some(&progress_cb))?;
 
-        // Worker may have crashed — check and restart
-        if !worker.borrow_mut().is_alive() {
-            if restarts >= config::MAX_WORKER_RESTARTS {
-                log::error!(
-                    "Worker crashed {} times. {} errors remain.",
-                    restarts + 1,
-                    stats.errors
-                );
-                break;
-            }
-            restarts += 1;
-            log::warn!(
-                "Worker crashed. Restarting ({restarts}/{})...",
-                config::MAX_WORKER_RESTARTS
-            );
-            *worker.borrow_mut() =
-                embedder::WorkerHandle::spawn(std::time::Duration::from_secs(120))?;
-            // Next iteration will pick up remaining unchunked vectors
-        } else {
-            // Worker alive but had encode errors — don't retry
-            log::info!("Done: {} filled, {} errors.", stats.filled, stats.errors);
-            break;
-        }
+    if stats.filled > 0 {
+        log::info!("Backfilled {} vectors.", stats.filled);
+    } else {
+        log::info!("No missing vectors.");
+    }
+    if stats.errors > 0 {
+        log::warn!("{} errors during backfill.", stats.errors);
     }
 
     // Clear backfill status on completion
@@ -392,12 +338,6 @@ pub fn run_vector_fill(conn: &rusqlite::Connection, batch_size: usize) -> anyhow
     });
 
     Ok(())
-}
-
-/// Run backfill via a worker subprocess with specified batch size (opens DB).
-pub fn backfill_with_worker_sized(db_path: &Path, batch_size: usize) -> anyhow::Result<()> {
-    let conn = db::get_connection(db_path)?;
-    run_vector_fill(&conn, batch_size)
 }
 
 pub fn cmd_import_wordnet(wordnet_db: &Path) -> anyhow::Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,9 +18,6 @@ pub const BACKFILL_BATCH_SIZE: usize = 8;
 pub const MAX_QUERY_EXPANSIONS: usize = 5;
 pub const RECENT_DAYS: i64 = 30;
 pub const DICT_CANDIDATE_FREQ_THRESHOLD: i64 = 5;
-pub const WORKER_ENCODE_TIMEOUT_PER_ITEM_SECS: u64 = 5;
-pub const WORKER_ENCODE_TIMEOUT_BASE_SECS: u64 = 10;
-pub const MAX_WORKER_RESTARTS: usize = 3;
 pub const MIN_QUERY_KEYWORDS: usize = 1;
 
 const DEFAULT_STATE_DIR: &str = ".tsm";

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -1,9 +1,7 @@
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader};
 use std::net::Shutdown;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
-use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -187,20 +185,6 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
     let embedder = Embedder::load(&Device::Cpu)?;
     log::info!("Model loaded.");
 
-    // Backfill via worker subprocess in background (crash-isolated)
-    {
-        let db_path = crate::config::db_path();
-        if db_path.exists() {
-            std::thread::spawn(move || {
-                log::info!("Starting backfill worker...");
-                match crate::cli::backfill_with_worker(&db_path) {
-                    Ok(()) => log::info!("Backfill completed"),
-                    Err(e) => log::warn!("Backfill failed: {e}"),
-                }
-            });
-        }
-    }
-
     // Write embedder status
     crate::status::update(&crate::config::state_dir(), |s| {
         s.embedder = Some(crate::status::EmbedderStatus {
@@ -228,15 +212,6 @@ pub fn run_daemon(socket_path: &Path) -> Result<()> {
         });
     } else {
         log::info!("Idle timeout disabled.");
-    }
-
-    // Periodic backfill thread (skipped when interval is 0)
-    let backfill_interval_secs = config::embedder_backfill_interval_secs();
-    if backfill_interval_secs > 0 {
-        let running = Arc::clone(&running);
-        std::thread::spawn(move || {
-            periodic_backfill(&running, backfill_interval_secs);
-        });
     }
 
     while running.load(Ordering::Relaxed) {
@@ -286,57 +261,6 @@ fn watchdog(
             // Poke the listener to unblock accept
             let _ = UnixStream::connect(socket_path);
             break;
-        }
-    }
-}
-
-fn periodic_backfill(running: &AtomicBool, interval_secs: u64) {
-    let interval = Duration::from_secs(interval_secs);
-    let db_path = crate::config::db_path();
-
-    // Wait one full interval before first check (startup backfill handles the initial run)
-    let mut elapsed = Duration::ZERO;
-    while elapsed < interval {
-        std::thread::sleep(Duration::from_secs(10));
-        if !running.load(Ordering::Relaxed) {
-            return;
-        }
-        elapsed += Duration::from_secs(10);
-    }
-
-    loop {
-        if !running.load(Ordering::Relaxed) {
-            break;
-        }
-
-        if db_path.exists() {
-            if let Ok(conn) = crate::db::get_connection(&db_path) {
-                let chunks: i64 = conn
-                    .query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
-                    .unwrap_or(0);
-                let vecs: i64 = conn
-                    .query_row("SELECT COUNT(*) FROM chunks_vec", [], |r| r.get(0))
-                    .unwrap_or(0);
-                drop(conn);
-
-                if chunks > vecs {
-                    let missing = chunks - vecs;
-                    log::debug!("Periodic backfill: {missing} vectors missing. Starting backfill.");
-                    if let Err(e) = crate::cli::backfill_with_worker(&db_path) {
-                        log::warn!("Periodic backfill warning: {e}");
-                    }
-                }
-            }
-        }
-
-        // Sleep for the next interval (in 10s increments to check running flag)
-        let mut elapsed = Duration::ZERO;
-        while elapsed < interval {
-            std::thread::sleep(Duration::from_secs(10));
-            if !running.load(Ordering::Relaxed) {
-                return;
-            }
-            elapsed += Duration::from_secs(10);
         }
     }
 }
@@ -431,229 +355,6 @@ pub fn embed_via_socket_at(socket_path: &Path, texts: &[String]) -> Option<Vec<V
         .collect();
 
     Some(result)
-}
-
-// ─── Worker subprocess ──────────────────────────────────────────────
-
-/// Handle to a backfill-worker child process.
-/// The child loads the model once and processes encode requests via stdin/stdout pipes.
-/// If the child segfaults, the parent survives and can spawn a new worker.
-pub struct WorkerHandle {
-    child: Child,
-    stdin: std::process::ChildStdin,
-    stdout: Option<BufReader<std::process::ChildStdout>>,
-}
-
-impl WorkerHandle {
-    /// Spawn a new `tsm-embedder backfill-worker` child process.
-    /// Blocks until the child reports "READY" on stderr (with timeout).
-    ///
-    /// Always invokes the `tsm-embedder` sibling binary explicitly instead of
-    /// `current_exe()`, so the caller's identity doesn't matter — this is safe
-    /// to call from tsm, tsmd, or tsm-embedder itself.
-    pub fn spawn(timeout: Duration) -> Result<Self> {
-        let exe_dir = std::env::current_exe()
-            .context("cannot determine executable path")?
-            .parent()
-            .context("executable has no parent directory")?
-            .to_path_buf();
-        let worker_bin = exe_dir.join("tsm-embedder");
-        let mut child = Command::new(&worker_bin)
-            .arg("backfill-worker")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .context("failed to spawn backfill-worker")?;
-
-        let stdin = child.stdin.take().context("no stdin")?;
-        let stdout = BufReader::new(child.stdout.take().context("no stdout")?);
-        let mut stderr = BufReader::new(child.stderr.take().context("no stderr")?);
-
-        // Wait for READY signal on stderr
-        let (tx, rx) = std::sync::mpsc::channel();
-        std::thread::spawn(move || {
-            let mut line = String::new();
-            loop {
-                line.clear();
-                match stderr.read_line(&mut line) {
-                    Ok(0) => break, // EOF
-                    Ok(_) => {
-                        log::info!("[worker] {}", line.trim_end());
-                        if line.trim() == "READY" {
-                            let _ = tx.send(true);
-                            // Continue forwarding stderr
-                            loop {
-                                line.clear();
-                                match stderr.read_line(&mut line) {
-                                    Ok(0) => break,
-                                    Ok(_) => log::info!("[worker] {}", line.trim_end()),
-                                    Err(_) => break,
-                                }
-                            }
-                            break;
-                        }
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-
-        rx.recv_timeout(timeout).map_err(|_| {
-            anyhow::anyhow!("backfill-worker did not become ready within {timeout:?}")
-        })?;
-
-        Ok(Self {
-            child,
-            stdin,
-            stdout: Some(stdout),
-        })
-    }
-
-    /// Send texts and receive embeddings via the pipe protocol.
-    /// Returns Err on timeout or if the child has died.
-    pub fn encode(&mut self, texts: &[String], timeout: Duration) -> Result<Vec<Vec<f32>>> {
-        if self.stdout.is_none() {
-            anyhow::bail!("worker handle is dead (killed after a previous timeout or crash)");
-        }
-
-        let request = serde_json::json!({ "texts": texts });
-        let request_bytes = serde_json::to_vec(&request)?;
-        write_message(&mut self.stdin, &request_bytes)?;
-
-        // Take stdout to move into a reader thread so we can enforce a timeout.
-        let mut stdout = self.stdout.take().unwrap();
-
-        let (tx, rx) = std::sync::mpsc::channel();
-        std::thread::spawn(move || {
-            let result = read_message(&mut stdout);
-            let _ = tx.send((result, stdout));
-        });
-
-        let (read_result, stdout_back) = match rx.recv_timeout(timeout) {
-            Ok(pair) => pair,
-            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                self.kill();
-                anyhow::bail!("worker encode timed out after {timeout:?}");
-            }
-            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                self.kill();
-                anyhow::bail!("worker reader thread died unexpectedly");
-            }
-        };
-
-        self.stdout = Some(stdout_back);
-        let response_data =
-            read_result.context("worker pipe read error (child may have crashed)")?;
-
-        let response: serde_json::Value = serde_json::from_slice(&response_data)?;
-
-        if let Some(err) = response.get("error").and_then(|e| e.as_str()) {
-            anyhow::bail!("worker encode error: {err}");
-        }
-
-        let embeddings = response
-            .get("embeddings")
-            .and_then(|v| v.as_array())
-            .context("missing embeddings in worker response")?;
-
-        let result: Vec<Vec<f32>> = embeddings
-            .iter()
-            .filter_map(|row| {
-                row.as_array().map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_f64().map(|f| f as f32))
-                        .collect()
-                })
-            })
-            .collect();
-
-        Ok(result)
-    }
-
-    /// Check if the child process is still alive.
-    pub fn is_alive(&mut self) -> bool {
-        self.child.try_wait().ok().flatten().is_none()
-    }
-
-    /// Kill the child process and wait.
-    pub fn kill(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
-
-impl Drop for WorkerHandle {
-    fn drop(&mut self) {
-        self.kill();
-    }
-}
-
-/// Entry point for the `tsm backfill-worker` subprocess.
-/// Loads the model, signals READY, then processes encode requests on stdin/stdout.
-pub fn run_backfill_worker() -> Result<()> {
-    log::info!("Loading model...");
-    let embedder = Embedder::load(&Device::Cpu)?;
-    log::info!("Model loaded.");
-    eprintln!("READY"); // IPC protocol signal — must NOT use log macro
-
-    let mut stdin = std::io::stdin().lock();
-    let mut stdout = std::io::stdout().lock();
-
-    loop {
-        let request_data = match read_message(&mut stdin) {
-            Ok(data) => data,
-            Err(_) => break, // stdin closed — parent is done
-        };
-
-        let request: serde_json::Value = match serde_json::from_slice(&request_data) {
-            Ok(v) => v,
-            Err(e) => {
-                let err_resp = serde_json::json!({ "error": format!("invalid request: {e}") });
-                let err_bytes = serde_json::to_vec(&err_resp)?;
-                write_message(&mut stdout, &err_bytes)?;
-                continue;
-            }
-        };
-
-        let texts: Vec<String> = request
-            .get("texts")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let encode_result =
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| embedder.encode(&texts)));
-
-        let response = match encode_result {
-            Ok(Ok(emb)) => serde_json::json!({ "embeddings": emb }),
-            Ok(Err(e)) => {
-                log::error!("Encode error: {e}");
-                serde_json::json!({ "error": format!("{e}") })
-            }
-            Err(panic_info) => {
-                let msg = if let Some(s) = panic_info.downcast_ref::<String>() {
-                    s.clone()
-                } else if let Some(&s) = panic_info.downcast_ref::<&str>() {
-                    s.to_string()
-                } else {
-                    "unknown panic".to_string()
-                };
-                log::error!("PANIC in encode: {msg}");
-                serde_json::json!({ "error": format!("panic: {msg}") })
-            }
-        };
-
-        let response_bytes = serde_json::to_vec(&response)?;
-        write_message(&mut stdout, &response_bytes)?;
-    }
-
-    log::info!("Worker exiting.");
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1419,6 +1419,123 @@ mod tests {
         );
     }
 
+    // ─── backfill_next_batch tests ────────────────────────────
+
+    #[test]
+    fn test_next_batch_empty_db() {
+        let conn = db::get_memory_connection().unwrap();
+        let (stats, has_more) = backfill_next_batch(&conn, &mock_encode, 8, 0).unwrap();
+        assert_eq!(stats.filled, 0);
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn test_next_batch_keyset_pagination() {
+        let (conn, dir) = setup();
+        for i in 0..3 {
+            let md = format!("# Doc {i}\n\nContent for document number {i}.\n");
+            let path = write_md(dir.path(), &format!("daily/notes/test{i}.md"), &md);
+            index_file(&conn, &path, dir.path()).unwrap();
+        }
+        clear_vectors(&conn);
+
+        let chunks: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
+            .unwrap();
+        assert!(chunks >= 3);
+
+        // First batch: batch_size=2
+        let (stats1, has_more1) = backfill_next_batch(&conn, &mock_encode, 2, 0).unwrap();
+        assert_eq!(stats1.filled, 2);
+        assert!(has_more1);
+        assert!(stats1.last_id > 0);
+
+        // Second batch: from last_id
+        let (stats2, has_more2) =
+            backfill_next_batch(&conn, &mock_encode, 2, stats1.last_id).unwrap();
+        assert!(stats2.filled > 0);
+        assert!(stats2.last_id > stats1.last_id);
+
+        // Continue until exhausted
+        let mut last_id = stats2.last_id;
+        loop {
+            let (s, more) = backfill_next_batch(&conn, &mock_encode, 2, last_id).unwrap();
+            if !more {
+                break;
+            }
+            last_id = s.last_id;
+        }
+
+        // All vectors should be filled
+        let vecs: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks_vec", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(vecs, chunks);
+    }
+
+    #[test]
+    fn test_next_batch_encode_error_marks_skip() {
+        let (conn, dir) = setup();
+        let path = write_md(dir.path(), "daily/notes/test.md", "# Hello\n\nContent.\n");
+        index_file(&conn, &path, dir.path()).unwrap();
+        clear_vectors(&conn);
+
+        let (stats, _) = backfill_next_batch(&conn, &mock_encode_fail, 8, 0).unwrap();
+        assert_eq!(stats.filled, 0);
+        assert!(stats.errors > 0);
+
+        // Skip records should be written
+        let skips: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks_vec_skip", [], |r| r.get(0))
+            .unwrap();
+        assert!(skips > 0);
+
+        // Next call should find nothing (skipped chunks excluded)
+        let (stats2, has_more) = backfill_next_batch(&conn, &mock_encode, 8, 0).unwrap();
+        assert_eq!(stats2.filled, 0);
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn test_next_batch_partial_batch() {
+        let (conn, dir) = setup();
+        for i in 0..3 {
+            let md = format!("# Doc {i}\n\nContent for document number {i}.\n");
+            let path = write_md(dir.path(), &format!("daily/notes/test{i}.md"), &md);
+            index_file(&conn, &path, dir.path()).unwrap();
+        }
+        clear_vectors(&conn);
+
+        let chunks: i64 = conn
+            .query_row("SELECT COUNT(*) FROM chunks", [], |r| r.get(0))
+            .unwrap();
+
+        // Use a large batch_size that exceeds total chunks
+        let (stats, has_more) =
+            backfill_next_batch(&conn, &mock_encode, chunks as usize + 10, 0).unwrap();
+        assert_eq!(stats.filled as i64, chunks);
+        assert!(has_more); // non-empty batch always returns has_more=true
+
+        // Next call finds nothing
+        let (stats2, has_more2) =
+            backfill_next_batch(&conn, &mock_encode, chunks as usize + 10, stats.last_id)
+                .unwrap();
+        assert_eq!(stats2.filled, 0);
+        assert!(!has_more2);
+    }
+
+    #[test]
+    fn test_next_batch_catches_panic() {
+        let (conn, dir) = setup();
+        let path = write_md(dir.path(), "daily/notes/test.md", "# Hello\n\nContent.\n");
+        index_file(&conn, &path, dir.path()).unwrap();
+        clear_vectors(&conn);
+
+        let (stats, _) = backfill_next_batch(&conn, &mock_encode_panic, 8, 0).unwrap();
+        assert!(stats.panics > 0);
+        assert!(stats.errors > 0);
+    }
+
     // ─── entity integration tests ────────────────────────────
 
     #[test]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1518,8 +1518,7 @@ mod tests {
 
         // Next call finds nothing
         let (stats2, has_more2) =
-            backfill_next_batch(&conn, &mock_encode, chunks as usize + 10, stats.last_id)
-                .unwrap();
+            backfill_next_batch(&conn, &mock_encode, chunks as usize + 10, stats.last_id).unwrap();
         assert_eq!(stats2.filled, 0);
         assert!(!has_more2);
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -27,6 +27,8 @@ pub struct BackfillStats {
     pub filled: usize,
     pub errors: usize,
     pub panics: usize,
+    /// Keyset pagination cursor (last processed chunk ID).
+    pub last_id: i64,
 }
 
 fn file_hash(path: &Path) -> anyhow::Result<String> {
@@ -690,6 +692,103 @@ fn retry_individually(
             }
         }
     }
+}
+
+/// Process one batch of missing vectors. Returns (stats, has_more).
+/// `last_id` is the keyset pagination cursor — pass 0 for the first call,
+/// then pass the returned `stats.last_id` for subsequent calls.
+pub fn backfill_next_batch(
+    conn: &Connection,
+    encode_fn: EncodeFn,
+    batch_size: usize,
+    last_id: i64,
+) -> anyhow::Result<(BackfillStats, bool)> {
+    if !db::has_vec_table(conn) {
+        return Ok((BackfillStats::default(), false));
+    }
+
+    let batch: Vec<(i64, String, String)> = conn
+        .prepare(
+            "SELECT c.id, c.content, d.file_path
+             FROM chunks c
+             LEFT JOIN chunks_vec v ON c.id = v.rowid
+             LEFT JOIN chunks_vec_skip s ON c.id = s.chunk_id
+             JOIN documents d ON c.document_id = d.id
+             WHERE v.rowid IS NULL AND s.chunk_id IS NULL AND c.id > ?
+             ORDER BY c.id
+             LIMIT ?",
+        )?
+        .query_map(rusqlite::params![last_id, batch_size as i64], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    if batch.is_empty() {
+        return Ok((BackfillStats::default(), false));
+    }
+
+    let mut stats = BackfillStats {
+        last_id: batch.last().unwrap().0,
+        ..BackfillStats::default()
+    };
+
+    let texts: Vec<String> = batch
+        .iter()
+        .map(|(_, content, _)| content.clone())
+        .collect();
+
+    match catch_unwind(AssertUnwindSafe(|| encode_fn(&texts))) {
+        Ok(Ok(embeddings)) if embeddings.len() == batch.len() => {
+            let tx = conn.unchecked_transaction()?;
+            for ((chunk_id, _, _), emb) in batch.iter().zip(embeddings.iter()) {
+                if write_vec_row(&tx, *chunk_id, emb) {
+                    stats.filled += 1;
+                } else {
+                    log::warn!("Insert error for chunk {chunk_id} — skipping");
+                    mark_chunk_skip(conn, *chunk_id, "insert_error");
+                    stats.errors += 1;
+                }
+            }
+            tx.commit()?;
+        }
+        Ok(Ok(embeddings)) => {
+            log::warn!(
+                "Embedding count mismatch (got {}, expected {})",
+                embeddings.len(),
+                batch.len()
+            );
+            if batch.len() > 1 {
+                retry_individually(&batch, encode_fn, conn, &mut stats);
+            } else {
+                let chunk_id = batch[0].0;
+                mark_chunk_skip(conn, chunk_id, "embedding_count_mismatch");
+                stats.errors += 1;
+            }
+        }
+        Ok(Err(e)) => {
+            log::warn!("Batch error: {e}");
+            if batch.len() > 1 {
+                retry_individually(&batch, encode_fn, conn, &mut stats);
+            } else {
+                mark_chunk_skip(conn, batch[0].0, "encode_error");
+                stats.errors += 1;
+            }
+        }
+        Err(panic_info) => {
+            let msg = panic_message(&panic_info);
+            log::error!("PANIC in encode: {msg}");
+            stats.panics += 1;
+            if batch.len() > 1 {
+                retry_individually(&batch, encode_fn, conn, &mut stats);
+            } else {
+                mark_chunk_skip(conn, batch[0].0, "panic");
+                stats.errors += 1;
+            }
+        }
+    }
+
+    Ok((stats, true))
 }
 
 /// Fill in missing vectors for chunks that have FTS5 entries but no vector entries.

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,9 +139,6 @@ enum Commands {
     },
     /// Restart the daemon (stop + start)
     Restart,
-    /// Internal: backfill worker subprocess (do not call directly)
-    #[command(hide = true)]
-    BackfillWorker,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -158,7 +155,6 @@ fn main() -> anyhow::Result<()> {
             cmd_start()?;
         }
         Commands::Setup => cli::cmd_setup()?,
-        Commands::BackfillWorker => cli::cmd_backfill_worker()?,
         Commands::VectorFill { batch_size } => cli::cmd_vector_fill(batch_size)?,
 
         // ── Direct-only with daemon guard ──


### PR DESCRIPTION
## Summary

- DB アクセスを tsm-embedder から tsmd に集約し、embedder を純粋な encode サーバーに変更
- tsmd が startup / periodic backfill をオーケストレーション（バッチ間で DB lock を解放）
- `search_active` カウンタ + RAII ガードで検索リクエストを優先（backfill が yield）
- `WorkerHandle`, `run_backfill_worker`, `backfill-worker` サブコマンドを完全削除
- `tsm vector-fill` はデーモン起動中なら tsmd に委譲

## Motivation

- SQLite 書き込みロック競合リスクの解消（#44 で修正した fork bomb の根本原因）
- embedder のステートレス化（テスト・デプロイが容易に）
- backfill-worker の fork 管理不要化（プロセス管理の複雑さ大幅削減）

## Key Design Decisions

- **バッチ間 DB lock 解放**: `backfill_next_batch` API で 1 バッチずつ処理、バッチ間で lock を解放して search/index が割り込める
- **search_active 協調 yield**: backfill は各バッチの前に `search_active` カウンタをチェックし、検索中は最大 10s yield
- **embedder socket 統一**: backfill も検索と同じ embedder socket 経由で encode（モデル二重ロードを排除）

## Changes

| File | Change |
|---|---|
| `embedder.rs` | startup/periodic backfill, WorkerHandle, run_backfill_worker 削除 (-299 lines) |
| `bin/tsmd.rs` | search_active, run_backfill_pass, periodic_backfill 追加 (+192 lines) |
| `indexer.rs` | `backfill_next_batch` API 追加, BackfillStats に last_id (+99 lines) |
| `cli.rs` | run_vector_fill を socket 版に書き換え, backfill_with_worker* 削除 |
| `bin/tsm_embedder.rs` | backfill-worker arm 削除（純粋サーバー起動のみ） |
| `main.rs` | BackfillWorker コマンド削除 |
| `config.rs` | 不要定数 WORKER_ENCODE_TIMEOUT_*, MAX_WORKER_RESTARTS 削除 |

## Test plan

- [x] `cargo test` — 388 テスト全通過
- [x] `cargo clippy` — warning なし
- [ ] `tsm start` → `tsm status` でバックフィルが動くことを確認
- [ ] バックフィル中に `tsm search` が即座に応答することを確認
- [ ] `tsm vector-fill` がデーモン経由で正常動作することを確認

Closes #45