### PR TITLE
feat: make content_dirs configurable via tsm.toml

### DIFF
--- a/src/bin/tsm_watcher.rs
+++ b/src/bin/tsm_watcher.rs
@@ -66,8 +66,7 @@ fn main() -> Result<()> {
 
     // Watch content directories
     let mut watched = 0;
-    for &(dir, _) in config::CONTENT_DIRS {
-        let full_dir = index_root.join(dir);
+    for full_dir in the_space_memory::cli::discover_watch_dirs(&index_root) {
         if full_dir.is_dir() {
             if let Err(e) = debouncer
                 .watcher()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,9 +58,11 @@ pub fn read_paths_from_stdin(index_root: &Path) -> Vec<PathBuf> {
 pub fn collect_content_files(index_root: &Path) -> Vec<PathBuf> {
     let dirs = config::content_dirs();
     if dirs.is_empty() {
-        // Auto-discover: recursively find all .md files, excluding hidden dirs
+        // Auto-discover: recursively find .md in non-hidden subdirs of index_root
         let mut files = Vec::new();
-        collect_md_files_excluding_hidden(index_root, &mut files);
+        for subdir in discover_subdirs(index_root) {
+            collect_md_files_excluding_hidden(&subdir, &mut files);
+        }
         files
     } else {
         let mut files = Vec::new();
@@ -68,6 +70,12 @@ pub fn collect_content_files(index_root: &Path) -> Vec<PathBuf> {
             let full_dir = index_root.join(&dir.path);
             if full_dir.is_dir() {
                 collect_md_files(&full_dir, &mut files);
+            } else {
+                log::warn!(
+                    "content_dir '{}' not found at {}; skipping",
+                    dir.path,
+                    full_dir.display()
+                );
             }
         }
         files
@@ -77,9 +85,19 @@ pub fn collect_content_files(index_root: &Path) -> Vec<PathBuf> {
 fn collect_md_files_excluding_hidden(dir: &Path, out: &mut Vec<PathBuf>) {
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
-        Err(_) => return,
+        Err(e) => {
+            log::warn!("cannot read directory {}: {e}", dir.display());
+            return;
+        }
     };
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                log::warn!("cannot read entry in {}: {e}", dir.display());
+                continue;
+            }
+        };
         let path = entry.path();
         if path.is_dir() {
             let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
@@ -93,15 +111,25 @@ fn collect_md_files_excluding_hidden(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-/// List directories to watch (for tsm-watcher). When content_dirs is configured,
-/// returns those paths. Otherwise discovers non-hidden subdirs under index_root.
-pub fn discover_watch_dirs(index_root: &Path) -> Vec<PathBuf> {
-    let dirs = config::content_dirs();
-    if dirs.is_empty() {
-        // Auto-discover: immediate non-hidden subdirectories
-        let mut result = Vec::new();
-        if let Ok(entries) = std::fs::read_dir(index_root) {
-            for entry in entries.flatten() {
+/// Discover immediate non-hidden subdirectories of a directory.
+fn discover_subdirs(dir: &Path) -> Vec<PathBuf> {
+    let mut result = Vec::new();
+    match std::fs::read_dir(dir) {
+        Err(e) => {
+            log::warn!(
+                "cannot read {}: {e}; no subdirectories discovered",
+                dir.display()
+            );
+        }
+        Ok(entries) => {
+            for entry in entries {
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(e) => {
+                        log::warn!("cannot read entry in {}: {e}", dir.display());
+                        continue;
+                    }
+                };
                 let path = entry.path();
                 if path.is_dir() {
                     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
@@ -111,9 +139,31 @@ pub fn discover_watch_dirs(index_root: &Path) -> Vec<PathBuf> {
                 }
             }
         }
-        result
+    }
+    result
+}
+
+/// List directories to watch (for tsm-watcher). When content_dirs is configured,
+/// returns those paths. Otherwise discovers non-hidden subdirs under index_root.
+pub fn discover_watch_dirs(index_root: &Path) -> Vec<PathBuf> {
+    let dirs = config::content_dirs();
+    if dirs.is_empty() {
+        discover_subdirs(index_root)
     } else {
-        dirs.iter().map(|d| index_root.join(&d.path)).collect()
+        let mut result = Vec::new();
+        for dir in dirs {
+            let full_dir = index_root.join(&dir.path);
+            if full_dir.is_dir() {
+                result.push(full_dir);
+            } else {
+                log::warn!(
+                    "content_dir '{}' not found at {}; will not be watched",
+                    dir.path,
+                    full_dir.display()
+                );
+            }
+        }
+        result
     }
 }
 
@@ -1596,5 +1646,44 @@ mod tests {
         assert_eq!(parsed["issue_count"], 0);
         assert_eq!(parsed["sections"][0]["name"], "Test");
         assert_eq!(parsed["sections"][0]["items"][0]["status"], "ok");
+    }
+
+    #[test]
+    fn test_discover_subdirs_excludes_hidden() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join("visible")).unwrap();
+        std::fs::create_dir(dir.path().join(".hidden")).unwrap();
+        std::fs::create_dir(dir.path().join("another")).unwrap();
+
+        let dirs = super::discover_subdirs(dir.path());
+        let names: Vec<&str> = dirs
+            .iter()
+            .filter_map(|p| p.file_name().and_then(|n| n.to_str()))
+            .collect();
+        assert!(names.contains(&"visible"));
+        assert!(names.contains(&"another"));
+        assert!(!names.contains(&".hidden"));
+    }
+
+    #[test]
+    fn test_collect_md_files_excluding_hidden() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let visible = dir.path().join("visible");
+        std::fs::create_dir(&visible).unwrap();
+        std::fs::write(visible.join("note.md"), "# Note").unwrap();
+
+        let hidden = dir.path().join(".hidden");
+        std::fs::create_dir(&hidden).unwrap();
+        std::fs::write(hidden.join("secret.md"), "# Secret").unwrap();
+
+        let mut files = Vec::new();
+        super::collect_md_files_excluding_hidden(dir.path(), &mut files);
+
+        let names: Vec<&str> = files
+            .iter()
+            .filter_map(|p| p.file_name().and_then(|n| n.to_str()))
+            .collect();
+        assert!(names.contains(&"note.md"));
+        assert!(!names.contains(&"secret.md"));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,15 +56,65 @@ pub fn read_paths_from_stdin(index_root: &Path) -> Vec<PathBuf> {
 }
 
 pub fn collect_content_files(index_root: &Path) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    for &(dir, _) in config::CONTENT_DIRS {
-        let full_dir = index_root.join(dir);
-        if !full_dir.is_dir() {
-            continue;
+    let dirs = config::content_dirs();
+    if dirs.is_empty() {
+        // Auto-discover: recursively find all .md files, excluding hidden dirs
+        let mut files = Vec::new();
+        collect_md_files_excluding_hidden(index_root, &mut files);
+        files
+    } else {
+        let mut files = Vec::new();
+        for dir in dirs {
+            let full_dir = index_root.join(&dir.path);
+            if full_dir.is_dir() {
+                collect_md_files(&full_dir, &mut files);
+            }
         }
-        collect_md_files(&full_dir, &mut files);
+        files
     }
-    files
+}
+
+fn collect_md_files_excluding_hidden(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if name.starts_with('.') {
+                continue;
+            }
+            collect_md_files_excluding_hidden(&path, out);
+        } else if path.extension().is_some_and(|e| e == "md") {
+            out.push(path);
+        }
+    }
+}
+
+/// List directories to watch (for tsm-watcher). When content_dirs is configured,
+/// returns those paths. Otherwise discovers non-hidden subdirs under index_root.
+pub fn discover_watch_dirs(index_root: &Path) -> Vec<PathBuf> {
+    let dirs = config::content_dirs();
+    if dirs.is_empty() {
+        // Auto-discover: immediate non-hidden subdirectories
+        let mut result = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(index_root) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    if !name.starts_with('.') {
+                        result.push(path);
+                    }
+                }
+            }
+        }
+        result
+    } else {
+        dirs.iter().map(|d| index_root.join(&d.path)).collect()
+    }
 }
 
 pub fn collect_md_files(dir: &Path, out: &mut Vec<PathBuf>) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,24 +74,42 @@ impl std::str::FromStr for SearchFallback {
     }
 }
 
-/// Content directories with score weights. (directory, weight)
-pub const CONTENT_DIRS: &[(&str, f64)] = &[
-    // daily
-    ("daily/notes", 1.0),
-    ("daily/daily/research", 1.1),
-    ("daily/daily/intel", 0.7),
-    // company
-    ("company/knowledge", 1.3),
-    ("company/ideas", 0.9),
-    ("company/updates", 0.8),
-    ("company/research", 1.2),
-    ("company/products", 1.2),
-    ("company/decisions", 1.1),
-    ("company/retrospectives", 0.9),
-];
-pub const SESSION_WEIGHT: f64 = 0.3;
+const DEFAULT_SESSION_WEIGHT: f64 = 0.3;
+const DEFAULT_SESSION_HALF_LIFE_DAYS: f64 = 30.0;
 
 // ─── Config struct ───────────────────────────────────────────────
+
+/// A content directory entry as written in tsm.toml.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub(crate) struct ContentDirConfig {
+    pub path: String,
+    pub weight: Option<f64>,
+    pub half_life_days: Option<f64>,
+}
+
+/// A content directory entry with all values resolved.
+#[derive(Debug, Clone)]
+pub struct ContentDir {
+    pub path: String,
+    pub weight: f64,
+    pub half_life_days: f64,
+}
+
+/// Claude session scoring config as written in tsm.toml.
+#[derive(Debug, Default, Clone, serde::Deserialize)]
+#[serde(default)]
+pub(crate) struct ClaudeSessionConfig {
+    pub weight: Option<f64>,
+    pub half_life_days: Option<f64>,
+}
+
+/// The `[index]` section of tsm.toml.
+#[derive(Debug, Default, Clone, serde::Deserialize)]
+#[serde(default)]
+pub(crate) struct IndexConfig {
+    pub content_dirs: Vec<ContentDirConfig>,
+    pub claude_session: ClaudeSessionConfig,
+}
 
 /// Shape of tsm.toml — all fields optional for partial config files.
 #[derive(Debug, Default, serde::Deserialize)]
@@ -105,6 +123,8 @@ pub(crate) struct ConfigFile {
     embedder_idle_timeout_secs: Option<u64>,
     embedder_backfill_interval_secs: Option<u64>,
     search_fallback: Option<SearchFallback>,
+    #[serde(default)]
+    index: IndexConfig,
 }
 
 /// Fully resolved configuration — all values determined at startup.
@@ -153,6 +173,16 @@ pub struct ResolvedConfig {
     /// Default: `Error` (refuse to search without vector search).
     /// Env: `TSM_SEARCH_FALLBACK`. Config: `search_fallback`.
     pub search_fallback: SearchFallback,
+
+    /// Content directories with scoring weights and half-life.
+    /// Empty = auto-discover mode (recursively index all .md under index_root).
+    pub content_dirs: Vec<ContentDir>,
+
+    /// Score weight for Claude Code session data.
+    pub session_weight: f64,
+
+    /// Half-life in days for Claude Code session data time decay.
+    pub session_half_life_days: f64,
 }
 
 impl ResolvedConfig {
@@ -197,6 +227,29 @@ impl ResolvedConfig {
 
         let search_fallback = env_parse_fallback(file_cfg.search_fallback);
 
+        let content_dirs = file_cfg
+            .index
+            .content_dirs
+            .iter()
+            .map(|c| ContentDir {
+                path: c.path.clone(),
+                weight: c.weight.unwrap_or(1.0),
+                half_life_days: c.half_life_days.unwrap_or(DEFAULT_HALF_LIFE_DAYS),
+            })
+            .collect();
+
+        let session_weight = file_cfg
+            .index
+            .claude_session
+            .weight
+            .unwrap_or(DEFAULT_SESSION_WEIGHT);
+
+        let session_half_life_days = file_cfg
+            .index
+            .claude_session
+            .half_life_days
+            .unwrap_or(DEFAULT_SESSION_HALF_LIFE_DAYS);
+
         Self {
             state_dir,
             index_root,
@@ -206,6 +259,9 @@ impl ResolvedConfig {
             embedder_idle_timeout_secs,
             embedder_backfill_interval_secs,
             search_fallback,
+            content_dirs,
+            session_weight,
+            session_half_life_days,
         }
     }
 }
@@ -287,6 +343,19 @@ fn load_config_from(candidates: &[PathBuf]) -> ConfigFile {
             .embedder_backfill_interval_secs
             .or(file.embedder_backfill_interval_secs);
         merged.search_fallback = merged.search_fallback.or(file.search_fallback);
+        if merged.index.content_dirs.is_empty() {
+            merged.index.content_dirs = file.index.content_dirs;
+        }
+        merged.index.claude_session.weight = merged
+            .index
+            .claude_session
+            .weight
+            .or(file.index.claude_session.weight);
+        merged.index.claude_session.half_life_days = merged
+            .index
+            .claude_session
+            .half_life_days
+            .or(file.index.claude_session.half_life_days);
     }
     merged
 }
@@ -335,6 +404,18 @@ pub fn embedder_backfill_interval_secs() -> u64 {
 
 pub fn search_fallback() -> SearchFallback {
     resolved().search_fallback
+}
+
+pub fn content_dirs() -> &'static [ContentDir] {
+    &resolved().content_dirs
+}
+
+pub fn session_weight() -> f64 {
+    resolved().session_weight
+}
+
+pub fn session_half_life_days() -> f64 {
+    resolved().session_half_life_days
 }
 
 // ─── Derived paths ───────────────────────────────────────────────
@@ -400,7 +481,24 @@ pub fn status_penalty(status: Option<&str>) -> f64 {
     }
 }
 
-pub fn half_life_days(source_type: &str) -> f64 {
+/// Half-life in days, resolved from content_dirs config by file path prefix.
+/// Falls back to source_type-based defaults when content_dirs is empty or unmatched.
+pub fn half_life_days(file_path: &str, source_type: &str) -> f64 {
+    if file_path.starts_with("session:") {
+        return resolved().session_half_life_days;
+    }
+    for dir in &resolved().content_dirs {
+        if file_path.starts_with(dir.path.as_str())
+            && file_path.as_bytes().get(dir.path.len()) == Some(&b'/')
+        {
+            return dir.half_life_days;
+        }
+    }
+    half_life_days_by_source_type(source_type)
+}
+
+/// Default half-life by source_type (used when content_dirs is empty or unmatched).
+fn half_life_days_by_source_type(source_type: &str) -> f64 {
     match source_type {
         "note" => 120.0,
         "research" => 60.0,
@@ -429,11 +527,13 @@ pub fn source_type_from_dir(directory: &str) -> String {
 /// Score weight based on directory prefix of file_path.
 pub fn directory_weight(file_path: &str) -> f64 {
     if file_path.starts_with("session:") {
-        return SESSION_WEIGHT;
+        return resolved().session_weight;
     }
-    for &(dir, weight) in CONTENT_DIRS {
-        if file_path.starts_with(dir) && file_path.as_bytes().get(dir.len()) == Some(&b'/') {
-            return weight;
+    for dir in &resolved().content_dirs {
+        if file_path.starts_with(dir.path.as_str())
+            && file_path.as_bytes().get(dir.path.len()) == Some(&b'/')
+        {
+            return dir.weight;
         }
     }
     1.0
@@ -455,11 +555,6 @@ mod tests {
     }
 
     // ─── Constants ──────────────────────────────────────────────────
-
-    #[test]
-    fn test_content_dirs_count() {
-        assert_eq!(CONTENT_DIRS.len(), 10);
-    }
 
     #[test]
     fn test_constants() {
@@ -652,40 +747,16 @@ index_root = "/low-root"
     // ─── Pure functions ─────────────────────────────────────────────
 
     #[test]
-    fn test_directory_weight_known() {
-        assert_eq!(directory_weight("company/knowledge/foo.md"), 1.3);
-        assert_eq!(directory_weight("daily/daily/intel/2026-01.md"), 0.7);
-        assert_eq!(directory_weight("company/products/ks.md"), 1.2);
-        assert_eq!(directory_weight("daily/notes/test.md"), 1.0);
-    }
-
-    #[test]
-    fn test_directory_weight_session() {
-        assert_eq!(directory_weight("session:abc123"), SESSION_WEIGHT);
-    }
-
-    #[test]
     fn test_directory_weight_unknown() {
+        // With no content_dirs configured, everything falls through to 1.0
         assert_eq!(directory_weight("unknown/path/file.md"), 1.0);
     }
 
     #[test]
-    fn test_directory_weight_boundary() {
-        assert_eq!(directory_weight("daily/notes_extra/foo.md"), 1.0);
-    }
-
-    #[test]
-    fn test_no_prefix_shadowing() {
-        for (i, &(a, _)) in CONTENT_DIRS.iter().enumerate() {
-            for (j, &(b, _)) in CONTENT_DIRS.iter().enumerate() {
-                if i != j {
-                    assert!(
-                        !b.starts_with(a) || !a.starts_with(b),
-                        "CONTENT_DIRS[{i}]=\"{a}\" and [{j}]=\"{b}\" overlap — reorder longest-first"
-                    );
-                }
-            }
-        }
+    fn test_directory_weight_session() {
+        // session weight uses the default
+        let w = directory_weight("session:abc123");
+        assert!(w > 0.0 && w < 1.0);
     }
 
     #[test]
@@ -699,11 +770,18 @@ index_root = "/low-root"
     }
 
     #[test]
-    fn test_half_life_days_values() {
-        assert_eq!(half_life_days("note"), 120.0);
-        assert_eq!(half_life_days("research"), 60.0);
-        assert_eq!(half_life_days("session"), 30.0);
-        assert_eq!(half_life_days("unknown"), DEFAULT_HALF_LIFE_DAYS);
+    fn test_half_life_days_fallback() {
+        // No content_dirs configured → falls back to source_type-based defaults
+        assert_eq!(half_life_days("daily/notes/test.md", "note"), 120.0);
+        assert_eq!(half_life_days("daily/research/r.md", "research"), 60.0);
+        assert_eq!(
+            half_life_days("session:abc", "session"),
+            DEFAULT_SESSION_HALF_LIFE_DAYS
+        );
+        assert_eq!(
+            half_life_days("unknown/path.md", "unknown"),
+            DEFAULT_HALF_LIFE_DAYS
+        );
     }
 
     #[test]
@@ -893,5 +971,64 @@ index_root = "/low-root"
         std::env::remove_var("TSM_SEARCH_FALLBACK");
         // Invalid env → falls back to config file value
         assert_eq!(cfg.search_fallback, SearchFallback::FtsOnly);
+    }
+
+    // ─── content_dirs config ────────────────────────────────────────
+
+    #[test]
+    fn test_content_dirs_from_toml() {
+        let cfg = resolved_from_toml(
+            r#"
+[[index.content_dirs]]
+path = "daily/notes"
+weight = 1.2
+half_life_days = 120
+
+[[index.content_dirs]]
+path = "company/knowledge"
+weight = 1.3
+"#,
+        );
+        assert_eq!(cfg.content_dirs.len(), 2);
+        assert_eq!(cfg.content_dirs[0].path, "daily/notes");
+        assert_eq!(cfg.content_dirs[0].weight, 1.2);
+        assert_eq!(cfg.content_dirs[0].half_life_days, 120.0);
+        assert_eq!(cfg.content_dirs[1].path, "company/knowledge");
+        assert_eq!(cfg.content_dirs[1].weight, 1.3);
+        assert_eq!(cfg.content_dirs[1].half_life_days, DEFAULT_HALF_LIFE_DAYS);
+    }
+
+    #[test]
+    fn test_content_dirs_defaults_empty() {
+        let cfg = resolved_from_toml("");
+        assert!(cfg.content_dirs.is_empty());
+        assert_eq!(cfg.session_weight, DEFAULT_SESSION_WEIGHT);
+        assert_eq!(cfg.session_half_life_days, DEFAULT_SESSION_HALF_LIFE_DAYS);
+    }
+
+    #[test]
+    fn test_claude_session_from_toml() {
+        let cfg = resolved_from_toml(
+            r#"
+[index.claude_session]
+weight = 0.5
+half_life_days = 14
+"#,
+        );
+        assert_eq!(cfg.session_weight, 0.5);
+        assert_eq!(cfg.session_half_life_days, 14.0);
+    }
+
+    #[test]
+    fn test_content_dirs_weight_defaults() {
+        let cfg = resolved_from_toml(
+            r#"
+[[index.content_dirs]]
+path = "daily/notes"
+"#,
+        );
+        assert_eq!(cfg.content_dirs.len(), 1);
+        assert_eq!(cfg.content_dirs[0].weight, 1.0);
+        assert_eq!(cfg.content_dirs[0].half_life_days, DEFAULT_HALF_LIFE_DAYS);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -227,16 +227,53 @@ impl ResolvedConfig {
 
         let search_fallback = env_parse_fallback(file_cfg.search_fallback);
 
-        let content_dirs = file_cfg
+        let mut content_dirs: Vec<ContentDir> = file_cfg
             .index
             .content_dirs
             .iter()
-            .map(|c| ContentDir {
-                path: c.path.clone(),
-                weight: c.weight.unwrap_or(1.0),
-                half_life_days: c.half_life_days.unwrap_or(DEFAULT_HALF_LIFE_DAYS),
+            .filter_map(|c| {
+                if c.path.is_empty() {
+                    log::warn!("content_dirs entry has empty path; skipping");
+                    return None;
+                }
+                if std::path::Path::new(&c.path).is_absolute() {
+                    log::warn!(
+                        "content_dirs entry '{}' is absolute; paths must be relative to index_root",
+                        c.path
+                    );
+                    return None;
+                }
+                let weight = c.weight.unwrap_or(1.0);
+                if !weight.is_finite() || weight <= 0.0 {
+                    log::warn!(
+                        "content_dirs '{}': weight {weight} is invalid; using 1.0",
+                        c.path
+                    );
+                }
+                let half_life = c.half_life_days.unwrap_or(DEFAULT_HALF_LIFE_DAYS);
+                if !half_life.is_finite() || half_life <= 0.0 {
+                    log::warn!(
+                        "content_dirs '{}': half_life_days {half_life} is invalid; using {DEFAULT_HALF_LIFE_DAYS}",
+                        c.path
+                    );
+                }
+                Some(ContentDir {
+                    path: c.path.clone(),
+                    weight: if weight.is_finite() && weight > 0.0 {
+                        weight
+                    } else {
+                        1.0
+                    },
+                    half_life_days: if half_life.is_finite() && half_life > 0.0 {
+                        half_life
+                    } else {
+                        DEFAULT_HALF_LIFE_DAYS
+                    },
+                })
             })
             .collect();
+        // Sort longest-first so more-specific paths match before shorter prefixes
+        content_dirs.sort_by(|a, b| b.path.len().cmp(&a.path.len()));
 
         let session_weight = file_cfg
             .index
@@ -754,9 +791,7 @@ index_root = "/low-root"
 
     #[test]
     fn test_directory_weight_session() {
-        // session weight uses the default
-        let w = directory_weight("session:abc123");
-        assert!(w > 0.0 && w < 1.0);
+        assert_eq!(directory_weight("session:abc123"), DEFAULT_SESSION_WEIGHT);
     }
 
     #[test]
@@ -990,12 +1025,13 @@ weight = 1.3
 "#,
         );
         assert_eq!(cfg.content_dirs.len(), 2);
-        assert_eq!(cfg.content_dirs[0].path, "daily/notes");
-        assert_eq!(cfg.content_dirs[0].weight, 1.2);
-        assert_eq!(cfg.content_dirs[0].half_life_days, 120.0);
-        assert_eq!(cfg.content_dirs[1].path, "company/knowledge");
-        assert_eq!(cfg.content_dirs[1].weight, 1.3);
-        assert_eq!(cfg.content_dirs[1].half_life_days, DEFAULT_HALF_LIFE_DAYS);
+        // Sorted longest-first: "company/knowledge" (19) > "daily/notes" (11)
+        assert_eq!(cfg.content_dirs[0].path, "company/knowledge");
+        assert_eq!(cfg.content_dirs[0].weight, 1.3);
+        assert_eq!(cfg.content_dirs[0].half_life_days, DEFAULT_HALF_LIFE_DAYS);
+        assert_eq!(cfg.content_dirs[1].path, "daily/notes");
+        assert_eq!(cfg.content_dirs[1].weight, 1.2);
+        assert_eq!(cfg.content_dirs[1].half_life_days, 120.0);
     }
 
     #[test]
@@ -1030,5 +1066,136 @@ path = "daily/notes"
         assert_eq!(cfg.content_dirs.len(), 1);
         assert_eq!(cfg.content_dirs[0].weight, 1.0);
         assert_eq!(cfg.content_dirs[0].half_life_days, DEFAULT_HALF_LIFE_DAYS);
+    }
+
+    #[test]
+    fn test_content_dirs_prefix_specificity() {
+        // More-specific path should match before shorter prefix
+        let cfg = resolved_from_toml(
+            r#"
+[[index.content_dirs]]
+path = "company"
+weight = 1.0
+
+[[index.content_dirs]]
+path = "company/knowledge"
+weight = 1.5
+"#,
+        );
+        // Sorted longest-first
+        assert_eq!(cfg.content_dirs[0].path, "company/knowledge");
+        assert_eq!(cfg.content_dirs[1].path, "company");
+    }
+
+    #[test]
+    fn test_content_dirs_validation_empty_path_skipped() {
+        let cfg = resolved_from_toml(
+            r#"
+[[index.content_dirs]]
+path = ""
+
+[[index.content_dirs]]
+path = "daily/notes"
+"#,
+        );
+        assert_eq!(cfg.content_dirs.len(), 1);
+        assert_eq!(cfg.content_dirs[0].path, "daily/notes");
+    }
+
+    #[test]
+    fn test_content_dirs_validation_absolute_path_skipped() {
+        let cfg = resolved_from_toml(
+            r#"
+[[index.content_dirs]]
+path = "/etc/passwd"
+
+[[index.content_dirs]]
+path = "daily/notes"
+"#,
+        );
+        assert_eq!(cfg.content_dirs.len(), 1);
+        assert_eq!(cfg.content_dirs[0].path, "daily/notes");
+    }
+
+    #[test]
+    fn test_content_dirs_validation_negative_weight_clamped() {
+        let cfg = resolved_from_toml(
+            r#"
+[[index.content_dirs]]
+path = "daily/notes"
+weight = -1.0
+"#,
+        );
+        assert_eq!(cfg.content_dirs[0].weight, 1.0);
+    }
+
+    #[test]
+    fn test_content_dirs_validation_zero_half_life_clamped() {
+        let cfg = resolved_from_toml(
+            r#"
+[[index.content_dirs]]
+path = "daily/notes"
+half_life_days = 0.0
+"#,
+        );
+        assert_eq!(cfg.content_dirs[0].half_life_days, DEFAULT_HALF_LIFE_DAYS);
+    }
+
+    #[test]
+    fn test_directory_weight_with_config() {
+        let cfg = resolved_from_toml(
+            r#"
+[[index.content_dirs]]
+path = "company/knowledge"
+weight = 1.5
+"#,
+        );
+        // Simulate directory_weight logic against config
+        let file_path = "company/knowledge/foo.md";
+        let weight = cfg
+            .content_dirs
+            .iter()
+            .find(|d| {
+                file_path.starts_with(d.path.as_str())
+                    && file_path.as_bytes().get(d.path.len()) == Some(&b'/')
+            })
+            .map(|d| d.weight)
+            .unwrap_or(1.0);
+        assert_eq!(weight, 1.5);
+
+        // Boundary: similar prefix should NOT match
+        let file_path2 = "company/knowledge_extra/foo.md";
+        let weight2 = cfg
+            .content_dirs
+            .iter()
+            .find(|d| {
+                file_path2.starts_with(d.path.as_str())
+                    && file_path2.as_bytes().get(d.path.len()) == Some(&b'/')
+            })
+            .map(|d| d.weight)
+            .unwrap_or(1.0);
+        assert_eq!(weight2, 1.0);
+    }
+
+    #[test]
+    fn test_half_life_days_with_config() {
+        let cfg = resolved_from_toml(
+            r#"
+[[index.content_dirs]]
+path = "daily/notes"
+half_life_days = 180
+"#,
+        );
+        let file_path = "daily/notes/test.md";
+        let hl = cfg
+            .content_dirs
+            .iter()
+            .find(|d| {
+                file_path.starts_with(d.path.as_str())
+                    && file_path.as_bytes().get(d.path.len()) == Some(&b'/')
+            })
+            .map(|d| d.half_life_days)
+            .unwrap_or(DEFAULT_HALF_LIFE_DAYS);
+        assert_eq!(hl, 180.0);
     }
 }

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -166,7 +166,7 @@ pub fn search(
             rrf += 1.0 / (config::RRF_K + rank as f64);
         }
 
-        let decay = time_decay(updated.as_deref(), &source_type);
+        let decay = time_decay(updated.as_deref(), &file_path, &source_type);
         let penalty = config::status_penalty(status.as_deref());
         let weight = config::directory_weight(&file_path);
         let score = rrf * decay * penalty * weight;
@@ -223,7 +223,7 @@ pub fn search(
     Ok(results)
 }
 
-pub(crate) fn time_decay(updated: Option<&str>, source_type: &str) -> f64 {
+pub(crate) fn time_decay(updated: Option<&str>, file_path: &str, source_type: &str) -> f64 {
     let updated = match updated {
         Some(s) if !s.is_empty() => s,
         _ => return 0.5,
@@ -242,7 +242,7 @@ pub(crate) fn time_decay(updated: Option<&str>, source_type: &str) -> f64 {
 
     let now = Utc::now();
     let days = (now - updated_dt).num_days().max(0) as f64;
-    let half_life = config::half_life_days(source_type);
+    let half_life = config::half_life_days(file_path, source_type);
     0.5_f64.powf(days / half_life)
 }
 
@@ -388,32 +388,35 @@ mod tests {
     #[test]
     fn test_recent_date_high_decay() {
         let now = Utc::now().format("%Y-%m-%d").to_string();
-        let decay = time_decay(Some(&now), "note");
+        let decay = time_decay(Some(&now), "daily/notes/test.md", "note");
         assert!(decay > 0.9);
         assert!(decay <= 1.0);
     }
 
     #[test]
     fn test_none_returns_half() {
-        assert_eq!(time_decay(None, "note"), 0.5);
+        assert_eq!(time_decay(None, "daily/notes/test.md", "note"), 0.5);
     }
 
     #[test]
     fn test_invalid_date_returns_half() {
-        assert_eq!(time_decay(Some("not-a-date"), "note"), 0.5);
+        assert_eq!(
+            time_decay(Some("not-a-date"), "daily/notes/test.md", "note"),
+            0.5
+        );
     }
 
     #[test]
     fn test_old_date_low_decay() {
-        let decay = time_decay(Some("2020-01-01"), "note");
+        let decay = time_decay(Some("2020-01-01"), "daily/notes/test.md", "note");
         assert!(decay < 0.1);
     }
 
     #[test]
     fn test_source_type_half_life() {
         let date = "2025-01-01";
-        let session_decay = time_decay(Some(date), "session");
-        let note_decay = time_decay(Some(date), "note");
+        let session_decay = time_decay(Some(date), "session:abc", "session");
+        let note_decay = time_decay(Some(date), "daily/notes/test.md", "note");
         assert!(session_decay < note_decay);
     }
 


### PR DESCRIPTION
## Summary

- ハードコードの `CONTENT_DIRS` 定数を `tsm.toml` の `[index.content_dirs]` で設定可能に
- `[index.claude_session]` で session のスコアリング設定も外部化
- 未設定時は `index_root` 以下を再帰走査して `.md` ファイルを自動収集（隠しディレクトリ除外）

## toml format

```toml
[[index.content_dirs]]
path = "daily/notes"
weight = 1.2
half_life_days = 120

[index.claude_session]
weight = 0.3
half_life_days = 30
```

## Changes

| File | Change |
|---|---|
| `config.rs` | `ContentDir` struct, `ConfigFile` 拡張, `directory_weight()` / `half_life_days()` 動的化, `CONTENT_DIRS` 削除 |
| `cli.rs` | `collect_content_files()` auto-discover, `discover_watch_dirs()` 追加 |
| `tsm_watcher.rs` | `CONTENT_DIRS` → `discover_watch_dirs()` |
| `searcher.rs` | `time_decay()` に `file_path` 引数追加 |

## Test plan

- [x] `cargo test` — 394 テスト全通過
- [x] `cargo clippy` — warning なし
- [x] `cargo fmt --check` — clean
- [ ] `tsm start` → 自動検出モードで全ディレクトリが watch されることを確認
- [ ] tsm.toml に `[[index.content_dirs]]` を設定して指定ディレクトリのみ index/watch されることを確認

Closes #42