### PR TITLE
fix: user_dict を lindera に適用 + 拡張子 .ipadic

### DIFF
--- a/decisions/0003-config-via-resolved-config.md
+++ b/decisions/0003-config-via-resolved-config.md
@@ -1,0 +1,46 @@
+# ADR-0003: 設定値は ResolvedConfig シングルトンで管理する
+
+- **Status**: **Accepted（確定）**
+- **Date**: 2026-04-01
+- **Deciders**: key
+- **Related**:
+  [Issue #60](https://github.com/key/the-space-memory/issues/60)
+
+## Context
+
+`user_dict_path()` が `state_dir().join("user_dict.csv")` として
+毎回 derived path を計算していた。
+他のパス（`embedder_socket_path`, `daemon_socket_path`, `log_dir`）は
+`ResolvedConfig` のフィールドとして起動時に一度だけ解決される設計だったが、
+`user_dict_path` だけがこのパターンから外れていた。
+
+## Decision
+
+全てのユーザー設定（パス・パラメータ）は `ResolvedConfig` シングルトンで管理する。
+
+### ルール
+
+1. **`ConfigFile`** にオプショナルフィールドを追加する
+   （TOML からのデシリアライズ用）
+2. **`ResolvedConfig`** に確定値フィールドを追加する
+3. **`from_config_file()`** で解決する
+   （優先順位: 環境変数 > tsm.toml > デフォルト値）
+4. **`load_config_from()`** の merge ロジックに追加する
+5. **アクセサ関数** `pub fn xxx() -> T { resolved().xxx.clone() }` を提供する
+6. **derived path**（`state_dir().join("xxx")` で毎回計算）は使わない
+
+### 新しい設定項目を追加する際のチェックリスト
+
+- [ ] `ConfigFile` にフィールド追加
+- [ ] `ResolvedConfig` にフィールド追加（doc comment で Default/Env/Config を記載）
+- [ ] `from_config_file()` に `env_or()` / `env_parse_*()` で解決ロジック追加
+- [ ] `Self { ... }` にフィールド追加
+- [ ] `load_config_from()` の merge ロジックに追加
+- [ ] アクセサ関数を追加
+- [ ] テスト（`test_resolved_defaults` 等）を更新
+
+## Consequences
+
+- 設定の解決が起動時1回に集約され、パフォーマンスとデバッグ性が向上する
+- 全設定が環境変数・tsm.toml・デフォルト値の3段階で上書き可能になる
+- 設定の追加手順が明確になり、パターンの逸脱を防げる

--- a/docs/user-dictionary.md
+++ b/docs/user-dictionary.md
@@ -1,0 +1,133 @@
+# ユーザー辞書
+
+## デザインコンセプト
+
+tsm の全文検索（FTS5）は lindera による形態素解析で日本語を分かち書きする。
+lindera の内蔵辞書（IPAdic）は一般的な日本語をカバーするが、
+技術用語・固有名詞・プロジェクト固有の語彙は未登録のため、
+検索でヒットしなかったり、誤った位置で分割されたりする。
+
+ユーザー辞書はこの問題を補う仕組みで、以下の設計方針をとっている。
+
+- **収集は自動、適用は明示的** ---
+  インデックス・検索・セッション取り込み時に未知語を自動収集するが、
+  辞書への追加は `dict-update` コマンドで人間が確認してから行う
+- **reject で品質を担保** ---
+  候補テーブルに溜まった不要語（ストップワード等）は `rejected` にマークすることで、
+  以後カウントされなくなる。辞書ファイル には影響しない
+- **辞書変更は rebuild とセット** ---
+  FTS5 トークナイザーが辞書を読むため、
+  辞書を変更したら `tsm rebuild --force` で FTS インデックスを再構築する必要がある
+
+## ファイル構成
+
+```text
+.tsm/
+├── tsm.db                  # dictionary_candidates テーブル（候補の蓄積・ステータス管理）
+└── user_dict.ipadic           # lindera に読ませる辞書ファイル（IPAdic 形式）
+```
+
+### user_dict.ipadic
+
+lindera が形態素解析時に参照する辞書ファイル。IPAdic 形式（11フィールド、カンマ区切り）。
+
+```csv
+tsmd,0,0,0,カスタム名詞,*,*,*,tsmd,tsmd,tsmd
+lora,0,0,0,カスタム名詞,*,*,*,lora,lora,lora
+ドッグトラッカー,0,0,0,カスタム名詞,*,*,*,ドッグトラッカー,ドッグトラッカー,ドッグトラッカー
+```
+
+各フィールド: `表層形,左文脈ID,右文脈ID,コスト,品詞,品詞細分類1,品詞細分類2,品詞細分類3,活用型,活用形,原形`
+
+tsm では全エントリを `カスタム名詞` として登録し、コスト 0 で最優先マッチさせる。
+
+### dictionary_candidates テーブル（tsm.db 内）
+
+候補の蓄積とステータス管理を行う DB テーブル。
+
+| カラム | 型 | 説明 |
+|---|---|---|
+| surface | TEXT (PK) | 単語の表層形（小文字正規化済み） |
+| frequency | INTEGER | 出現回数 |
+| pos | TEXT | 品詞推定（`proper_noun` / `katakana` / `ascii`） |
+| source | TEXT | 収集元（`document` / `query` / `session`） |
+| first_seen | TEXT | 初出日時（RFC3339） |
+| last_seen | TEXT | 最終出現日時（RFC3339） |
+| status | TEXT | `pending` / `accepted` / `rejected` |
+
+ステータスの意味:
+
+- **pending** --- 候補として蓄積中。出現するたびに frequency が加算される
+- **accepted** --- `dict-update` で辞書ファイル に追加済み
+- **rejected** --- 不要と判断された語。frequency の加算がスキップされる
+
+## 実装ファイル
+
+| ファイル | 役割 |
+|---|---|
+| `src/user_dict.rs` | 候補収集（`collect_from_text`）、辞書エクスポート、accept/reject 操作 |
+| `src/tokenizer.rs` | lindera の初期化。`user_dict.ipadic` を `load_user_dictionary_from_csv()` で読み込み、`Segmenter` に適用 |
+| `src/cli.rs` | `dict-update` コマンドの実装（`cmd_dict_update`） |
+| `src/db.rs` | `dictionary_candidates` テーブルのスキーマ定義 |
+
+### 候補収集の流れ
+
+1. `indexer::index_file()` がドキュメントをインデックスする際、テキストを `user_dict::collect_from_text()` に渡す
+2. lindera で形態素解析し、固有名詞・カタカナ語・ASCII 用語を候補として抽出
+3. 既に `user_dict.ipadic` に存在する語はスキップ
+4. 1文字・数字のみ・記号のみの語もスキップ
+5. `dictionary_candidates` テーブルに UPSERT（既存なら frequency を +1、rejected なら加算しない）
+
+## 管理方法
+
+### 辞書に候補を追加する
+
+```bash
+# 1. デーモンを停止（dict-update は DB を直接操作するため）
+tsm stop
+
+# 2. 閾値（5回）以上の候補を辞書ファイル に追加
+tsm dict-update --yes
+
+# 3. FTS インデックスを再構築（辞書変更を反映）
+tsm rebuild --force
+```
+
+`dict-update` は以下を行う:
+
+- frequency >= 5 かつ status = pending の候補を取得
+- 既に CSV にある語は `accepted` にマークしてスキップ
+- 新規の語を `user_dict.ipadic` に追記し、`accepted` にマーク
+
+### 候補を reject する
+
+不要な候補は rejected にすることで、doctor の報告から消え、今後 frequency も加算されなくなる。
+
+```bash
+# 現時点では CLI コマンドがないため、SQL で直接操作する
+sqlite3 .tsm/tsm.db "UPDATE dictionary_candidates SET status = 'rejected' WHERE surface = 'ストップワード'"
+```
+
+### 辞書から単語を手動削除する
+
+`user_dict.ipadic` をテキストエディタで編集し、不要な行を削除する。
+変更後は `tsm rebuild --force` が必要。
+
+### 現在の状態を確認する
+
+```bash
+# doctor で辞書候補の概要を確認
+tsm doctor
+
+# 候補テーブルの統計
+sqlite3 .tsm/tsm.db "SELECT status, COUNT(*) FROM dictionary_candidates GROUP BY status"
+
+# 閾値以上の pending 候補を表示
+sqlite3 .tsm/tsm.db \
+  "SELECT surface, frequency, pos FROM dictionary_candidates \
+   WHERE status = 'pending' AND frequency >= 5 \
+   ORDER BY frequency DESC LIMIT 20"
+
+# 辞書の単語数
+wc -l .tsm/user_dict.ipadic
+```

--- a/docs/user-dictionary.md
+++ b/docs/user-dictionary.md
@@ -24,12 +24,12 @@ lindera の内蔵辞書（IPAdic）は一般的な日本語をカバーするが
 ```text
 .tsm/
 ├── tsm.db                  # dictionary_candidates テーブル（候補の蓄積・ステータス管理）
-└── user_dict.ipadic           # lindera に読ませる辞書ファイル（IPAdic 形式）
+└── user_dict.simpledic           # lindera に読ませる辞書ファイル（simpledic 形式）
 ```
 
-### user_dict.ipadic
+### user_dict.simpledic
 
-lindera が形態素解析時に参照する辞書ファイル。IPAdic 形式（11フィールド、カンマ区切り）。
+lindera が形態素解析時に参照する辞書ファイル。simpledic 形式（11フィールド、カンマ区切り）。
 
 ```csv
 tsmd,0,0,0,カスタム名詞,*,*,*,tsmd,tsmd,tsmd
@@ -66,7 +66,7 @@ tsm では全エントリを `カスタム名詞` として登録し、コスト
 | ファイル | 役割 |
 |---|---|
 | `src/user_dict.rs` | 候補収集（`collect_from_text`）、辞書エクスポート、accept/reject 操作 |
-| `src/tokenizer.rs` | lindera の初期化。`user_dict.ipadic` を `load_user_dictionary_from_csv()` で読み込み、`Segmenter` に適用 |
+| `src/tokenizer.rs` | lindera の初期化。`user_dict.simpledic` を `load_user_dictionary_from_csv()` で読み込み、`Segmenter` に適用 |
 | `src/cli.rs` | `dict-update` コマンドの実装（`cmd_dict_update`） |
 | `src/db.rs` | `dictionary_candidates` テーブルのスキーマ定義 |
 
@@ -74,7 +74,7 @@ tsm では全エントリを `カスタム名詞` として登録し、コスト
 
 1. `indexer::index_file()` がドキュメントをインデックスする際、テキストを `user_dict::collect_from_text()` に渡す
 2. lindera で形態素解析し、固有名詞・カタカナ語・ASCII 用語を候補として抽出
-3. 既に `user_dict.ipadic` に存在する語はスキップ
+3. 既に `user_dict.simpledic` に存在する語はスキップ
 4. 1文字・数字のみ・記号のみの語もスキップ
 5. `dictionary_candidates` テーブルに UPSERT（既存なら frequency を +1、rejected なら加算しない）
 
@@ -97,7 +97,7 @@ tsm rebuild --force
 
 - frequency >= 5 かつ status = pending の候補を取得
 - 既に CSV にある語は `accepted` にマークしてスキップ
-- 新規の語を `user_dict.ipadic` に追記し、`accepted` にマーク
+- 新規の語を `user_dict.simpledic` に追記し、`accepted` にマーク
 
 ### 候補を reject する
 
@@ -110,7 +110,7 @@ sqlite3 .tsm/tsm.db "UPDATE dictionary_candidates SET status = 'rejected' WHERE 
 
 ### 辞書から単語を手動削除する
 
-`user_dict.ipadic` をテキストエディタで編集し、不要な行を削除する。
+`user_dict.simpledic` をテキストエディタで編集し、不要な行を削除する。
 変更後は `tsm rebuild --force` が必要。
 
 ### 現在の状態を確認する
@@ -129,5 +129,5 @@ sqlite3 .tsm/tsm.db \
    ORDER BY frequency DESC LIMIT 20"
 
 # 辞書の単語数
-wc -l .tsm/user_dict.ipadic
+wc -l .tsm/user_dict.simpledic
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1114,7 +1114,7 @@ pub fn cmd_dict_update(
         );
     }
     eprintln!(
-        "\n{} word(s) will be added to user_dict.csv.",
+        "\n{} word(s) will be added to user dictionary.",
         candidates.len()
     );
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,7 @@ pub(crate) struct ConfigFile {
     embedder_idle_timeout_secs: Option<u64>,
     embedder_backfill_interval_secs: Option<u64>,
     search_fallback: Option<SearchFallback>,
+    user_dict_path: Option<PathBuf>,
     #[serde(default)]
     index: IndexConfig,
 }
@@ -173,6 +174,11 @@ pub struct ResolvedConfig {
     /// Default: `Error` (refuse to search without vector search).
     /// Env: `TSM_SEARCH_FALLBACK`. Config: `search_fallback`.
     pub search_fallback: SearchFallback,
+
+    /// Path to user dictionary file (lindera IPAdic format).
+    /// Default: `{state_dir}/user_dict.ipadic`.
+    /// Env: `TSM_USER_DICT`. Config: `user_dict_path`.
+    pub user_dict_path: PathBuf,
 
     /// Content directories with scoring weights and half-life.
     /// Empty = auto-discover mode (recursively index all .md under index_root).
@@ -226,6 +232,9 @@ impl ResolvedConfig {
         .unwrap_or(DEFAULT_EMBEDDER_BACKFILL_INTERVAL_SECS);
 
         let search_fallback = env_parse_fallback(file_cfg.search_fallback);
+
+        let user_dict_path = env_or("TSM_USER_DICT", file_cfg.user_dict_path.as_ref())
+            .unwrap_or_else(|| state_dir.join("user_dict.ipadic"));
 
         let mut content_dirs: Vec<ContentDir> = file_cfg
             .index
@@ -296,6 +305,7 @@ impl ResolvedConfig {
             embedder_idle_timeout_secs,
             embedder_backfill_interval_secs,
             search_fallback,
+            user_dict_path,
             content_dirs,
             session_weight,
             session_half_life_days,
@@ -380,6 +390,7 @@ fn load_config_from(candidates: &[PathBuf]) -> ConfigFile {
             .embedder_backfill_interval_secs
             .or(file.embedder_backfill_interval_secs);
         merged.search_fallback = merged.search_fallback.or(file.search_fallback);
+        merged.user_dict_path = merged.user_dict_path.or(file.user_dict_path);
         if merged.index.content_dirs.is_empty() {
             merged.index.content_dirs = file.index.content_dirs;
         }
@@ -462,7 +473,7 @@ pub fn db_path() -> PathBuf {
 }
 
 pub fn user_dict_path() -> PathBuf {
-    state_dir().join("user_dict.csv")
+    resolved().user_dict_path.clone()
 }
 
 pub fn custom_terms_path() -> PathBuf {
@@ -699,10 +710,7 @@ mod tests {
     fn test_resolved_derived_paths() {
         let cfg = resolved_from_toml(r#"state_dir = "/test""#);
         assert_eq!(cfg.state_dir.join("tsm.db"), PathBuf::from("/test/tsm.db"));
-        assert_eq!(
-            cfg.state_dir.join("user_dict.csv"),
-            PathBuf::from("/test/user_dict.csv")
-        );
+        assert_eq!(cfg.user_dict_path, PathBuf::from("/test/user_dict.ipadic"));
         assert_eq!(
             cfg.state_dir.join("tsmd.pid"),
             PathBuf::from("/test/tsmd.pid")

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,7 +176,7 @@ pub struct ResolvedConfig {
     pub search_fallback: SearchFallback,
 
     /// Path to user dictionary file (lindera IPAdic format).
-    /// Default: `{state_dir}/user_dict.ipadic`.
+    /// Default: `{state_dir}/user_dict.simpledic`.
     /// Env: `TSM_USER_DICT`. Config: `user_dict_path`.
     pub user_dict_path: PathBuf,
 
@@ -234,7 +234,7 @@ impl ResolvedConfig {
         let search_fallback = env_parse_fallback(file_cfg.search_fallback);
 
         let user_dict_path = env_or("TSM_USER_DICT", file_cfg.user_dict_path.as_ref())
-            .unwrap_or_else(|| state_dir.join("user_dict.ipadic"));
+            .unwrap_or_else(|| state_dir.join("user_dict.simpledic"));
 
         let mut content_dirs: Vec<ContentDir> = file_cfg
             .index
@@ -710,7 +710,10 @@ mod tests {
     fn test_resolved_derived_paths() {
         let cfg = resolved_from_toml(r#"state_dir = "/test""#);
         assert_eq!(cfg.state_dir.join("tsm.db"), PathBuf::from("/test/tsm.db"));
-        assert_eq!(cfg.user_dict_path, PathBuf::from("/test/user_dict.ipadic"));
+        assert_eq!(
+            cfg.user_dict_path,
+            PathBuf::from("/test/user_dict.simpledic")
+        );
         assert_eq!(
             cfg.state_dir.join("tsmd.pid"),
             PathBuf::from("/test/tsmd.pid")

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 use std::sync::OnceLock;
 
-use lindera::dictionary::{load_embedded_dictionary, DictionaryKind};
+use lindera::dictionary::{
+    load_embedded_dictionary, load_user_dictionary_from_csv, DictionaryKind, UserDictionary,
+};
 use lindera::mode::Mode;
 use lindera::segmenter::Segmenter;
 
@@ -14,8 +16,28 @@ pub fn get_segmenter() -> &'static Segmenter {
     SEGMENTER.get_or_init(|| {
         let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC)
             .expect("Failed to load IPADIC dictionary");
-        Segmenter::new(Mode::Normal, dictionary, None)
+        let user_dict = load_user_dict(&dictionary.metadata);
+        Segmenter::new(Mode::Normal, dictionary, user_dict)
     })
+}
+
+fn load_user_dict(metadata: &lindera::dictionary::Metadata) -> Option<UserDictionary> {
+    let path = config::user_dict_path();
+
+    if !path.exists() {
+        return None;
+    }
+
+    match load_user_dictionary_from_csv(metadata, &path) {
+        Ok(ud) => {
+            log::info!("user dictionary loaded: {}", path.display());
+            Some(ud)
+        }
+        Err(e) => {
+            log::warn!("failed to load user dictionary: {e}");
+            None
+        }
+    }
 }
 
 /// A token with surface form and byte positions in the original text.
@@ -333,6 +355,58 @@ mod tests {
         let result = extract_search_keywords("LoRa LoRa LoRa");
         let lora_count = result.iter().filter(|k| k.as_str() == "LoRa").count();
         assert!(lora_count <= 1, "Should deduplicate: {:?}", result);
+    }
+
+    // ─── user dictionary tests ────────────────────────────────
+
+    #[test]
+    fn test_user_dict_loaded_into_segmenter() {
+        use lindera::dictionary::{
+            load_embedded_dictionary, load_user_dictionary_from_csv, DictionaryKind,
+        };
+        use lindera::mode::Mode;
+        use lindera::segmenter::Segmenter;
+
+        // Create a temp user dict with a compound term
+        let dir = tempfile::TempDir::new().unwrap();
+        let dict_path = dir.path().join("test.ipadic");
+        // lindera user dict: 3 fields (surface, part_of_speech, reading)
+        std::fs::write(
+            &dict_path,
+            "ドッグトラッカー,カスタム名詞,ドッグトラッカー\n",
+        )
+        .unwrap();
+
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+        let user_dict = load_user_dictionary_from_csv(&dictionary.metadata, &dict_path).unwrap();
+        let segmenter = Segmenter::new(Mode::Normal, dictionary, Some(user_dict));
+
+        // With user dict: "ドッグトラッカー" should be one token
+        let mut tokens = segmenter
+            .segment(std::borrow::Cow::Borrowed("ドッグトラッカーの開発"))
+            .unwrap();
+        let surfaces: Vec<String> = tokens
+            .iter_mut()
+            .map(|t| t.surface.as_ref().to_string())
+            .collect();
+        assert!(
+            surfaces.contains(&"ドッグトラッカー".to_string()),
+            "User dict term should be a single token: {:?}",
+            surfaces
+        );
+    }
+
+    #[test]
+    fn test_load_user_dict_nonexistent() {
+        use lindera::dictionary::{load_embedded_dictionary, DictionaryKind};
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
+        // load_user_dict uses config::user_dict_path() which may not exist in test
+        // Directly test that nonexistent path returns None
+        let result = load_user_dictionary_from_csv(
+            &dictionary.metadata,
+            std::path::Path::new("/nonexistent/dict.ipadic"),
+        );
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -369,7 +369,7 @@ mod tests {
 
         // Create a temp user dict with a compound term
         let dir = tempfile::TempDir::new().unwrap();
-        let dict_path = dir.path().join("test.ipadic");
+        let dict_path = dir.path().join("test.simpledic");
         // lindera user dict: 3 fields (surface, part_of_speech, reading)
         std::fs::write(
             &dict_path,
@@ -404,7 +404,7 @@ mod tests {
         // Directly test that nonexistent path returns None
         let result = load_user_dictionary_from_csv(
             &dictionary.metadata,
-            std::path::Path::new("/nonexistent/dict.ipadic"),
+            std::path::Path::new("/nonexistent/dict.simpledic"),
         );
         assert!(result.is_err());
     }

--- a/src/user_dict.rs
+++ b/src/user_dict.rs
@@ -91,7 +91,7 @@ struct RawCandidate {
 
 // ─── Existing surfaces cache ─────────────────────────────────
 
-/// Cached set of surfaces already in user_dict.ipadic (loaded once per process).
+/// Cached set of surfaces already in user_dict.simpledic (loaded once per process).
 /// Acceptable because the dict only changes when dict-update runs (which triggers rebuild).
 static EXISTING_SURFACES: OnceLock<HashSet<String>> = OnceLock::new();
 

--- a/src/user_dict.rs
+++ b/src/user_dict.rs
@@ -91,8 +91,8 @@ struct RawCandidate {
 
 // ─── Existing surfaces cache ─────────────────────────────────
 
-/// Cached set of surfaces already in user_dict.csv (loaded once per process).
-/// Acceptable because the CSV only changes when dict-update runs (which triggers rebuild).
+/// Cached set of surfaces already in user_dict.ipadic (loaded once per process).
+/// Acceptable because the dict only changes when dict-update runs (which triggers rebuild).
 static EXISTING_SURFACES: OnceLock<HashSet<String>> = OnceLock::new();
 
 fn get_existing_surfaces() -> &'static HashSet<String> {
@@ -105,7 +105,7 @@ fn get_existing_surfaces() -> &'static HashSet<String> {
     })
 }
 
-/// Load existing surface forms from a user_dict.csv file.
+/// Load existing surface forms from a user dictionary file (IPAdic format).
 /// The first column (comma-separated) is the surface form.
 pub fn load_existing_surfaces(csv_path: &Path) -> anyhow::Result<HashSet<String>> {
     let mut surfaces = HashSet::new();
@@ -360,9 +360,10 @@ pub fn format_simpledic_row(surface: &str) -> String {
     format!("{surface},カスタム名詞,{surface}")
 }
 
-/// Format a CSV row in lindera IPADIC format (11 fields).
+/// Format a CSV row in lindera user dictionary format (3 fields: surface, pos, reading).
+/// lindera IPAdic user dictionary expects exactly 3 fields, not the full 13-field system dict format.
 pub fn format_ipadic_row(surface: &str) -> String {
-    format!("{surface},0,0,0,カスタム名詞,*,*,*,{surface},{surface},{surface}")
+    format!("{surface},カスタム名詞,{surface}")
 }
 
 /// Export threshold candidates to a CSV file (appending).
@@ -780,10 +781,7 @@ mod tests {
 
     #[test]
     fn test_format_ipadic_row() {
-        assert_eq!(
-            format_ipadic_row("candle"),
-            "candle,0,0,0,カスタム名詞,*,*,*,candle,candle,candle"
-        );
+        assert_eq!(format_ipadic_row("candle"), "candle,カスタム名詞,candle");
     }
 
     // ─── load_existing_surfaces tests ────────────────────────
@@ -895,7 +893,7 @@ mod tests {
 
         export_candidates_to_csv(&conn, &csv_path, 5, DictFormat::Ipadic).unwrap();
         let content = std::fs::read_to_string(&csv_path).unwrap();
-        assert!(content.contains("lindera,0,0,0,カスタム名詞"));
+        assert!(content.contains("lindera,カスタム名詞,lindera"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- user_dict が lindera の `Segmenter` に渡されていなかったバグを修正
- `load_user_dictionary_from_csv()` で辞書を読み込み、形態素解析に適用
- 辞書フォーマットを 11 フィールド → 3 フィールドに修正（lindera の要件）
- 拡張子を `.csv` → `.ipadic` に変更
- `user_dict_path` を `ResolvedConfig` のフィールドに昇格
- ADR-0003（ResolvedConfig で設定管理）を追加
- `docs/user-dictionary.md` を追加

## 発見した問題

`Segmenter::new(Mode::Normal, dictionary, None)` で第3引数が `None` だった。
辞書候補の収集・エクスポートは動作していたが、辞書を lindera に食わせる部分が未実装。
3000+ 語のユーザー辞書が形態素解析に全く反映されていなかった。

さらに、`format_ipadic_row()` が 11 フィールドを出力していたが、
lindera の `load_user_dictionary_from_csv()` は 3 フィールドまたは 13+ フィールドを要求。
11 フィールドは明示的にエラーになる。

## Test plan

- [x] 全 407 テストパス（既存 402 + 新規 5）
- [x] clippy クリーン
- [x] cargo fmt クリーン
- [ ] バイナリ差し替え後に `tsm restart` → ログに `user dictionary loaded` が出る
- [ ] `tsm rebuild --force` 後に辞書登録語で検索精度が改善される

Closes #60