### PR TITLE
fix: rename doctor command title to The Space Memory

### DIFF
--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -5,10 +5,10 @@ disable-model-invocation: true
 allowed-tools: Bash(tsm *)
 ---
 
-# Doctor
+# The Space Memory — Doctor
 
-以下の JSON はナレッジ検索システム (tsm) のヘルスチェック結果です。
-セクションごとに見やすく整形して表示してください。
+以下の JSON はナレッジ検索システムのヘルスチェック結果です。
+タイトルは「The Space Memory — Doctor」として、セクションごとに見やすく整形して表示してください。
 
 - status が "ok" のアイテムは ✔ を付ける
 - status が "warning" のアイテムは ⚠ を付けて hint を添える


### PR DESCRIPTION
## Summary

- プラグインコマンド doctor のタイトルを「The Space Memory — Doctor」に変更
- 「ナレッジ検索システム (tsm)」→「ナレッジ検索システム」に簡略化

## Test plan

- [x] `/the-space-memory:doctor` で正式名称が表示される