### PR TITLE
feat: tsm reload — hot config reload without restart

### DIFF
--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -15,7 +15,9 @@ use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
 use the_space_memory::cli;
 use the_space_memory::config;
 use the_space_memory::daemon;
-use the_space_memory::daemon_protocol::{read_request, write_response, DaemonRequest, DaemonResponse};
+use the_space_memory::daemon_protocol::{
+    read_request, write_response, DaemonRequest, DaemonResponse,
+};
 use the_space_memory::db;
 use the_space_memory::status;
 
@@ -548,7 +550,9 @@ fn sleep_interruptible(duration: std::time::Duration) {
 /// and indexes them directly via the shared DB connection.
 /// Set up watch targets and return the set of watched directories.
 fn setup_watches(
-    debouncer: &mut notify_debouncer_mini::Debouncer<notify_debouncer_mini::notify::RecommendedWatcher>,
+    debouncer: &mut notify_debouncer_mini::Debouncer<
+        notify_debouncer_mini::notify::RecommendedWatcher,
+    >,
     index_root: &Path,
 ) -> HashSet<PathBuf> {
     let mut watched = HashSet::new();
@@ -569,7 +573,9 @@ fn setup_watches(
 
 /// Update watch targets: unwatch removed dirs, watch added dirs.
 fn update_watches(
-    debouncer: &mut notify_debouncer_mini::Debouncer<notify_debouncer_mini::notify::RecommendedWatcher>,
+    debouncer: &mut notify_debouncer_mini::Debouncer<
+        notify_debouncer_mini::notify::RecommendedWatcher,
+    >,
     current: &mut HashSet<PathBuf>,
     index_root: &Path,
 ) {
@@ -589,10 +595,7 @@ fn update_watches(
     // Watch new dirs
     for dir in desired.difference(current) {
         log::info!("watching {}", dir.display());
-        if let Err(e) = debouncer
-            .watcher()
-            .watch(dir, RecursiveMode::Recursive)
-        {
+        if let Err(e) = debouncer.watcher().watch(dir, RecursiveMode::Recursive) {
             log::warn!("cannot watch {}: {e}", dir.display());
         }
     }

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -3,6 +3,7 @@ use std::os::unix::net::UnixListener;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -14,7 +15,7 @@ use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
 use the_space_memory::cli;
 use the_space_memory::config;
 use the_space_memory::daemon;
-use the_space_memory::daemon_protocol::{read_request, write_response, DaemonRequest};
+use the_space_memory::daemon_protocol::{read_request, write_response, DaemonRequest, DaemonResponse};
 use the_space_memory::db;
 use the_space_memory::status;
 
@@ -152,6 +153,7 @@ fn main() -> Result<()> {
     };
 
     // Start watcher as a thread (not a child process)
+    let (reload_tx, reload_rx) = mpsc::channel::<()>();
     if !args.no_watcher {
         let conn = Arc::clone(&conn);
         let index_root = index_root.clone();
@@ -163,7 +165,7 @@ fn main() -> Result<()> {
         });
         log::info!("starting watcher thread");
         std::thread::spawn(move || {
-            if let Err(e) = run_watcher(&conn, &index_root) {
+            if let Err(e) = run_watcher(&conn, &index_root, reload_rx) {
                 log::error!("watcher thread failed: {e}");
             }
             log::info!("watcher thread stopped");
@@ -220,8 +222,11 @@ fn main() -> Result<()> {
                 let index_root = index_root.clone();
                 let search_active = Arc::clone(&search_active);
 
+                let reload_tx = reload_tx.clone();
                 std::thread::spawn(move || {
-                    if let Err(e) = handle_client(&mut stream, &conn, &index_root, &search_active) {
+                    if let Err(e) =
+                        handle_client(&mut stream, &conn, &index_root, &search_active, &reload_tx)
+                    {
                         log::warn!("client error: {e}");
                     }
                 });
@@ -378,10 +383,28 @@ fn handle_client(
     conn: &Arc<Mutex<rusqlite::Connection>>,
     index_root: &std::path::Path,
     search_active: &Arc<AtomicUsize>,
+    reload_tx: &Sender<()>,
 ) -> Result<()> {
     stream.set_read_timeout(Some(std::time::Duration::from_secs(30)))?;
     stream.set_write_timeout(Some(std::time::Duration::from_secs(30)))?;
     let req = read_request(stream)?;
+
+    // Handle Reload directly in tsmd (needs watcher channel, not DB)
+    if matches!(req, DaemonRequest::Reload) {
+        let mut warnings = config::reload();
+        if reload_tx.send(()).is_err() {
+            warnings.push("watcher is not running; watch targets not updated".to_string());
+        }
+        let resp = if warnings.is_empty() {
+            DaemonResponse::success_empty()
+        } else {
+            DaemonResponse::success(serde_json::json!({
+                "warnings": warnings,
+            }))
+        };
+        write_response(stream, &resp)?;
+        return Ok(());
+    }
 
     // Track active search requests so backfill can yield
     let _guard = if matches!(req, DaemonRequest::Search { .. }) {
@@ -523,12 +546,12 @@ fn sleep_interruptible(duration: std::time::Duration) {
 
 /// Run the file watcher loop. Watches content directories for .md changes
 /// and indexes them directly via the shared DB connection.
-fn run_watcher(conn: &Arc<Mutex<rusqlite::Connection>>, index_root: &Path) -> Result<()> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    let mut debouncer =
-        new_debouncer(Duration::from_secs(2), tx).context("Failed to create file watcher")?;
-
-    let mut watched = 0;
+/// Set up watch targets and return the set of watched directories.
+fn setup_watches(
+    debouncer: &mut notify_debouncer_mini::Debouncer<notify_debouncer_mini::notify::RecommendedWatcher>,
+    index_root: &Path,
+) -> HashSet<PathBuf> {
+    let mut watched = HashSet::new();
     for full_dir in cli::discover_watch_dirs(index_root) {
         if full_dir.is_dir() {
             if let Err(e) = debouncer
@@ -537,12 +560,56 @@ fn run_watcher(conn: &Arc<Mutex<rusqlite::Connection>>, index_root: &Path) -> Re
             {
                 log::warn!("cannot watch {}: {e}", full_dir.display());
             } else {
-                watched += 1;
+                watched.insert(full_dir);
             }
         }
     }
+    watched
+}
 
-    if watched == 0 {
+/// Update watch targets: unwatch removed dirs, watch added dirs.
+fn update_watches(
+    debouncer: &mut notify_debouncer_mini::Debouncer<notify_debouncer_mini::notify::RecommendedWatcher>,
+    current: &mut HashSet<PathBuf>,
+    index_root: &Path,
+) {
+    let desired: HashSet<PathBuf> = cli::discover_watch_dirs(index_root)
+        .into_iter()
+        .filter(|d| d.is_dir())
+        .collect();
+
+    // Unwatch removed dirs
+    for dir in current.difference(&desired) {
+        log::info!("unwatching {}", dir.display());
+        let _ = debouncer.watcher().unwatch(dir);
+    }
+
+    // Watch new dirs
+    for dir in desired.difference(current) {
+        log::info!("watching {}", dir.display());
+        if let Err(e) = debouncer
+            .watcher()
+            .watch(dir, RecursiveMode::Recursive)
+        {
+            log::warn!("cannot watch {}: {e}", dir.display());
+        }
+    }
+
+    *current = desired;
+}
+
+fn run_watcher(
+    conn: &Arc<Mutex<rusqlite::Connection>>,
+    index_root: &Path,
+    reload_rx: mpsc::Receiver<()>,
+) -> Result<()> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut debouncer =
+        new_debouncer(Duration::from_secs(2), tx).context("Failed to create file watcher")?;
+
+    let mut watched = setup_watches(&mut debouncer, index_root);
+
+    if watched.is_empty() {
         anyhow::bail!(
             "No content directories found to watch under {}",
             index_root.display()
@@ -550,11 +617,20 @@ fn run_watcher(conn: &Arc<Mutex<rusqlite::Connection>>, index_root: &Path) -> Re
     }
 
     log::info!(
-        "watching {watched} directories under {}",
+        "watching {} directories under {}",
+        watched.len(),
         index_root.display()
     );
 
     while !SHUTDOWN.load(Ordering::SeqCst) {
+        // Drain all queued reload notifications (coalesce multiple reloads)
+        if reload_rx.try_recv().is_ok() {
+            while reload_rx.try_recv().is_ok() {}
+            log::info!("watcher: reload notification received, updating watch targets");
+            update_watches(&mut debouncer, &mut watched, index_root);
+            log::info!("watcher: now watching {} directories", watched.len());
+        }
+
         match rx.recv_timeout(Duration::from_millis(500)) {
             Ok(Ok(events)) => {
                 let mut files_to_index: HashSet<String> = HashSet::new();
@@ -638,7 +714,8 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let conn = the_space_memory::db::get_memory_connection().unwrap();
         let conn = Arc::new(Mutex::new(conn));
-        let result = run_watcher(&conn, dir.path());
+        let (_reload_tx, reload_rx) = mpsc::channel::<()>();
+        let result = run_watcher(&conn, dir.path(), reload_rx);
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -658,7 +735,8 @@ mod tests {
 
         // Pre-set SHUTDOWN so the watcher loop exits immediately
         SHUTDOWN.store(true, Ordering::SeqCst);
-        let result = run_watcher(&conn, dir.path());
+        let (_reload_tx, reload_rx) = mpsc::channel::<()>();
+        let result = run_watcher(&conn, dir.path(), reload_rx);
         // Reset for other tests
         SHUTDOWN.store(false, Ordering::SeqCst);
         assert!(result.is_ok());

--- a/src/bin/tsmd.rs
+++ b/src/bin/tsmd.rs
@@ -581,7 +581,9 @@ fn update_watches(
     // Unwatch removed dirs
     for dir in current.difference(&desired) {
         log::info!("unwatching {}", dir.display());
-        let _ = debouncer.watcher().unwatch(dir);
+        if let Err(e) = debouncer.watcher().unwatch(dir) {
+            log::warn!("failed to unwatch {}: {e}", dir.display());
+        }
     }
 
     // Watch new dirs
@@ -623,7 +625,8 @@ fn run_watcher(
     );
 
     while !SHUTDOWN.load(Ordering::SeqCst) {
-        // Drain all queued reload notifications (coalesce multiple reloads)
+        // Drain all queued reload notifications. Coalescing avoids redundant
+        // update_watches calls when multiple reload requests arrive in quick succession.
         if reload_rx.try_recv().is_ok() {
             while reload_rx.try_recv().is_ok() {}
             log::info!("watcher: reload notification received, updating watch targets");

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,10 +128,11 @@ pub(crate) struct ConfigFile {
     index: IndexConfig,
 }
 
-/// Fully resolved configuration — all values determined at startup.
+/// Fully resolved configuration.
 ///
 /// Resolution priority: env var > config file (tsm.toml) > default.
-/// Built once via `from_env()` and stored in a `OnceLock` singleton.
+/// Stored in a `OnceLock<RwLock<ResolvedConfig>>` singleton. Initialized lazily
+/// via `from_env()`; may be updated at runtime by calling `reload()`.
 /// In tests, construct directly via `from_config_file()` without env var mutation.
 #[derive(Debug, Clone)]
 pub struct ResolvedConfig {
@@ -357,10 +358,12 @@ fn resolved() -> ResolvedConfig {
 /// Reload config from tsm.toml. Returns a list of warnings for fields
 /// that changed but require a daemon restart to take effect.
 pub fn reload() -> Vec<String> {
+    // Ensure singleton is initialized before building new config
+    let _ = resolved();
     let new_cfg = ResolvedConfig::from_env();
 
     // Hold write lock for the entire read-compare-write to avoid TOCTOU races
-    let lock = RESOLVED.get_or_init(|| RwLock::new(ResolvedConfig::from_env()));
+    let lock = RESOLVED.get().expect("config not initialized");
     let mut w = lock.write().expect("config RwLock poisoned");
     let old = w.clone();
 
@@ -1282,5 +1285,42 @@ half_life_days = 180
         let warnings = reload();
         // No structural fields changed, so no warnings
         assert!(warnings.is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn test_reload_warns_on_structural_changes() {
+        // Force singleton initialization with current env
+        let _ = resolved();
+
+        // Set env vars to force structural field changes
+        std::env::set_var("TSM_STATE_DIR", "/tmp/reload-test-state");
+        std::env::set_var("TSM_INDEX_ROOT", "/tmp/reload-test-root");
+
+        let warnings = reload();
+
+        // Clean up env vars
+        std::env::remove_var("TSM_STATE_DIR");
+        std::env::remove_var("TSM_INDEX_ROOT");
+
+        // Restore original config
+        reload();
+
+        // Should have warnings for state_dir and index_root (and derived paths)
+        assert!(
+            warnings.iter().any(|w| w.contains("state_dir")),
+            "expected state_dir warning, got: {warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("index_root")),
+            "expected index_root warning, got: {warnings:?}"
+        );
+        // All warnings should mention tsm restart
+        for w in &warnings {
+            assert!(
+                w.contains("tsm restart"),
+                "warning should mention tsm restart: {w}"
+            );
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::path::PathBuf;
-use std::sync::OnceLock;
+use std::sync::{OnceLock, RwLock};
 
 use directories::ProjectDirs;
 
@@ -343,11 +343,65 @@ fn env_parse_u64(var: &str, file_val: Option<u64>) -> Option<u64> {
     file_val
 }
 
-static RESOLVED: OnceLock<ResolvedConfig> = OnceLock::new();
+static RESOLVED: OnceLock<RwLock<ResolvedConfig>> = OnceLock::new();
 
-/// Get the lazily-loaded resolved config singleton.
-fn resolved() -> &'static ResolvedConfig {
-    RESOLVED.get_or_init(ResolvedConfig::from_env)
+/// Get the lazily-loaded resolved config singleton (cloned).
+fn resolved() -> ResolvedConfig {
+    RESOLVED
+        .get_or_init(|| RwLock::new(ResolvedConfig::from_env()))
+        .read()
+        .expect("config RwLock poisoned")
+        .clone()
+}
+
+/// Reload config from tsm.toml. Returns a list of warnings for fields
+/// that changed but require a daemon restart to take effect.
+pub fn reload() -> Vec<String> {
+    let new_cfg = ResolvedConfig::from_env();
+
+    // Hold write lock for the entire read-compare-write to avoid TOCTOU races
+    let lock = RESOLVED.get_or_init(|| RwLock::new(ResolvedConfig::from_env()));
+    let mut w = lock.write().expect("config RwLock poisoned");
+    let old = w.clone();
+
+    let mut warnings = Vec::new();
+
+    if old.state_dir != new_cfg.state_dir {
+        warnings.push(format!(
+            "state_dir changed ({} → {}); requires `tsm restart`",
+            old.state_dir.display(),
+            new_cfg.state_dir.display()
+        ));
+    }
+    if old.index_root != new_cfg.index_root {
+        warnings.push(format!(
+            "index_root changed ({} → {}); requires `tsm restart`",
+            old.index_root.display(),
+            new_cfg.index_root.display()
+        ));
+    }
+    if old.daemon_socket_path != new_cfg.daemon_socket_path {
+        warnings.push("daemon_socket_path changed; requires `tsm restart`".to_string());
+    }
+    if old.embedder_socket_path != new_cfg.embedder_socket_path {
+        warnings.push("embedder_socket_path changed; requires `tsm restart`".to_string());
+    }
+    if old.log_dir != new_cfg.log_dir {
+        warnings.push("log_dir changed; requires `tsm restart`".to_string());
+    }
+    if old.user_dict_path != new_cfg.user_dict_path {
+        warnings.push("user_dict_path changed; requires `tsm restart`".to_string());
+    }
+
+    *w = new_cfg;
+
+    log::info!("config reloaded from tsm.toml");
+    if !warnings.is_empty() {
+        for w in &warnings {
+            log::warn!("{w}");
+        }
+    }
+    warnings
 }
 
 /// Merge config values from `candidates` in order; first non-None value for each field wins.
@@ -454,8 +508,8 @@ pub fn search_fallback() -> SearchFallback {
     resolved().search_fallback
 }
 
-pub fn content_dirs() -> &'static [ContentDir] {
-    &resolved().content_dirs
+pub fn content_dirs() -> Vec<ContentDir> {
+    resolved().content_dirs
 }
 
 pub fn session_weight() -> f64 {
@@ -536,10 +590,11 @@ pub fn status_penalty(status: Option<&str>) -> f64 {
 /// Half-life in days, resolved from content_dirs config by file path prefix.
 /// Falls back to source_type-based defaults when content_dirs is empty or unmatched.
 pub fn half_life_days(file_path: &str, source_type: &str) -> f64 {
+    let cfg = resolved();
     if file_path.starts_with("session:") {
-        return resolved().session_half_life_days;
+        return cfg.session_half_life_days;
     }
-    for dir in &resolved().content_dirs {
+    for dir in &cfg.content_dirs {
         if file_path.starts_with(dir.path.as_str())
             && file_path.as_bytes().get(dir.path.len()) == Some(&b'/')
         {
@@ -578,10 +633,11 @@ pub fn source_type_from_dir(directory: &str) -> String {
 
 /// Score weight based on directory prefix of file_path.
 pub fn directory_weight(file_path: &str) -> f64 {
+    let cfg = resolved();
     if file_path.starts_with("session:") {
-        return resolved().session_weight;
+        return cfg.session_weight;
     }
-    for dir in &resolved().content_dirs {
+    for dir in &cfg.content_dirs {
         if file_path.starts_with(dir.path.as_str())
             && file_path.as_bytes().get(dir.path.len()) == Some(&b'/')
         {
@@ -1212,5 +1268,19 @@ half_life_days = 180
             .map(|d| d.half_life_days)
             .unwrap_or(DEFAULT_HALF_LIFE_DAYS);
         assert_eq!(hl, 180.0);
+    }
+
+    // ─── reload ──────────────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn test_reload_updates_config() {
+        // Force singleton initialization
+        let _ = resolved();
+
+        // reload should not panic even without tsm.toml changes
+        let warnings = reload();
+        // No structural fields changed, so no warnings
+        assert!(warnings.is_empty());
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -128,8 +128,9 @@ pub fn handle_request(
             DaemonResponse::error("rebuild cannot run while tsmd is active. Run `tsm stop` first.")
         }
 
-        // Reload is handled directly in tsmd::handle_client before reaching here.
-        // This arm exists for exhaustiveness and testing without a daemon.
+        // In the live daemon, tsmd::handle_client intercepts Reload first
+        // (to access the watcher channel). This arm handles the same logic
+        // for callers without a watcher, including unit tests.
         DaemonRequest::Reload => {
             let warnings = config::reload();
             if warnings.is_empty() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -127,6 +127,17 @@ pub fn handle_request(
         DaemonRequest::Rebuild { .. } => {
             DaemonResponse::error("rebuild cannot run while tsmd is active. Run `tsm stop` first.")
         }
+
+        // Reload is handled directly in tsmd::handle_client before reaching here.
+        // This arm exists for exhaustiveness and testing without a daemon.
+        DaemonRequest::Reload => {
+            let warnings = config::reload();
+            if warnings.is_empty() {
+                DaemonResponse::success_empty()
+            } else {
+                DaemonResponse::success(serde_json::json!({ "warnings": warnings }))
+            }
+        }
     }
 }
 
@@ -278,6 +289,16 @@ mod tests {
         let resp = handle_request(&conn, req, dir.path(), &flag);
         assert!(!resp.ok);
         assert!(resp.error.unwrap().contains("tsm stop"));
+    }
+
+    #[test]
+    fn test_reload() {
+        let (conn, dir) = setup();
+        let flag = AtomicBool::new(false);
+        let resp = handle_request(&conn, DaemonRequest::Reload, dir.path(), &flag);
+        assert!(resp.ok);
+        // Shutdown flag should NOT be set by reload
+        assert!(!flag.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -51,6 +51,7 @@ pub enum DaemonRequest {
     Rebuild {
         force: bool,
     },
+    Reload,
     Shutdown,
     Ping,
 }
@@ -315,6 +316,14 @@ mod tests {
         let json = serde_json::to_string(&req).unwrap();
         let decoded: DaemonRequest = serde_json::from_str(&json).unwrap();
         assert!(matches!(decoded, DaemonRequest::Ping));
+    }
+
+    #[test]
+    fn serde_roundtrip_reload() {
+        let req = DaemonRequest::Reload;
+        let json = serde_json::to_string(&req).unwrap();
+        let decoded: DaemonRequest = serde_json::from_str(&json).unwrap();
+        assert!(matches!(decoded, DaemonRequest::Reload));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -433,7 +433,7 @@ fn render_reload(resp: DaemonResponse) -> anyhow::Result<()> {
             }
         }
     }
-    eprintln!("config reloaded");
+    println!("config reloaded");
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,6 +162,8 @@ enum Commands {
         #[arg(long)]
         fts_only: bool,
     },
+    /// Reload config (tsm.toml) without restarting the daemon
+    Reload,
     /// Restart the daemon (stop + start)
     Restart,
 }
@@ -281,6 +283,10 @@ fn main() -> anyhow::Result<()> {
                 wordnet_db: wordnet_db.to_string_lossy().to_string(),
             };
             render_import_wordnet(send_to_daemon(&req)?)?;
+        }
+
+        Commands::Reload => {
+            render_reload(send_to_daemon(&DaemonRequest::Reload)?)?;
         }
     }
     Ok(())
@@ -413,6 +419,21 @@ fn render_doctor(resp: DaemonResponse, format: &str) -> anyhow::Result<()> {
         )
     })?;
     cli::render_doctor_report(&report);
+    Ok(())
+}
+
+fn render_reload(resp: DaemonResponse) -> anyhow::Result<()> {
+    check_resp(&resp)?;
+    if let Some(payload) = &resp.payload {
+        if let Some(warnings) = payload.get("warnings").and_then(|w| w.as_array()) {
+            for w in warnings {
+                if let Some(s) = w.as_str() {
+                    eprintln!("warning: {s}");
+                }
+            }
+        }
+    }
+    eprintln!("config reloaded");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- `tsm reload` コマンドを追加。`tsm.toml` の変更をデーモン再起動なしで反映
- `ResolvedConfig` シングルトンを `OnceLock<RwLock>` に変更し、ランタイムでの設定更新をサポート
- watcher スレッドに channel 経由で reload 通知し、監視対象ディレクトリを更新
- 構造的フィールド（state_dir, index_root, socket paths 等）の変更は検出して警告を表示

Closes #67

## Changes

| File | Change |
|---|---|
| `src/config.rs` | `OnceLock` → `OnceLock<RwLock>`, `reload()` 関数追加, `content_dirs()` を `Vec` 返却に変更 |
| `src/daemon_protocol.rs` | `Reload` variant 追加 |
| `src/daemon.rs` | `Reload` arm 追加（フォールバック用）+ テスト |
| `src/main.rs` | `Reload` サブコマンド + `render_reload()` |
| `src/bin/tsmd.rs` | `handle_client` で Reload を直接処理, watcher に reload channel, `setup_watches`/`update_watches` ヘルパー |

## Test plan

- [x] `cargo test` — 421 tests passed
- [x] `cargo clippy` — no new warnings
- [ ] 手動テスト: `tsm start` → `tsm.toml` の `content_dirs` 変更 → `tsm reload` → `tsm index` で新ディレクトリが反映される
- [ ] 手動テスト: 構造的フィールド変更時に警告が表示される