### PR TITLE
fix: replace nightly floor_char_boundary with stable alternative

### DIFF
--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -90,7 +90,7 @@ impl Embedder {
             .map(|t| {
                 if t.len() > MAX_CHARS {
                     let mut end = MAX_CHARS;
-                    while !t.is_char_boundary(end) {
+                    while end > 0 && !t.is_char_boundary(end) {
                         end -= 1;
                     }
                     t[..end].to_string()

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -89,7 +89,11 @@ impl Embedder {
             .iter()
             .map(|t| {
                 if t.len() > MAX_CHARS {
-                    t[..t.floor_char_boundary(MAX_CHARS)].to_string()
+                    let mut end = MAX_CHARS;
+                    while !t.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    t[..end].to_string()
                 } else {
                     t.clone()
                 }


### PR DESCRIPTION
## Summary
- `str::floor_char_boundary` は unstable (rust#93743) のため、stable toolchain でビルドエラーになっていた
- `is_char_boundary` ループによる同等処理に置き換え、macOS の stable Rust (1.89) でビルド可能に

## Test plan
- [x] `cargo build --release` 成功確認
- [x] `cargo test` 全415テスト pass