### PR TITLE
ci: add release workflow for binary distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive_name: linux-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            archive_name: darwin-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9  # stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          key: release-${{ matrix.target }}
+
+      - name: Build release binaries
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package archive
+        env:
+          TAG: ${{ github.ref_name }}
+          ARCHIVE_NAME: ${{ matrix.archive_name }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          DIR="tsm-${TAG}-${ARCHIVE_NAME}"
+          mkdir -p "${DIR}/data" "${DIR}/docs"
+          cp "target/${TARGET}/release/tsm" "${DIR}/"
+          cp "target/${TARGET}/release/tsmd" "${DIR}/"
+          cp "target/${TARGET}/release/tsm-embedder" "${DIR}/"
+          cp README.md LICENSE tsm.toml.sample "${DIR}/"
+          cp data/stopwords.txt "${DIR}/data/"
+          cp docs/user-dictionary.md "${DIR}/docs/"
+          cp -r hooks "${DIR}/"
+          tar czf "${DIR}.tar.gz" "${DIR}"
+
+      - name: Upload archive
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: tsm-${{ matrix.archive_name }}
+          path: tsm-*.tar.gz
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631  # v2.2.2
+        with:
+          generate_release_notes: true
+          files: tsm-*.tar.gz

--- a/tsm.toml.sample
+++ b/tsm.toml.sample
@@ -1,0 +1,76 @@
+# tsm.toml — The Space Memory configuration
+#
+# Resolution priority: env var > config file > default
+# All fields are optional. Uncomment and modify as needed.
+
+# Root directory for all tsm data (DB, dictionaries, PID files, logs).
+# Default: ".tsm/"
+# Env: TSM_STATE_DIR
+# state_dir = ".tsm"
+
+# Root directory containing content workspaces to index.
+# Default: "/workspaces"
+# Env: TSM_INDEX_ROOT
+# index_root = "/workspaces"
+
+# UNIX socket path for tsm-embedder (encode requests).
+# Default: "{state_dir}/embedder.sock"
+# Env: TSM_EMBEDDER_SOCKET
+# embedder_socket_path = ".tsm/embedder.sock"
+
+# UNIX socket path for tsmd (client requests).
+# Default: "{state_dir}/daemon.sock"
+# Env: TSM_DAEMON_SOCKET
+# daemon_socket_path = ".tsm/daemon.sock"
+
+# Directory for daemon log files (tsmd, tsm-embedder).
+# Default: "{state_dir}/logs"
+# Env: TSM_LOG_DIR
+# log_dir = ".tsm/logs"
+
+# Seconds of inactivity before tsm-embedder shuts down. 0 = never.
+# Default: 600
+# Env: TSM_EMBEDDER_IDLE_TIMEOUT
+# embedder_idle_timeout_secs = 600
+
+# Seconds between periodic backfill checks. 0 = disable.
+# Default: 300
+# Env: TSM_EMBEDDER_BACKFILL_INTERVAL
+# embedder_backfill_interval_secs = 300
+
+# Behavior when the embedder is stopped during search.
+# Options: "error" (refuse to search) | "fts_only" (FTS5 fallback with warning)
+# Default: "error"
+# Env: TSM_SEARCH_FALLBACK
+# search_fallback = "error"
+
+# Path to user dictionary file (lindera IPAdic format).
+# Default: "{state_dir}/user_dict.simpledic"
+# Env: TSM_USER_DICT
+# user_dict_path = ".tsm/user_dict.simpledic"
+
+# ─── Index settings ───────────────────────────────────────────────
+
+[index]
+
+# Content directories to index. Each entry has:
+#   path           — directory path (required)
+#   weight         — scoring weight (default: 1.0)
+#   half_life_days — time decay half-life in days (default: 90.0)
+#
+# Empty = auto-discover mode (recursively index all .md under index_root).
+#
+# content_dirs = [
+#     { path = "/workspaces/notes", weight = 1.0, half_life_days = 90.0 },
+#     { path = "/workspaces/docs",  weight = 0.8, half_life_days = 180.0 },
+# ]
+
+[index.claude_session]
+
+# Score weight for Claude Code session data.
+# Default: 0.3
+# weight = 0.3
+
+# Half-life in days for Claude Code session data time decay.
+# Default: 30.0
+# half_life_days = 30.0


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` for tag-triggered releases (`v*`)
- Add `tsm.toml.sample` with all config options documented
- Include Claude Code hooks (index-file, ingest, search) for plugin integration
- Builds Linux x86_64 + macOS arm64, packages with README/LICENSE/stopwords/docs/hooks

## Archive contents
```
tsm-v0.2.1-darwin-arm64/
├── tsm, tsmd, tsm-embedder
├── README.md, LICENSE, tsm.toml.sample
├── data/stopwords.txt
├── docs/user-dictionary.md
└── hooks/ (hooks.json + scripts/)
```

## Test plan
- [x] TOML syntax valid (`tsm.toml.sample`)
- [x] YAML lint passes (`release.yml`)
- [x] Action SHA pins verified against GitHub tags
- [ ] Merge and test with `git tag v0.2.1 && git push --tags`