### PR TITLE
ci: update action SHAs to latest and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           tar czf "${DIR}.tar.gz" "${DIR}"
 
       - name: Upload archive
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: tsm-${{ matrix.archive_name }}
           path: tsm-*.tar.gz
@@ -64,12 +64,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631  # v2.2.2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         with:
           generate_release_notes: true
           files: tsm-*.tar.gz


### PR DESCRIPTION
## Summary
- Update `upload-artifact` v4.6.2 → v7.0.0 (fixes Node.js 20 deprecation warning)
- Update `download-artifact` v4.3.0 → v8.0.1
- Update `action-gh-release` v2.2.2 → v2.6.1
- Add `dependabot.yml` for weekly cargo + github-actions dependency updates

## Test plan
- [ ] Lint CI passes
- [ ] Next tag release uses updated actions without Node.js deprecation warning