### PR TITLE
feat: add --path flag to search for path prefix filtering

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -192,6 +192,7 @@ pub struct SearchOptions<'a> {
     pub recent: Option<&'a str>,
     pub year: Option<i32>,
     pub fallback: Option<&'a str>,
+    pub paths: Option<&'a [String]>,
 }
 
 /// Run search and return structured results (no DB open, no output).
@@ -233,6 +234,7 @@ pub fn run_search(
         opts.top_k,
         filter.as_ref(),
         require_vector,
+        opts.paths,
     )
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -194,6 +194,61 @@ mod tests {
     }
 
     #[test]
+    fn test_search_with_path_filter() {
+        let (conn, dir) = setup();
+        let flag = AtomicBool::new(false);
+
+        // Create files in two directories
+        let daily_dir = dir.path().join("daily/notes");
+        std::fs::create_dir_all(&daily_dir).unwrap();
+        std::fs::write(
+            daily_dir.join("mtg.md"),
+            "---\nstatus: current\n---\n\n# MTG\n\nMTG meeting notes.\n",
+        )
+        .unwrap();
+
+        let projects_dir = dir.path().join("projects/tsm");
+        std::fs::create_dir_all(&projects_dir).unwrap();
+        std::fs::write(
+            projects_dir.join("mtg.md"),
+            "---\nstatus: current\n---\n\n# MTG\n\nMTG project notes.\n",
+        )
+        .unwrap();
+
+        // Index both files
+        let req = DaemonRequest::Index {
+            files: vec!["daily/notes/mtg.md".into(), "projects/tsm/mtg.md".into()],
+        };
+        let resp = handle_request(&conn, req, dir.path(), &flag);
+        assert!(resp.ok);
+
+        // Search with path filter
+        let req = DaemonRequest::Search {
+            query: "MTG".into(),
+            top_k: 10,
+            format: "json".into(),
+            include_content: None,
+            after: None,
+            before: None,
+            recent: None,
+            year: None,
+            fallback: Some("fts_only".into()),
+            paths: Some(vec!["daily/".into()]),
+        };
+        let resp = handle_request(&conn, req, dir.path(), &flag);
+        assert!(resp.ok);
+        let results = resp.payload.unwrap();
+        let arr = results.as_array().unwrap();
+        for item in arr {
+            let path = item["source_file"].as_str().unwrap();
+            assert!(
+                path.starts_with("daily/"),
+                "Expected daily/ prefix, got: {path}"
+            );
+        }
+    }
+
+    #[test]
     fn test_index_empty() {
         let (conn, dir) = setup();
         let flag = AtomicBool::new(false);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -34,6 +34,7 @@ pub fn handle_request(
             recent,
             year,
             fallback,
+            paths,
         } => {
             let opts = cli::SearchOptions {
                 query: &query,
@@ -45,6 +46,7 @@ pub fn handle_request(
                 recent: recent.as_deref(),
                 year,
                 fallback: fallback.as_deref(),
+                paths: paths.as_deref(),
             };
             match cli::run_search(conn, &opts) {
                 Ok(results) => {
@@ -181,6 +183,7 @@ mod tests {
             recent: None,
             year: None,
             fallback: Some("fts_only".into()),
+            paths: None,
         };
         let resp = handle_request(&conn, req, dir.path(), &flag);
         assert!(resp.ok);
@@ -407,6 +410,7 @@ mod tests {
                 recent: None,
                 year: None,
                 fallback: Some("fts_only".into()),
+                paths: None,
             },
         )
         .unwrap();

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -195,6 +195,34 @@ mod tests {
     }
 
     #[test]
+    fn serde_roundtrip_search_with_paths() {
+        let req = DaemonRequest::Search {
+            query: "MTG".into(),
+            top_k: 5,
+            format: "json".into(),
+            include_content: None,
+            after: None,
+            before: None,
+            recent: None,
+            year: None,
+            fallback: None,
+            paths: Some(vec!["daily/".into(), "projects/".into()]),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"paths\""));
+        let decoded: DaemonRequest = serde_json::from_str(&json).unwrap();
+        match decoded {
+            DaemonRequest::Search { paths, .. } => {
+                assert_eq!(
+                    paths,
+                    Some(vec!["daily/".to_string(), "projects/".to_string()])
+                );
+            }
+            _ => panic!("Expected Search variant"),
+        }
+    }
+
+    #[test]
     fn serde_roundtrip_index() {
         let req = DaemonRequest::Index {
             files: vec!["daily/notes/test.md".into()],

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -26,6 +26,8 @@ pub enum DaemonRequest {
         year: Option<i32>,
         #[serde(skip_serializing_if = "Option::is_none")]
         fallback: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        paths: Option<Vec<String>>,
     },
     Index {
         files: Vec<String>,
@@ -171,6 +173,7 @@ mod tests {
             recent: None,
             year: None,
             fallback: None,
+            paths: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let decoded: DaemonRequest = serde_json::from_str(&json).unwrap();
@@ -376,6 +379,7 @@ mod tests {
             recent: None,
             year: None,
             fallback: None,
+            paths: None,
         };
         let req_bytes = serde_json::to_vec(&req).unwrap();
         let mut buf = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,9 @@ enum Commands {
         /// Embedder fallback mode: error (default) or fts_only
         #[arg(long, value_enum)]
         fallback: Option<SearchFallbackArg>,
+        /// Filter by path prefix (can be specified multiple times, OR combined)
+        #[arg(long = "path")]
+        paths: Vec<String>,
     },
     /// Ingest a session JSONL file
     IngestSession {
@@ -223,6 +226,7 @@ fn main() -> anyhow::Result<()> {
             recent,
             year,
             fallback,
+            paths,
         } => {
             // Always resolve fallback so the daemon uses the CLI caller's config
             let fallback = Some(
@@ -230,6 +234,7 @@ fn main() -> anyhow::Result<()> {
                     .map(|f| f.to_string())
                     .unwrap_or_else(|| config::search_fallback().to_string()),
             );
+            let paths = if paths.is_empty() { None } else { Some(paths) };
             let req = DaemonRequest::Search {
                 query,
                 top_k,
@@ -240,6 +245,7 @@ fn main() -> anyhow::Result<()> {
                 recent,
                 year,
                 fallback,
+                paths,
             };
             render_search(send_to_daemon(&req)?, &format)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,6 +234,16 @@ fn main() -> anyhow::Result<()> {
                     .map(|f| f.to_string())
                     .unwrap_or_else(|| config::search_fallback().to_string()),
             );
+            for p in &paths {
+                if p.is_empty() {
+                    anyhow::bail!("--path cannot be empty");
+                }
+                if std::path::Path::new(p).is_absolute() {
+                    anyhow::bail!(
+                        "--path must be a relative path (e.g. 'daily/'), got absolute: {p}"
+                    );
+                }
+            }
             let paths = if paths.is_empty() { None } else { Some(paths) };
             let req = DaemonRequest::Search {
                 query,

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -127,10 +127,14 @@ pub fn search(
         Some(prefixes) if !prefixes.is_empty() => {
             let conditions: Vec<String> = prefixes
                 .iter()
-                .map(|_| "d.file_path LIKE ?".to_string())
+                .map(|_| "d.file_path LIKE ? ESCAPE '\\'".to_string())
                 .collect();
             for p in prefixes {
-                extra_params.push(Box::new(format!("{}%", p)));
+                let escaped = p
+                    .replace('\\', "\\\\")
+                    .replace('%', "\\%")
+                    .replace('_', "\\_");
+                extra_params.push(Box::new(format!("{}%", escaped)));
             }
             format!(" AND ({})", conditions.join(" OR "))
         }
@@ -888,6 +892,82 @@ mod tests {
         assert!(!results.is_empty());
         for r in &results {
             assert_eq!(r.source_file, "docs/api.md");
+        }
+    }
+
+    #[test]
+    fn test_search_path_filter_escapes_like_metacharacters() {
+        use crate::indexer;
+        use std::io::Write;
+
+        let conn = db::get_memory_connection().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // Create files: one with underscore, one without
+        for (rel, title) in [
+            ("daily_notes/mtg.md", "Daily Notes MTG"),
+            ("dailyXnotes/mtg.md", "DailyX Notes MTG"),
+        ] {
+            let md =
+                format!("---\nstatus: current\n---\n\n# {title}\n\nMTG content for testing.\n");
+            let full = dir.path().join(rel);
+            std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+            let mut f = std::fs::File::create(&full).unwrap();
+            f.write_all(md.as_bytes()).unwrap();
+            indexer::index_file(&conn, &full, dir.path()).unwrap();
+        }
+
+        // _ in path must be literal, not a wildcard
+        let paths = vec!["daily_notes/".to_string()];
+        let results = search(&conn, "MTG", 10, None, false, Some(&paths)).unwrap();
+        assert!(!results.is_empty());
+        for r in &results {
+            assert!(
+                r.source_file.starts_with("daily_notes/"),
+                "Expected daily_notes/ prefix, got: {}",
+                r.source_file
+            );
+        }
+    }
+
+    #[test]
+    fn test_search_path_filter_with_time_filter() {
+        use crate::indexer;
+        use crate::temporal::TimeFilter;
+        use std::io::Write;
+
+        let conn = db::get_memory_connection().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        for (rel, date) in [
+            ("daily/recent.md", today.as_str()),
+            ("daily/old.md", "2020-01-01"),
+            ("projects/recent.md", today.as_str()),
+        ] {
+            let md = format!(
+                "---\nstatus: current\nupdated: {date}\n---\n\n# MTG\n\nMTG content here.\n"
+            );
+            let full = dir.path().join(rel);
+            std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+            let mut f = std::fs::File::create(&full).unwrap();
+            f.write_all(md.as_bytes()).unwrap();
+            indexer::index_file(&conn, &full, dir.path()).unwrap();
+        }
+
+        // Combine path filter + time filter
+        let paths = vec!["daily/".to_string()];
+        let filter = TimeFilter {
+            after: Some("2025-01-01".to_string()),
+            before: None,
+        };
+        let results = search(&conn, "MTG", 10, Some(&filter), false, Some(&paths)).unwrap();
+        for r in &results {
+            assert!(
+                r.source_file.starts_with("daily/"),
+                "Expected daily/ prefix, got: {}",
+                r.source_file
+            );
         }
     }
 

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -35,6 +35,7 @@ pub fn search(
     top_k: usize,
     time_filter: Option<&TimeFilter>,
     require_vector: bool,
+    path_prefixes: Option<&[String]>,
 ) -> anyhow::Result<Vec<SearchResult>> {
     // Query preprocessing: extract meaningful keywords, skip noise-only queries
     let keywords = extract_search_keywords(query);
@@ -122,12 +123,26 @@ pub fn search(
         format!(" AND {}", time_clauses.join(" AND "))
     };
 
+    let path_sql = match path_prefixes {
+        Some(prefixes) if !prefixes.is_empty() => {
+            let conditions: Vec<String> = prefixes
+                .iter()
+                .map(|_| "d.file_path LIKE ?".to_string())
+                .collect();
+            for p in prefixes {
+                extra_params.push(Box::new(format!("{}%", p)));
+            }
+            format!(" AND ({})", conditions.join(" OR "))
+        }
+        _ => String::new(),
+    };
+
     let sql = format!(
         "SELECT c.id AS chunk_id, c.section_path, c.content,
                 d.file_path, d.source_type, d.status, d.updated
          FROM chunks c
          JOIN documents d ON c.document_id = d.id
-         WHERE c.id IN ({placeholders}){time_sql}"
+         WHERE c.id IN ({placeholders}){time_sql}{path_sql}"
     );
 
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = all_chunk_ids
@@ -539,7 +554,7 @@ mod tests {
         indexer::index_file(&conn, &full, dir.path()).unwrap();
 
         // Search should find it
-        let results = search(&conn, "射撃", 5, None, false).unwrap();
+        let results = search(&conn, "射撃", 5, None, false, None).unwrap();
         assert!(!results.is_empty());
         assert!(results[0].source_file.contains("shooting"));
         assert!(results[0].score > 0.0);
@@ -549,14 +564,14 @@ mod tests {
     #[test]
     fn test_search_empty_query() {
         let conn = db::get_memory_connection().unwrap();
-        let results = search(&conn, "", 5, None, false).unwrap();
+        let results = search(&conn, "", 5, None, false, None).unwrap();
         assert!(results.is_empty());
     }
 
     #[test]
     fn test_search_no_results() {
         let conn = db::get_memory_connection().unwrap();
-        let results = search(&conn, "存在しないキーワード", 5, None, false).unwrap();
+        let results = search(&conn, "存在しないキーワード", 5, None, false, None).unwrap();
         assert!(results.is_empty());
     }
 
@@ -581,7 +596,7 @@ mod tests {
             indexer::index_file(&conn, &full, dir.path()).unwrap();
         }
 
-        let results = search(&conn, "テスト", 3, None, false).unwrap();
+        let results = search(&conn, "テスト", 3, None, false, None).unwrap();
         assert!(results.len() <= 3);
     }
 
@@ -609,7 +624,7 @@ mod tests {
             after: Some("2020-01-01".to_string()),
             before: Some("2099-01-01".to_string()),
         };
-        let results = search(&conn, "射撃", 5, Some(&filter), false).unwrap();
+        let results = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
         assert!(!results.is_empty());
     }
 
@@ -637,7 +652,7 @@ mod tests {
             after: Some("2099-01-01".to_string()),
             before: None,
         };
-        let results = search(&conn, "射撃", 5, Some(&filter), false).unwrap();
+        let results = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
         assert!(results.is_empty());
     }
 
@@ -661,7 +676,7 @@ mod tests {
             after: Some("2025-01-01".to_string()),
             before: None,
         };
-        let results = search(&conn, "射撃", 5, Some(&filter), false).unwrap();
+        let results = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
         assert!(!results.is_empty());
     }
 
@@ -693,7 +708,7 @@ mod tests {
     fn test_search_noise_query_returns_empty() {
         let conn = db::get_memory_connection().unwrap();
         // Pure interjection/greeting should return empty results
-        let results = search(&conn, "よかったーーー", 5, None, false).unwrap();
+        let results = search(&conn, "よかったーーー", 5, None, false, None).unwrap();
         assert!(
             results.is_empty(),
             "Noise query should return empty results"
@@ -703,7 +718,7 @@ mod tests {
     #[test]
     fn test_search_stopword_query_returns_empty() {
         let conn = db::get_memory_connection().unwrap();
-        let results = search(&conn, "なるほど", 5, None, false).unwrap();
+        let results = search(&conn, "なるほど", 5, None, false, None).unwrap();
         assert!(
             results.is_empty(),
             "Stopword-only query should return empty results"
@@ -727,8 +742,153 @@ mod tests {
         indexer::index_file(&conn, &full, dir.path()).unwrap();
 
         // A meaningful query should still find results
-        let results = search(&conn, "LoRaモジュール", 5, None, false).unwrap();
+        let results = search(&conn, "LoRaモジュール", 5, None, false, None).unwrap();
         assert!(!results.is_empty(), "Meaningful query should find results");
+    }
+
+    #[test]
+    fn test_search_with_path_filter_includes() {
+        use crate::indexer;
+        use std::io::Write;
+
+        let conn = db::get_memory_connection().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // Create files in different directories
+        let daily_md = "---\nstatus: current\n---\n\n# MTG Notes\n\nMTG meeting notes content.\n";
+        let daily_path = dir.path().join("daily/notes/mtg.md");
+        std::fs::create_dir_all(daily_path.parent().unwrap()).unwrap();
+        let mut f = std::fs::File::create(&daily_path).unwrap();
+        f.write_all(daily_md.as_bytes()).unwrap();
+
+        let project_md =
+            "---\nstatus: current\n---\n\n# Project MTG\n\nMTG project documentation.\n";
+        let project_path = dir.path().join("projects/tsm/mtg.md");
+        std::fs::create_dir_all(project_path.parent().unwrap()).unwrap();
+        let mut f = std::fs::File::create(&project_path).unwrap();
+        f.write_all(project_md.as_bytes()).unwrap();
+
+        indexer::index_file(&conn, &daily_path, dir.path()).unwrap();
+        indexer::index_file(&conn, &project_path, dir.path()).unwrap();
+
+        // Filter to daily/ only
+        let paths = vec!["daily/".to_string()];
+        let results = search(&conn, "MTG", 5, None, false, Some(&paths)).unwrap();
+        assert!(!results.is_empty());
+        for r in &results {
+            assert!(
+                r.source_file.starts_with("daily/"),
+                "Expected daily/ prefix, got: {}",
+                r.source_file
+            );
+        }
+    }
+
+    #[test]
+    fn test_search_with_path_filter_excludes() {
+        use crate::indexer;
+        use std::io::Write;
+
+        let conn = db::get_memory_connection().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let md = "---\nstatus: current\n---\n\n# MTG Notes\n\nMTG meeting notes.\n";
+        let path = dir.path().join("daily/notes/mtg.md");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(md.as_bytes()).unwrap();
+        indexer::index_file(&conn, &path, dir.path()).unwrap();
+
+        // Filter to projects/ — should exclude daily/
+        let paths = vec!["projects/".to_string()];
+        let results = search(&conn, "MTG", 5, None, false, Some(&paths)).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_with_multiple_path_filters() {
+        use crate::indexer;
+        use std::io::Write;
+
+        let conn = db::get_memory_connection().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        for (rel, title) in [
+            ("daily/notes/mtg.md", "Daily MTG"),
+            ("projects/tsm/mtg.md", "Project MTG"),
+            ("docs/api.md", "API MTG"),
+        ] {
+            let md =
+                format!("---\nstatus: current\n---\n\n# {title}\n\nMTG content for searching.\n");
+            let full = dir.path().join(rel);
+            std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+            let mut f = std::fs::File::create(&full).unwrap();
+            f.write_all(md.as_bytes()).unwrap();
+            indexer::index_file(&conn, &full, dir.path()).unwrap();
+        }
+
+        // Filter to daily/ and docs/ (OR)
+        let paths = vec!["daily/".to_string(), "docs/".to_string()];
+        let results = search(&conn, "MTG", 10, None, false, Some(&paths)).unwrap();
+        assert!(!results.is_empty());
+        for r in &results {
+            assert!(
+                r.source_file.starts_with("daily/") || r.source_file.starts_with("docs/"),
+                "Unexpected path: {}",
+                r.source_file
+            );
+        }
+    }
+
+    #[test]
+    fn test_search_with_no_path_filter_returns_all() {
+        use crate::indexer;
+        use std::io::Write;
+
+        let conn = db::get_memory_connection().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        for rel in ["daily/notes/mtg.md", "projects/tsm/mtg.md"] {
+            let md = "---\nstatus: current\n---\n\n# MTG Notes\n\nMTG meeting content.\n";
+            let full = dir.path().join(rel);
+            std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+            let mut f = std::fs::File::create(&full).unwrap();
+            f.write_all(md.as_bytes()).unwrap();
+            indexer::index_file(&conn, &full, dir.path()).unwrap();
+        }
+
+        // No path filter — should return results from both directories
+        let results = search(&conn, "MTG", 10, None, false, None).unwrap();
+        assert!(results.len() >= 2);
+    }
+
+    #[test]
+    fn test_search_with_file_path_filter() {
+        use crate::indexer;
+        use std::io::Write;
+
+        let conn = db::get_memory_connection().unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        for rel in ["docs/api.md", "docs/guide.md"] {
+            let md = format!(
+                "---\nstatus: current\n---\n\n# Auth\n\nAuthentication details for {}.\n",
+                rel
+            );
+            let full = dir.path().join(rel);
+            std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+            let mut f = std::fs::File::create(&full).unwrap();
+            f.write_all(md.as_bytes()).unwrap();
+            indexer::index_file(&conn, &full, dir.path()).unwrap();
+        }
+
+        // Filter to a specific file
+        let paths = vec!["docs/api.md".to_string()];
+        let results = search(&conn, "Authentication", 10, None, false, Some(&paths)).unwrap();
+        assert!(!results.is_empty());
+        for r in &results {
+            assert_eq!(r.source_file, "docs/api.md");
+        }
     }
 
     #[test]
@@ -750,7 +910,7 @@ mod tests {
         let _ = conn.execute("DELETE FROM dictionary_candidates", []);
 
         // Search should collect query candidates
-        let _ = search(&conn, "candle framework", 5, None, false);
+        let _ = search(&conn, "candle framework", 5, None, false, None);
 
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM dictionary_candidates", [], |r| {


### PR DESCRIPTION
## Summary

- Add `--path` CLI flag to `tsm search` for filtering results by file path prefix
- Multiple `--path` flags are OR-combined (e.g. `--path daily/ --path docs/`)
- Supports both directory prefixes and specific file paths
- Filter applied at the JOIN stage after FTS5/vector candidate retrieval

## Test plan

- [x] `test_search_with_path_filter_includes` — filtered results only contain matching prefix
- [x] `test_search_with_path_filter_excludes` — non-matching paths excluded
- [x] `test_search_with_multiple_path_filters` — OR combination works
- [x] `test_search_with_no_path_filter_returns_all` — backward compatible
- [x] `test_search_with_file_path_filter` — specific file path works
- [ ] E2E: `tsm search -q "keyword" --path daily/`

Closes #84