### PR TITLE
refactor: remove unused ipadic dict format, simpledic only

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1084,11 +1084,7 @@ fn estimate_eta(started_at: &str, processed: usize, total: usize) -> String {
     }
 }
 
-pub fn cmd_dict_update(
-    threshold: i64,
-    apply: bool,
-    format: user_dict::DictFormat,
-) -> anyhow::Result<()> {
+pub fn cmd_dict_update(threshold: i64, apply: bool) -> anyhow::Result<()> {
     let db_path = config::db_path();
     let conn = db::get_connection(&db_path)?;
 
@@ -1115,7 +1111,7 @@ pub fn cmd_dict_update(
 
     // Export to CSV
     let csv_path = config::user_dict_path();
-    let exported = user_dict::export_candidates_to_csv(&conn, &csv_path, threshold, format)?;
+    let exported = user_dict::export_candidates_to_csv(&conn, &csv_path, threshold)?;
     let count = exported.len();
     log::info!("Wrote {count} word(s) to {}", csv_path.display());
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -333,7 +333,6 @@ mod tests {
         let req = DaemonRequest::DictUpdate {
             threshold: 5,
             apply: true,
-            format: "ipadic".into(),
         };
         let resp = handle_request(&conn, req, dir.path(), &flag);
         assert!(!resp.ok);

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -45,7 +45,6 @@ pub enum DaemonRequest {
     DictUpdate {
         threshold: i64,
         apply: bool,
-        format: String,
     },
     ImportWordnet {
         wordnet_db: String,
@@ -289,19 +288,13 @@ mod tests {
         let req = DaemonRequest::DictUpdate {
             threshold: 10,
             apply: true,
-            format: "ipadic".into(),
         };
         let json = serde_json::to_string(&req).unwrap();
         let decoded: DaemonRequest = serde_json::from_str(&json).unwrap();
         match decoded {
-            DaemonRequest::DictUpdate {
-                threshold,
-                apply,
-                format,
-            } => {
+            DaemonRequest::DictUpdate { threshold, apply } => {
                 assert_eq!(threshold, 10);
                 assert!(apply);
-                assert_eq!(format, "ipadic");
             }
             _ => panic!("Expected DictUpdate variant"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,23 +6,6 @@ use clap::{Parser, Subcommand, ValueEnum};
 use the_space_memory::cli;
 use the_space_memory::config;
 use the_space_memory::daemon_protocol::{self, DaemonRequest, DaemonResponse};
-use the_space_memory::user_dict::DictFormat;
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-enum DictFormatArg {
-    Simpledic,
-    Ipadic,
-}
-
-impl From<DictFormatArg> for DictFormat {
-    fn from(arg: DictFormatArg) -> Self {
-        match arg {
-            DictFormatArg::Simpledic => DictFormat::Simpledic,
-            DictFormatArg::Ipadic => DictFormat::Ipadic,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum SearchFallbackArg {
     Error,
@@ -59,9 +42,6 @@ enum DictCommands {
         /// Add words to dict and rebuild FTS
         #[arg(long)]
         apply: bool,
-        /// CSV format: simpledic (janome) or ipadic (lindera)
-        #[arg(long, value_enum, default_value = "ipadic")]
-        format: DictFormatArg,
     },
     /// Manage reject list (reject_words.txt)
     Reject {
@@ -200,15 +180,11 @@ fn main() -> anyhow::Result<()> {
             }
         }
         Commands::Dict { command } => match command {
-            DictCommands::Update {
-                threshold,
-                apply,
-                format,
-            } => {
+            DictCommands::Update { threshold, apply } => {
                 if apply {
                     guard_daemon_not_running("dict update --apply")?;
                 }
-                cli::cmd_dict_update(threshold, apply, format.into())?;
+                cli::cmd_dict_update(threshold, apply)?;
             }
             DictCommands::Reject { apply, all } => {
                 cli::cmd_dict_reject(apply, all)?;

--- a/src/user_dict.rs
+++ b/src/user_dict.rs
@@ -27,40 +27,6 @@ impl CandidatePos {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DictFormat {
-    Simpledic,
-    Ipadic,
-}
-
-impl DictFormat {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Simpledic => "simpledic",
-            Self::Ipadic => "ipadic",
-        }
-    }
-}
-
-impl std::str::FromStr for DictFormat {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "simpledic" => Ok(Self::Simpledic),
-            "ipadic" => Ok(Self::Ipadic),
-            other => Err(format!(
-                "unknown format '{other}'. Supported: simpledic, ipadic"
-            )),
-        }
-    }
-}
-
-impl std::fmt::Display for DictFormat {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
 // ─── Data types ──────────────────────────────────────────────
 
 /// A dictionary candidate record.
@@ -448,19 +414,13 @@ pub fn format_simpledic_row(surface: &str) -> String {
     format!("{surface},カスタム名詞,{surface}")
 }
 
-/// Format a CSV row in lindera user dictionary format (3 fields: surface, pos, reading).
-/// lindera IPAdic user dictionary expects exactly 3 fields, not the full 13-field system dict format.
-pub fn format_ipadic_row(surface: &str) -> String {
-    format!("{surface},カスタム名詞,{surface}")
-}
-
 /// Export threshold candidates to a CSV file (appending).
 /// Returns the list of newly written candidates.
+/// Output format is simpledic (3 fields: surface, pos, reading).
 pub fn export_candidates_to_csv(
     conn: &Connection,
     csv_path: &Path,
     threshold: i64,
-    format: DictFormat,
 ) -> anyhow::Result<Vec<Candidate>> {
     let candidates = get_threshold_candidates(conn, threshold);
     if candidates.is_empty() {
@@ -497,10 +457,7 @@ pub fn export_candidates_to_csv(
         .open(csv_path)?;
 
     for c in &new_candidates {
-        let row = match format {
-            DictFormat::Ipadic => format_ipadic_row(&c.surface),
-            DictFormat::Simpledic => format_simpledic_row(&c.surface),
-        };
+        let row = format_simpledic_row(&c.surface);
         writeln!(file, "{row}")?;
     }
 
@@ -523,16 +480,6 @@ mod tests {
         assert_eq!(CandidatePos::ProperNoun.as_str(), "proper_noun");
         assert_eq!(CandidatePos::Katakana.as_str(), "katakana");
         assert_eq!(CandidatePos::Ascii.as_str(), "ascii");
-    }
-
-    #[test]
-    fn test_dict_format_parse() {
-        assert_eq!(
-            "simpledic".parse::<DictFormat>().unwrap(),
-            DictFormat::Simpledic
-        );
-        assert_eq!("ipadic".parse::<DictFormat>().unwrap(), DictFormat::Ipadic);
-        assert!("invalid".parse::<DictFormat>().is_err());
     }
 
     // ─── is_valid_candidate tests ────────────────────────────
@@ -867,11 +814,6 @@ mod tests {
         assert_eq!(format_simpledic_row("candle"), "candle,カスタム名詞,candle");
     }
 
-    #[test]
-    fn test_format_ipadic_row() {
-        assert_eq!(format_ipadic_row("candle"), "candle,カスタム名詞,candle");
-    }
-
     // ─── load_existing_surfaces tests ────────────────────────
 
     #[test]
@@ -921,8 +863,7 @@ mod tests {
             [now, now],
         ).unwrap();
 
-        let exported =
-            export_candidates_to_csv(&conn, &csv_path, 5, DictFormat::Simpledic).unwrap();
+        let exported = export_candidates_to_csv(&conn, &csv_path, 5).unwrap();
         assert_eq!(exported.len(), 1);
         assert_eq!(exported[0].surface, "candle");
         assert!(csv_path.exists());
@@ -952,8 +893,7 @@ mod tests {
             [now, now],
         ).unwrap();
 
-        let exported1 =
-            export_candidates_to_csv(&conn, &csv_path, 5, DictFormat::Simpledic).unwrap();
+        let exported1 = export_candidates_to_csv(&conn, &csv_path, 5).unwrap();
         assert_eq!(exported1.len(), 1);
 
         conn.execute(
@@ -962,28 +902,11 @@ mod tests {
         )
         .unwrap();
 
-        let exported2 =
-            export_candidates_to_csv(&conn, &csv_path, 5, DictFormat::Simpledic).unwrap();
+        let exported2 = export_candidates_to_csv(&conn, &csv_path, 5).unwrap();
         assert!(exported2.is_empty(), "should not write duplicates");
     }
 
     #[test]
-    fn test_export_candidates_ipadic_format() {
-        let conn = setup();
-        let dir = tempfile::TempDir::new().unwrap();
-        let csv_path = dir.path().join("user_dict.csv");
-
-        let now = "2026-01-01T00:00:00Z";
-        conn.execute(
-            "INSERT INTO dictionary_candidates VALUES ('lindera', 10, 'ascii', 'document', ?, ?, 'pending')",
-            [now, now],
-        ).unwrap();
-
-        export_candidates_to_csv(&conn, &csv_path, 5, DictFormat::Ipadic).unwrap();
-        let content = std::fs::read_to_string(&csv_path).unwrap();
-        assert!(content.contains("lindera,カスタム名詞,lindera"));
-    }
-
     #[test]
     fn test_export_candidates_preserves_existing_rows() {
         let conn = setup();
@@ -999,7 +922,7 @@ mod tests {
             [now, now],
         ).unwrap();
 
-        export_candidates_to_csv(&conn, &csv_path, 5, DictFormat::Simpledic).unwrap();
+        export_candidates_to_csv(&conn, &csv_path, 5).unwrap();
 
         let content = std::fs::read_to_string(&csv_path).unwrap();
         assert!(
@@ -1015,8 +938,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let csv_path = dir.path().join("user_dict.csv");
 
-        let exported =
-            export_candidates_to_csv(&conn, &csv_path, 5, DictFormat::Simpledic).unwrap();
+        let exported = export_candidates_to_csv(&conn, &csv_path, 5).unwrap();
         assert!(exported.is_empty());
         assert!(!csv_path.exists());
     }


### PR DESCRIPTION
## Summary

- Remove `DictFormat` enum — simpledic is the only format lindera can consume
- Remove `--format` flag from `tsm dict update` CLI
- Remove `format` field from `DaemonRequest::DictUpdate` protocol
- Remove `format_ipadic_row` and related tests
- Net deletion: 114 lines

## Background

`format_ipadic_row` and `format_simpledic_row` produced identical output (`surface,カスタム名詞,surface`). The ipadic variant was never tested against lindera's actual IPAdic parser and would not have worked with the full 13-field format. Since lindera's `load_user_dictionary_from_csv` expects simpledic format, the ipadic option was dead code.

## Test plan

- [x] `cargo test` — all 441 tests pass
- [x] `cargo clippy -- -D warnings` — clean