### PR TITLE
feat: add GitHub release template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - breaking
+    - title: "New Features"
+      labels:
+        - enhancement
+        - feature
+    - title: "Bug Fixes"
+      labels:
+        - bug
+    - title: "Performance"
+      labels:
+        - performance
+    - title: "Documentation"
+      labels:
+        - documentation
+    - title: "Other Changes"
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary

- Add `.github/release.yml` to categorize release notes by PR labels (Breaking Changes / New Features / Bug Fixes / Performance / Documentation / Other Changes)
- Add missing labels to repository: `performance`, `breaking`, `skip-changelog`

Closes #100

## Test plan

- [ ] Verify `.github/release.yml` syntax is valid
- [ ] Confirm next release generates categorized notes when PRs have labels