### PR TITLE
feat: add PR labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,3 +12,6 @@ performance:
 
 dependencies:
   - head-branch: ['^dependabot/']
+
+chore:
+  - head-branch: ['^chore/']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,3 +9,6 @@ documentation:
 
 performance:
   - head-branch: ['^perf/']
+
+dependencies:
+  - head-branch: ['^dependabot/']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+enhancement:
+  - head-branch: ['^feat/']
+
+bug:
+  - head-branch: ['^fix/']
+
+documentation:
+  - head-branch: ['^docs/']
+
+performance:
+  - head-branch: ['^perf/']

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -19,6 +19,10 @@ changelog:
     - title: "Documentation"
       labels:
         - documentation
+    - title: "House Keeping"
+      labels:
+        - chore
+        - dependencies
     - title: "Other Changes"
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,26 +3,26 @@ changelog:
     labels:
       - skip-changelog
   categories:
-    - title: "Breaking Changes"
+    - title: "💥 Breaking Changes"
       labels:
         - breaking
-    - title: "New Features"
+    - title: "🚀 New Features"
       labels:
         - enhancement
         - feature
-    - title: "Bug Fixes"
+    - title: "🐛 Bug Fixes"
       labels:
         - bug
-    - title: "Performance"
+    - title: "⚡ Performance"
       labels:
         - performance
-    - title: "Documentation"
+    - title: "📚 Documentation"
       labels:
         - documentation
-    - title: "House Keeping"
+    - title: "🏠 House Keeping"
       labels:
         - chore
         - dependencies
-    - title: "Other Changes"
+    - title: "📦 Other Changes"
       labels:
         - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+        with:
+          configuration-path: .github/labeler.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,18 @@ src/
 - Embedder tests should use mockable trait design
 - Tests must not depend on external daemon state (embedder, etc.)
 
+## Branch Naming
+
+Branch names must follow `<type>/<description>` format.
+The PR labeler workflow (`.github/labeler.yml`) maps prefixes to labels:
+
+| Prefix | Label |
+|---|---|
+| `feat/` | enhancement |
+| `fix/` | bug |
+| `docs/` | documentation |
+| `perf/` | performance |
+
 ## Build & Deploy
 
 Build from a host container via Docker, then reference the binary from hooks/skills.


### PR DESCRIPTION
## Summary

- Add `actions/labeler` workflow to auto-label PRs based on branch name prefix
  - `feat/` → `enhancement`
  - `fix/` → `bug`
  - `docs/` → `documentation`
  - `perf/` → `performance`
- Backfilled labels on all merged PRs since v0.1.0

Closes #100

## Test plan

- [ ] Create a PR with `feat/` branch prefix → gets `enhancement` label
- [ ] Create a PR with `fix/` branch prefix → gets `bug` label