### PR TITLE
chore: add tsm.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .claude/settings.local.json
+tsm.toml
 
 # Rust
 /target/


### PR DESCRIPTION
## Summary

- Add `tsm.toml` to `.gitignore` — workspace-local config that varies per machine

## Test plan

- [x] `git status` no longer shows `tsm.toml` as untracked