### PR TITLE
feat: store model files in state_dir instead of HF Hub cache

### DIFF
--- a/src/bin/tsmd/daemon_mode.rs
+++ b/src/bin/tsmd/daemon_mode.rs
@@ -92,9 +92,10 @@ pub fn run(args: Args) -> Result<()> {
         } else {
             let _ = std::fs::remove_file(&embedder_pid_path);
             child::remove_stale_socket(&config::embedder_socket_path());
+            let model_arg = format!("--model={}", config::models_dir().display());
             let spawned = child::spawn_child(
                 "embedder",
-                &["--embedder", "--no-idle-timeout"],
+                &["--embedder", "--no-idle-timeout", &model_arg],
                 &embedder_pid_path,
             );
             if let Some(ref c) = spawned {

--- a/src/bin/tsmd/daemon_mode.rs
+++ b/src/bin/tsmd/daemon_mode.rs
@@ -92,12 +92,24 @@ pub fn run(args: Args) -> Result<()> {
         } else {
             let _ = std::fs::remove_file(&embedder_pid_path);
             child::remove_stale_socket(&config::embedder_socket_path());
-            let model_arg = format!("--model={}", config::models_dir().display());
-            let spawned = child::spawn_child(
-                "embedder",
-                &["--embedder", "--no-idle-timeout", &model_arg],
-                &embedder_pid_path,
-            );
+            let spawned = if let Some(dir) = config::models_dir_complete() {
+                let model_arg = format!("--model={}", dir.display());
+                child::spawn_child(
+                    "embedder",
+                    &["--embedder", "--no-idle-timeout", &model_arg],
+                    &embedder_pid_path,
+                )
+            } else {
+                log::warn!(
+                    "Local model files not found in {}; embedder will use HF Hub cache",
+                    config::models_dir().display()
+                );
+                child::spawn_child(
+                    "embedder",
+                    &["--embedder", "--no-idle-timeout"],
+                    &embedder_pid_path,
+                )
+            };
             if let Some(ref c) = spawned {
                 status::update(&state_dir, |s| {
                     s.embedder = Some(status::EmbedderStatus {

--- a/src/bin/tsmd/embedder_mode.rs
+++ b/src/bin/tsmd/embedder_mode.rs
@@ -38,12 +38,23 @@ fn run_daemon(socket_path: &Path, model_dir: Option<&Path>) -> Result<()> {
 
     log::info!("Loading model...");
     let embedder = if let Some(dir) = model_dir {
-        Embedder::load_from_paths(
-            &dir.join("config.json"),
-            &dir.join("tokenizer.json"),
-            &dir.join("model.safetensors"),
-            &Device::Cpu,
-        )?
+        let has_all_files = ["config.json", "tokenizer.json", "model.safetensors"]
+            .iter()
+            .all(|f| dir.join(f).is_file());
+        if has_all_files {
+            Embedder::load_from_paths(
+                &dir.join("config.json"),
+                &dir.join("tokenizer.json"),
+                &dir.join("model.safetensors"),
+                &Device::Cpu,
+            )?
+        } else {
+            log::warn!(
+                "Model files incomplete in {}; falling back to default load",
+                dir.display()
+            );
+            Embedder::load(&Device::Cpu)?
+        }
     } else {
         Embedder::load(&Device::Cpu)?
     };

--- a/src/bin/tsmd/embedder_mode.rs
+++ b/src/bin/tsmd/embedder_mode.rs
@@ -29,6 +29,28 @@ pub fn run(model: Option<PathBuf>, no_idle_timeout: bool) -> Result<()> {
     run_daemon(&socket_path, model.as_deref())
 }
 
+/// Load model from explicit directory or fall back to default resolution.
+fn load_model(model_dir: Option<&Path>) -> Result<Embedder> {
+    if let Some(dir) = model_dir {
+        let has_all_files = ["config.json", "tokenizer.json", "model.safetensors"]
+            .iter()
+            .all(|f| dir.join(f).is_file());
+        if has_all_files {
+            return Embedder::load_from_paths(
+                &dir.join("config.json"),
+                &dir.join("tokenizer.json"),
+                &dir.join("model.safetensors"),
+                &Device::Cpu,
+            );
+        }
+        log::warn!(
+            "Model files incomplete in {}; falling back to default load",
+            dir.display()
+        );
+    }
+    Embedder::load(&Device::Cpu)
+}
+
 /// Run the embedder socket server loop.
 fn run_daemon(socket_path: &Path, model_dir: Option<&Path>) -> Result<()> {
     // Clean up stale socket
@@ -37,27 +59,7 @@ fn run_daemon(socket_path: &Path, model_dir: Option<&Path>) -> Result<()> {
     }
 
     log::info!("Loading model...");
-    let embedder = if let Some(dir) = model_dir {
-        let has_all_files = ["config.json", "tokenizer.json", "model.safetensors"]
-            .iter()
-            .all(|f| dir.join(f).is_file());
-        if has_all_files {
-            Embedder::load_from_paths(
-                &dir.join("config.json"),
-                &dir.join("tokenizer.json"),
-                &dir.join("model.safetensors"),
-                &Device::Cpu,
-            )?
-        } else {
-            log::warn!(
-                "Model files incomplete in {}; falling back to default load",
-                dir.display()
-            );
-            Embedder::load(&Device::Cpu)?
-        }
-    } else {
-        Embedder::load(&Device::Cpu)?
-    };
+    let embedder = load_model(model_dir)?;
     log::info!("Model loaded.");
 
     log::info!("Listening on {}", socket_path.display());

--- a/src/bin/tsmd/embedder_mode.rs
+++ b/src/bin/tsmd/embedder_mode.rs
@@ -32,9 +32,7 @@ pub fn run(model: Option<PathBuf>, no_idle_timeout: bool) -> Result<()> {
 /// Load model from explicit directory or fall back to default resolution.
 fn load_model(model_dir: Option<&Path>) -> Result<Embedder> {
     if let Some(dir) = model_dir {
-        let has_all_files = config::MODEL_FILES
-            .iter()
-            .all(|f| dir.join(f).is_file());
+        let has_all_files = config::MODEL_FILES.iter().all(|f| dir.join(f).is_file());
         if has_all_files {
             return Embedder::load_from_paths(
                 &dir.join("config.json"),

--- a/src/bin/tsmd/embedder_mode.rs
+++ b/src/bin/tsmd/embedder_mode.rs
@@ -32,7 +32,7 @@ pub fn run(model: Option<PathBuf>, no_idle_timeout: bool) -> Result<()> {
 /// Load model from explicit directory or fall back to default resolution.
 fn load_model(model_dir: Option<&Path>) -> Result<Embedder> {
     if let Some(dir) = model_dir {
-        let has_all_files = ["config.json", "tokenizer.json", "model.safetensors"]
+        let has_all_files = config::MODEL_FILES
             .iter()
             .all(|f| dir.join(f).is_file());
         if has_all_files {
@@ -44,7 +44,8 @@ fn load_model(model_dir: Option<&Path>) -> Result<Embedder> {
             );
         }
         log::warn!(
-            "Model files incomplete in {}; falling back to default load",
+            "Model files incomplete in {}; falling back to HF Hub cache. \
+             Run `tsm setup` to install model files locally.",
             dir.display()
         );
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1915,6 +1915,7 @@ mod tests {
             "expected model warning, got: {issues:?}"
         );
         std::env::remove_var("TSM_STATE_DIR");
+        config::reload();
     }
 
     #[test]
@@ -1940,6 +1941,7 @@ mod tests {
             "expected model OK, got: {ok:?}"
         );
         std::env::remove_var("TSM_STATE_DIR");
+        config::reload();
     }
 
     #[test]
@@ -1969,5 +1971,6 @@ mod tests {
             "expected missing file name, got: {issues:?}"
         );
         std::env::remove_var("TSM_STATE_DIR");
+        config::reload();
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -463,6 +463,20 @@ pub fn cmd_setup() -> anyhow::Result<()> {
     log::info!("  config:    {}", config_path.display());
     log::info!("  tokenizer: {}", tokenizer_path.display());
     log::info!("  weights:   {}", weights_path.display());
+
+    // Copy to models_dir for local access
+    let dest = config::models_dir();
+    std::fs::create_dir_all(&dest)?;
+    for (src, name) in [
+        (&config_path, "config.json"),
+        (&tokenizer_path, "tokenizer.json"),
+        (&weights_path, "model.safetensors"),
+    ] {
+        let dst = dest.join(name);
+        std::fs::copy(src, &dst)?;
+        log::info!("  copied: {}", dst.display());
+    }
+    log::info!("Model files installed to {}", dest.display());
     Ok(())
 }
 
@@ -661,6 +675,39 @@ fn doctor_check_with_conn(
             status: CheckStatus::Warning,
             message: "Stopped".to_string(),
             hint: Some("Run `tsmd` to start the daemon (includes embedder).".to_string()),
+        });
+    }
+
+    // Check local model files
+    let models_dir = config::models_dir();
+    let model_files = ["config.json", "tokenizer.json", "model.safetensors"];
+    let present: Vec<&str> = model_files
+        .iter()
+        .filter(|f| models_dir.join(f).is_file())
+        .copied()
+        .collect();
+    if present.len() == model_files.len() {
+        emb_section.items.push(CheckItem {
+            status: CheckStatus::Ok,
+            message: format!("Model: {}", models_dir.display()),
+            hint: None,
+        });
+    } else if present.is_empty() {
+        emb_section.items.push(CheckItem {
+            status: CheckStatus::Warning,
+            message: format!("Model: not found in {}", models_dir.display()),
+            hint: Some("Run `tsm setup` to download and install model files.".to_string()),
+        });
+    } else {
+        let missing: Vec<&str> = model_files
+            .iter()
+            .filter(|f| !present.contains(f))
+            .copied()
+            .collect();
+        emb_section.items.push(CheckItem {
+            status: CheckStatus::Warning,
+            message: format!("Model: incomplete (missing: {})", missing.join(", ")),
+            hint: Some("Run `tsm setup` to re-download model files.".to_string()),
         });
     }
 
@@ -1837,5 +1884,45 @@ mod tests {
             .collect();
         assert!(names.contains(&"note.md"));
         assert!(!names.contains(&"secret.md"));
+    }
+
+    #[test]
+    fn test_doctor_model_files_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        db::init_db(&db_path).unwrap();
+
+        let report = doctor_check(&db_path);
+        // models_dir points to default .tsm/models/ruri-v3-30m which won't exist
+        let issues = report.issues();
+        assert!(
+            issues.iter().any(|s| s.contains("Model:")),
+            "expected model warning, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn test_doctor_model_files_present() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        db::init_db(&db_path).unwrap();
+
+        // Create model files in the default models_dir (.tsm/models/ruri-v3-30m)
+        let models_dir = config::models_dir();
+        std::fs::create_dir_all(&models_dir).unwrap();
+        for f in ["config.json", "tokenizer.json", "model.safetensors"] {
+            std::fs::write(models_dir.join(f), "dummy").unwrap();
+        }
+
+        let conn = db::get_connection(&db_path).unwrap();
+        let report = run_doctor(&conn, &db_path);
+        let ok = report.ok();
+        assert!(
+            ok.iter().any(|s| s.contains("Model:")),
+            "expected model OK, got: {ok:?}"
+        );
+
+        // Clean up
+        let _ = std::fs::remove_dir_all(models_dir.parent().unwrap());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -467,14 +467,27 @@ pub fn cmd_setup() -> anyhow::Result<()> {
     // Copy to models_dir for local access
     let dest = config::models_dir();
     std::fs::create_dir_all(&dest)?;
-    for (src, name) in [
+    let sources = [
         (&config_path, "config.json"),
         (&tokenizer_path, "tokenizer.json"),
         (&weights_path, "model.safetensors"),
-    ] {
-        let dst = dest.join(name);
-        std::fs::copy(src, &dst)?;
-        log::info!("  copied: {}", dst.display());
+    ];
+    let mut copied: Vec<std::path::PathBuf> = Vec::new();
+    let copy_result = (|| -> anyhow::Result<()> {
+        for (src, name) in &sources {
+            let dst = dest.join(name);
+            std::fs::copy(src, &dst)?;
+            copied.push(dst.clone());
+            log::info!("  copied: {}", dst.display());
+        }
+        Ok(())
+    })();
+    if let Err(e) = copy_result {
+        log::warn!("Setup failed; cleaning up partial files");
+        for f in &copied {
+            let _ = std::fs::remove_file(f);
+        }
+        return Err(e);
     }
     log::info!("Model files installed to {}", dest.display());
     Ok(())
@@ -680,7 +693,7 @@ fn doctor_check_with_conn(
 
     // Check local model files
     let models_dir = config::models_dir();
-    let model_files = ["config.json", "tokenizer.json", "model.safetensors"];
+    let model_files = config::MODEL_FILES;
     let present: Vec<&str> = model_files
         .iter()
         .filter(|f| models_dir.join(f).is_file())
@@ -705,7 +718,7 @@ fn doctor_check_with_conn(
             .copied()
             .collect();
         emb_section.items.push(CheckItem {
-            status: CheckStatus::Warning,
+            status: CheckStatus::Error,
             message: format!("Model: incomplete (missing: {})", missing.join(", ")),
             hint: Some("Run `tsm setup` to re-download model files.".to_string()),
         });
@@ -1887,30 +1900,35 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_doctor_model_files_missing() {
         let dir = tempfile::TempDir::new().unwrap();
+        std::env::set_var("TSM_STATE_DIR", dir.path());
+        config::reload();
         let db_path = dir.path().join("test.db");
         db::init_db(&db_path).unwrap();
 
         let report = doctor_check(&db_path);
-        // models_dir points to default .tsm/models/ruri-v3-30m which won't exist
         let issues = report.issues();
         assert!(
             issues.iter().any(|s| s.contains("Model:")),
             "expected model warning, got: {issues:?}"
         );
+        std::env::remove_var("TSM_STATE_DIR");
     }
 
     #[test]
+    #[serial_test::serial]
     fn test_doctor_model_files_present() {
         let dir = tempfile::TempDir::new().unwrap();
+        std::env::set_var("TSM_STATE_DIR", dir.path());
+        config::reload();
         let db_path = dir.path().join("test.db");
         db::init_db(&db_path).unwrap();
 
-        // Create model files in the default models_dir (.tsm/models/ruri-v3-30m)
         let models_dir = config::models_dir();
         std::fs::create_dir_all(&models_dir).unwrap();
-        for f in ["config.json", "tokenizer.json", "model.safetensors"] {
+        for f in config::MODEL_FILES {
             std::fs::write(models_dir.join(f), "dummy").unwrap();
         }
 
@@ -1921,8 +1939,35 @@ mod tests {
             ok.iter().any(|s| s.contains("Model:")),
             "expected model OK, got: {ok:?}"
         );
+        std::env::remove_var("TSM_STATE_DIR");
+    }
 
-        // Clean up
-        let _ = std::fs::remove_dir_all(models_dir.parent().unwrap());
+    #[test]
+    #[serial_test::serial]
+    fn test_doctor_model_files_partial() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::env::set_var("TSM_STATE_DIR", dir.path());
+        config::reload();
+        let db_path = dir.path().join("test.db");
+        db::init_db(&db_path).unwrap();
+
+        let models_dir = config::models_dir();
+        std::fs::create_dir_all(&models_dir).unwrap();
+        // Only create 2 of 3 files
+        std::fs::write(models_dir.join("config.json"), "{}").unwrap();
+        std::fs::write(models_dir.join("tokenizer.json"), "{}").unwrap();
+
+        let conn = db::get_connection(&db_path).unwrap();
+        let report = run_doctor(&conn, &db_path);
+        let issues = report.issues();
+        assert!(
+            issues.iter().any(|s| s.contains("incomplete")),
+            "expected incomplete warning, got: {issues:?}"
+        );
+        assert!(
+            issues.iter().any(|s| s.contains("model.safetensors")),
+            "expected missing file name, got: {issues:?}"
+        );
+        std::env::remove_var("TSM_STATE_DIR");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -552,7 +552,9 @@ pub fn daemon_pid_path() -> PathBuf {
 
 // ─── Local model directory ──────────────────────────────────────
 
-const MODEL_FILES: [&str; 3] = ["config.json", "tokenizer.json", "model.safetensors"];
+/// Canonical list of required model files. Used by `models_dir_complete()`,
+/// `embedder_mode::load_model()`, and `doctor_check_with_conn()`.
+pub const MODEL_FILES: [&str; 3] = ["config.json", "tokenizer.json", "model.safetensors"];
 
 /// Directory for locally cached model files: `{state_dir}/models/ruri-v3-30m/`.
 pub fn models_dir() -> PathBuf {
@@ -560,7 +562,7 @@ pub fn models_dir() -> PathBuf {
 }
 
 /// Check if all required model files exist in `models_dir()`.
-/// Returns `Some(path)` if all 3 files are present, `None` otherwise.
+/// Returns `Some(path)` if all files in `MODEL_FILES` are present, `None` otherwise.
 pub fn models_dir_complete() -> Option<PathBuf> {
     let dir = models_dir();
     if MODEL_FILES.iter().all(|f| dir.join(f).is_file()) {
@@ -1351,48 +1353,61 @@ half_life_days = 180
     #[serial]
     fn test_models_dir_default() {
         std::env::remove_var("TSM_STATE_DIR");
+        reload();
         let dir = models_dir();
         assert_eq!(dir, PathBuf::from(".tsm/models/ruri-v3-30m"));
     }
 
     #[test]
+    #[serial]
+    fn test_models_dir_with_custom_state_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("TSM_STATE_DIR", tmp.path());
+        reload();
+        let dir = models_dir();
+        assert_eq!(dir, tmp.path().join("models/ruri-v3-30m"));
+        std::env::remove_var("TSM_STATE_DIR");
+    }
+
+    #[test]
+    #[serial]
     fn test_models_dir_complete_empty() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let dir = tmp.path().join("models/ruri-v3-30m");
+        std::env::set_var("TSM_STATE_DIR", tmp.path());
+        reload();
+        let dir = models_dir();
         std::fs::create_dir_all(&dir).unwrap();
-        // No files — should return None
-        let check = MODEL_FILES.iter().all(|f| dir.join(f).is_file());
-        assert!(!check);
+        assert!(models_dir_complete().is_none());
+        std::env::remove_var("TSM_STATE_DIR");
     }
 
     #[test]
+    #[serial]
     fn test_models_dir_complete_partial() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let dir = tmp.path().join("models/ruri-v3-30m");
+        std::env::set_var("TSM_STATE_DIR", tmp.path());
+        reload();
+        let dir = models_dir();
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("config.json"), "{}").unwrap();
-        // Only 1 of 3 — should not be complete
-        let check = MODEL_FILES.iter().all(|f| dir.join(f).is_file());
-        assert!(!check);
+        assert!(models_dir_complete().is_none());
+        std::env::remove_var("TSM_STATE_DIR");
     }
 
     #[test]
+    #[serial]
     fn test_models_dir_complete_all_present() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let dir = tmp.path().join("models/ruri-v3-30m");
+        std::env::set_var("TSM_STATE_DIR", tmp.path());
+        reload();
+        let dir = models_dir();
         std::fs::create_dir_all(&dir).unwrap();
         for f in &MODEL_FILES {
             std::fs::write(dir.join(f), "dummy").unwrap();
         }
-        let check = MODEL_FILES.iter().all(|f| dir.join(f).is_file());
-        assert!(check);
-    }
-
-    #[test]
-    fn test_model_files_constant() {
-        assert_eq!(MODEL_FILES.len(), 3);
-        assert!(MODEL_FILES.contains(&"config.json"));
-        assert!(MODEL_FILES.contains(&"tokenizer.json"));
-        assert!(MODEL_FILES.contains(&"model.safetensors"));
+        let result = models_dir_complete();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), dir);
+        std::env::remove_var("TSM_STATE_DIR");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -550,6 +550,26 @@ pub fn daemon_pid_path() -> PathBuf {
     state_dir().join("tsmd.pid")
 }
 
+// ─── Local model directory ──────────────────────────────────────
+
+const MODEL_FILES: [&str; 3] = ["config.json", "tokenizer.json", "model.safetensors"];
+
+/// Directory for locally cached model files: `{state_dir}/models/ruri-v3-30m/`.
+pub fn models_dir() -> PathBuf {
+    state_dir().join("models/ruri-v3-30m")
+}
+
+/// Check if all required model files exist in `models_dir()`.
+/// Returns `Some(path)` if all 3 files are present, `None` otherwise.
+pub fn models_dir_complete() -> Option<PathBuf> {
+    let dir = models_dir();
+    if MODEL_FILES.iter().all(|f| dir.join(f).is_file()) {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
 // ─── Model cache (XDG) ──────────────────────────────────────────
 // NOTE: model_cache_dir and ensure_model_cache_env are intentionally NOT
 // part of ResolvedConfig. ensure_model_cache_env performs a side-effectful
@@ -1323,5 +1343,56 @@ half_life_days = 180
                 "warning should mention tsm restart: {w}"
             );
         }
+    }
+
+    // ─── models_dir / models_dir_complete ──────────────────────────
+
+    #[test]
+    #[serial]
+    fn test_models_dir_default() {
+        std::env::remove_var("TSM_STATE_DIR");
+        let dir = models_dir();
+        assert_eq!(dir, PathBuf::from(".tsm/models/ruri-v3-30m"));
+    }
+
+    #[test]
+    fn test_models_dir_complete_empty() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().join("models/ruri-v3-30m");
+        std::fs::create_dir_all(&dir).unwrap();
+        // No files — should return None
+        let check = MODEL_FILES.iter().all(|f| dir.join(f).is_file());
+        assert!(!check);
+    }
+
+    #[test]
+    fn test_models_dir_complete_partial() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().join("models/ruri-v3-30m");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("config.json"), "{}").unwrap();
+        // Only 1 of 3 — should not be complete
+        let check = MODEL_FILES.iter().all(|f| dir.join(f).is_file());
+        assert!(!check);
+    }
+
+    #[test]
+    fn test_models_dir_complete_all_present() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().join("models/ruri-v3-30m");
+        std::fs::create_dir_all(&dir).unwrap();
+        for f in &MODEL_FILES {
+            std::fs::write(dir.join(f), "dummy").unwrap();
+        }
+        let check = MODEL_FILES.iter().all(|f| dir.join(f).is_file());
+        assert!(check);
+    }
+
+    #[test]
+    fn test_model_files_constant() {
+        assert_eq!(MODEL_FILES.len(), 3);
+        assert!(MODEL_FILES.contains(&"config.json"));
+        assert!(MODEL_FILES.contains(&"tokenizer.json"));
+        assert!(MODEL_FILES.contains(&"model.safetensors"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1367,6 +1367,7 @@ half_life_days = 180
         let dir = models_dir();
         assert_eq!(dir, tmp.path().join("models/ruri-v3-30m"));
         std::env::remove_var("TSM_STATE_DIR");
+        reload();
     }
 
     #[test]
@@ -1379,6 +1380,7 @@ half_life_days = 180
         std::fs::create_dir_all(&dir).unwrap();
         assert!(models_dir_complete().is_none());
         std::env::remove_var("TSM_STATE_DIR");
+        reload();
     }
 
     #[test]
@@ -1392,6 +1394,7 @@ half_life_days = 180
         std::fs::write(dir.join("config.json"), "{}").unwrap();
         assert!(models_dir_complete().is_none());
         std::env::remove_var("TSM_STATE_DIR");
+        reload();
     }
 
     #[test]
@@ -1409,5 +1412,6 @@ half_life_days = 180
         assert!(result.is_some());
         assert_eq!(result.unwrap(), dir);
         std::env::remove_var("TSM_STATE_DIR");
+        reload();
     }
 }

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -40,7 +40,10 @@ impl Embedder {
         }
 
         // Fallback to HF Hub cache
-        log::info!("Local model not found; falling back to HF Hub cache");
+        log::warn!(
+            "Local model not found in {}; falling back to HF Hub cache (requires network)",
+            config::models_dir().display()
+        );
         let api = hf_hub::api::sync::Api::new()?;
         let repo = api.repo(hf_hub::Repo::new(
             MODEL_ID.to_string(),

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -22,8 +22,25 @@ pub struct Embedder {
 }
 
 impl Embedder {
-    /// Load the ruri-v3-30m model from HuggingFace Hub cache.
+    /// Load the ruri-v3-30m model.
+    ///
+    /// Resolution order:
+    /// 1. `{state_dir}/models/ruri-v3-30m/` — if all 3 files are present
+    /// 2. HuggingFace Hub cache — fallback for backward compatibility
     pub fn load(device: &Device) -> Result<Self> {
+        // Try local models_dir first
+        if let Some(dir) = config::models_dir_complete() {
+            log::info!("Loading model from {}", dir.display());
+            return Self::load_from_paths(
+                &dir.join("config.json"),
+                &dir.join("tokenizer.json"),
+                &dir.join("model.safetensors"),
+                device,
+            );
+        }
+
+        // Fallback to HF Hub cache
+        log::info!("Local model not found; falling back to HF Hub cache");
         let api = hf_hub::api::sync::Api::new()?;
         let repo = api.repo(hf_hub::Repo::new(
             MODEL_ID.to_string(),


### PR DESCRIPTION
## Summary

Closes #1

- モデルファイル（ruri-v3-30m）の保存先を `~/.cache/huggingface/` から `.tsm/models/ruri-v3-30m/` に変更
- `config::models_dir()` / `models_dir_complete()` ヘルパー追加
- `Embedder::load()` がローカル models_dir を優先、HF Hub キャッシュにフォールバック
- `cmd_setup()` がダウンロード後に models_dir へコピー
- `tsmd` が embedder 子プロセスに `--model` 引数を渡す（ps での可視化）
- `embedder_mode` で `--model` のファイルが不完全な場合のフォールバック追加
- `tsm doctor` にモデルファイルの存在チェック追加

## Test plan

- [x] `config::models_dir()` のデフォルトパステスト
- [x] `MODEL_FILES` 定数のテスト
- [x] `models_dir_complete` の空/部分/全存在テスト
- [x] `doctor` モデルファイル未検出テスト
- [x] `doctor` モデルファイル検出テスト
- [x] 既存テストが全て通ること（pre-existing failures 3件を除く）
- [x] clippy クリーン
- [ ] CI パス