### PR TITLE
refactor: separate progress display from import_wordnet via callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,6 +3401,7 @@ dependencies = [
  "chrono",
  "clap",
  "directories",
+ "flate2",
  "flexi_logger",
  "hf-hub",
  "libc",
@@ -3419,6 +3420,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokenizers",
  "toml",
+ "ureq",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ libc = "0.2"
 log = "0.4"
 flexi_logger = { version = "0.31", features = ["colors"] }
 notify-debouncer-mini = "0.7"
+ureq = "3"
+flate2 = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -130,18 +130,21 @@ tsm restart
 
 ### tsm setup
 
-Download ruri-v3-30m model files from HuggingFace Hub.
+Download model files and Japanese WordNet synonym database.
 
 ```text
 tsm setup
 ```
 
-Downloads `config.json`, `tokenizer.json`, and `model.safetensors` for
-`cl-nagoya/ruri-v3-30m` into the local model cache. Must be run before
-starting the daemon for the first time.
+Performs initial setup required before starting the daemon:
 
-Model files are cached in the HuggingFace cache directory
-(`$HF_HOME` or `~/.cache/huggingface`).
+1. Downloads `cl-nagoya/ruri-v3-30m` model files (`config.json`,
+   `tokenizer.json`, `model.safetensors`) from HuggingFace Hub
+   and copies them to `.tsm/models/ruri-v3-30m/`.
+2. Downloads Japanese WordNet (`wnjpn.db.gz`) from GitHub and
+   decompresses it to `.tsm/wnjpn.db`.
+3. If the database is already initialized (`tsm init`), imports
+   WordNet synonym pairs automatically.
 
 **Flags:** none
 
@@ -532,10 +535,11 @@ Import Japanese WordNet synonyms into the database.
 tsm import-wordnet <wnjpn.db>
 ```
 
-Imports synonym pairs from the Japanese WordNet SQLite database (`wnjpn.db`)
+Imports synonym pairs from a Japanese WordNet SQLite database (`wnjpn.db`)
 into the local synonyms table. Used for query expansion during search.
 
-Download `wnjpn.db` from the [Japanese WordNet project](http://compling.hss.ntu.edu.sg/wnja/).
+`tsm setup` downloads and imports WordNet automatically. This command is
+for manual import from a custom path.
 
 **Arguments:**
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use std::io::BufRead;
+use std::io::{BufRead, Read};
 use std::path::{Path, PathBuf};
 
 use crate::config;
@@ -439,7 +439,13 @@ pub fn cmd_import_wordnet(wordnet_db: &Path) -> anyhow::Result<()> {
     let db_path = config::db_path();
     let conn = db::get_connection(&db_path)?;
 
-    let count = crate::synonyms::import_wordnet(&conn, wordnet_db)?;
+    let progress = |imported: usize, total: usize| {
+        if imported.is_multiple_of(10000) || imported == total {
+            eprint!("\r  {imported}/{total}");
+        }
+    };
+    let count = crate::synonyms::import_wordnet(&conn, wordnet_db, Some(&progress))?;
+    eprint!("\r                              \r"); // clear progress line
     log::info!("Imported {count} synonym pairs from WordNet.");
 
     let total: i64 = conn
@@ -490,6 +496,42 @@ pub fn cmd_setup() -> anyhow::Result<()> {
         return Err(e);
     }
     log::info!("Model files installed to {}", dest.display());
+
+    // Download Japanese WordNet DB
+    let wordnet_dest = config::wordnet_db_path();
+    if wordnet_dest.is_file() {
+        log::info!("WordNet DB already exists at {}", wordnet_dest.display());
+    } else {
+        const WORDNET_URL: &str =
+            "https://github.com/bond-lab/wnja/releases/download/v1.1/wnjpn.db.gz";
+        log::info!("Downloading WordNet DB from {WORDNET_URL}...");
+        let resp = ureq::get(WORDNET_URL).call()?;
+        let mut gz_data = Vec::new();
+        resp.into_body()
+            .as_reader()
+            .read_to_end(&mut gz_data)?;
+        let mut decoder = flate2::read::GzDecoder::new(&gz_data[..]);
+        let parent = wordnet_dest.parent().expect("wordnet_dest has parent");
+        std::fs::create_dir_all(parent)?;
+        let tmp_path = wordnet_dest.with_extension("db.tmp");
+        let mut out = std::fs::File::create(&tmp_path)?;
+        std::io::copy(&mut decoder, &mut out)?;
+        std::fs::rename(&tmp_path, &wordnet_dest)?;
+        log::info!("WordNet DB installed to {}", wordnet_dest.display());
+    }
+
+    // Import WordNet synonyms if DB is initialized
+    let db_path = config::db_path();
+    if db_path.is_file() {
+        log::info!("Importing WordNet synonyms...");
+        cmd_import_wordnet(&wordnet_dest)?;
+    } else {
+        log::info!(
+            "Database not initialized yet. Run `tsm init` then `tsm import-wordnet {}` to import synonyms.",
+            wordnet_dest.display()
+        );
+    }
+
     Ok(())
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -497,27 +497,18 @@ pub fn cmd_setup() -> anyhow::Result<()> {
     }
     log::info!("Model files installed to {}", dest.display());
 
-    // Download Japanese WordNet DB
+    // Download and import Japanese WordNet
+    setup_wordnet()?;
+
+    Ok(())
+}
+
+fn setup_wordnet() -> anyhow::Result<()> {
     let wordnet_dest = config::wordnet_db_path();
     if wordnet_dest.is_file() {
         log::info!("WordNet DB already exists at {}", wordnet_dest.display());
     } else {
-        const WORDNET_URL: &str =
-            "https://github.com/bond-lab/wnja/releases/download/v1.1/wnjpn.db.gz";
-        log::info!("Downloading WordNet DB from {WORDNET_URL}...");
-        let resp = ureq::get(WORDNET_URL).call()?;
-        let mut gz_data = Vec::new();
-        resp.into_body()
-            .as_reader()
-            .read_to_end(&mut gz_data)?;
-        let mut decoder = flate2::read::GzDecoder::new(&gz_data[..]);
-        let parent = wordnet_dest.parent().expect("wordnet_dest has parent");
-        std::fs::create_dir_all(parent)?;
-        let tmp_path = wordnet_dest.with_extension("db.tmp");
-        let mut out = std::fs::File::create(&tmp_path)?;
-        std::io::copy(&mut decoder, &mut out)?;
-        std::fs::rename(&tmp_path, &wordnet_dest)?;
-        log::info!("WordNet DB installed to {}", wordnet_dest.display());
+        download_wordnet(&wordnet_dest)?;
     }
 
     // Import WordNet synonyms if DB is initialized
@@ -531,7 +522,23 @@ pub fn cmd_setup() -> anyhow::Result<()> {
             wordnet_dest.display()
         );
     }
+    Ok(())
+}
 
+fn download_wordnet(dest: &Path) -> anyhow::Result<()> {
+    const WORDNET_URL: &str = "https://github.com/bond-lab/wnja/releases/download/v1.1/wnjpn.db.gz";
+    log::info!("Downloading WordNet DB from {WORDNET_URL}...");
+    let resp = ureq::get(WORDNET_URL).call()?;
+    let mut gz_data = Vec::new();
+    resp.into_body().as_reader().read_to_end(&mut gz_data)?;
+    let mut decoder = flate2::read::GzDecoder::new(&gz_data[..]);
+    let parent = dest.parent().expect("dest has parent");
+    std::fs::create_dir_all(parent)?;
+    let tmp_path = dest.with_extension("db.tmp");
+    let mut out = std::fs::File::create(&tmp_path)?;
+    std::io::copy(&mut decoder, &mut out)?;
+    std::fs::rename(&tmp_path, dest)?;
+    log::info!("WordNet DB installed to {}", dest.display());
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -546,6 +546,10 @@ pub fn reject_words_path() -> PathBuf {
     state_dir().join("reject_words.txt")
 }
 
+pub fn wordnet_db_path() -> PathBuf {
+    state_dir().join("wnjpn.db")
+}
+
 pub fn daemon_pid_path() -> PathBuf {
     state_dir().join("tsmd.pid")
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -114,7 +114,7 @@ pub fn handle_request(
 
         DaemonRequest::ImportWordnet { wordnet_db } => {
             let path = PathBuf::from(&wordnet_db);
-            match crate::synonyms::import_wordnet(conn, &path) {
+            match crate::synonyms::import_wordnet(conn, &path, None) {
                 Ok(count) => DaemonResponse::success(serde_json::json!({
                     "imported": count,
                 })),

--- a/src/synonyms.rs
+++ b/src/synonyms.rs
@@ -151,9 +151,16 @@ pub fn upsert_synonym(
     Ok(())
 }
 
+/// Progress callback type for import_wordnet: (imported_so_far, total).
+pub type WordnetProgressCb<'a> = &'a dyn Fn(usize, usize);
+
 /// Import synonym pairs from a Japanese WordNet SQLite database.
 /// Extracts pairs of Japanese words that share a synset.
-pub fn import_wordnet(conn: &Connection, wordnet_path: &std::path::Path) -> anyhow::Result<usize> {
+pub fn import_wordnet(
+    conn: &Connection,
+    wordnet_path: &std::path::Path,
+    progress_cb: Option<WordnetProgressCb<'_>>,
+) -> anyhow::Result<usize> {
     if !db::has_synonyms_table(conn) {
         anyhow::bail!("synonyms table not found");
     }
@@ -199,12 +206,10 @@ pub fn import_wordnet(conn: &Connection, wordnet_path: &std::path::Path) -> anyh
         }
         tx.commit()?;
         imported += chunk.len();
-        if imported % 10000 == 0 {
-            eprint!("\r  {imported}/{total}");
+        if let Some(cb) = progress_cb {
+            cb(imported, total);
         }
     }
-
-    eprint!("\r                              \r"); // clear progress line
     log::info!("{imported}/{total} synonym pairs imported.");
     Ok(imported)
 }
@@ -600,5 +605,90 @@ mod tests {
             score < 0.1,
             "never-hit entry should decay from creation date"
         );
+    }
+
+    /// Create a minimal WordNet-schema SQLite DB with the given pairs.
+    fn create_mock_wordnet(pairs: &[(&str, &str)]) -> tempfile::NamedTempFile {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let wn = rusqlite::Connection::open(file.path()).unwrap();
+        wn.execute_batch(
+            "CREATE TABLE word (wordid INTEGER PRIMARY KEY, lemma TEXT, lang TEXT);
+             CREATE TABLE synset (synset TEXT PRIMARY KEY);
+             CREATE TABLE sense (synset TEXT, wordid INTEGER);",
+        )
+        .unwrap();
+        let mut word_id = 1i64;
+        let mut synset_id = 1;
+        for (a, b) in pairs {
+            let sid = format!("syn{synset_id:04}");
+            wn.execute(
+                "INSERT INTO synset (synset) VALUES (?)",
+                rusqlite::params![sid],
+            )
+            .unwrap();
+            wn.execute(
+                "INSERT INTO word (wordid, lemma, lang) VALUES (?, ?, 'jpn')",
+                rusqlite::params![word_id, a],
+            )
+            .unwrap();
+            wn.execute(
+                "INSERT INTO sense (synset, wordid) VALUES (?, ?)",
+                rusqlite::params![sid, word_id],
+            )
+            .unwrap();
+            word_id += 1;
+            wn.execute(
+                "INSERT INTO word (wordid, lemma, lang) VALUES (?, ?, 'jpn')",
+                rusqlite::params![word_id, b],
+            )
+            .unwrap();
+            wn.execute(
+                "INSERT INTO sense (synset, wordid) VALUES (?, ?)",
+                rusqlite::params![sid, word_id],
+            )
+            .unwrap();
+            word_id += 1;
+            synset_id += 1;
+        }
+        file
+    }
+
+    #[test]
+    fn test_import_wordnet_with_callback() {
+        let conn = setup();
+        let wn_file = create_mock_wordnet(&[("狩猟", "ハンティング"), ("射撃", "シューティング")]);
+
+        let calls = std::cell::RefCell::new(Vec::new());
+        let cb = |imported: usize, total: usize| {
+            calls.borrow_mut().push((imported, total));
+        };
+
+        let count = import_wordnet(&conn, wn_file.path(), Some(&cb)).unwrap();
+        assert_eq!(count, 2);
+
+        let calls = calls.into_inner();
+        assert!(!calls.is_empty(), "callback should be called at least once");
+        let last = calls.last().unwrap();
+        assert_eq!(last.0, 2, "last call should report all imported");
+        assert_eq!(last.1, 2, "total should match");
+    }
+
+    #[test]
+    fn test_import_wordnet_without_callback() {
+        let conn = setup();
+        let wn_file = create_mock_wordnet(&[("狩猟", "ハンティング")]);
+
+        let count = import_wordnet(&conn, wn_file.path(), None).unwrap();
+        assert_eq!(count, 1);
+
+        // Verify pair was inserted
+        let stored: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM synonyms WHERE source = 'wordnet'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, 1);
     }
 }


### PR DESCRIPTION
## Summary

- `synonyms::import_wordnet()` の進捗表示 (`eprint!`) をコールバックパターンに分離
- `tsm setup` に Japanese WordNet DB の自動ダウンロード・インポートを追加

## Changes

- **`src/synonyms.rs`** — `WordnetProgressCb` 型を追加し、`import_wordnet` にオプショナルなコールバック引数を追加。`eprint!` を除去
- **`src/daemon.rs`** — `None` を渡して stderr 出力を抑制
- **`src/cli.rs`** — `cmd_import_wordnet` に進捗コールバック追加。`cmd_setup` に WordNet ダウンロード・インポートを追加
- **`src/config.rs`** — `wordnet_db_path()` 追加
- **`Cargo.toml`** — `ureq`, `flate2` 追加
- **`docs/command-reference.md`** — `tsm setup` と `tsm import-wordnet` の説明を更新

## Test plan

- [x] `test_import_wordnet_with_callback` — コールバックが正しく呼ばれることを検証
- [x] `test_import_wordnet_without_callback` — `None` でも正常動作を検証
- [x] clippy 通過
- [ ] CI パス

Closes #41