### PR TITLE
feat: search JSON envelope + XML prompt format (#128, #130)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "the-space-memory",
   "description": "Cross-workspace knowledge search engine with hybrid FTS5 + vector search",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "author": {
     "name": "Mitsukuni Sato"
   },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "the-space-memory"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [[bin]]

--- a/hooks/scripts/search.sh
+++ b/hooks/scripts/search.sh
@@ -36,23 +36,70 @@ RESULT=$("$TSM" search --query "$QUERY" --format json 2>>"$LOG") || {
 }
 
 # 結果が空なら何も出力しない
-if [ -z "$RESULT" ] || [ "$RESULT" = "null" ] || [ "$RESULT" = "[]" ]; then
+if [ -z "$RESULT" ] || [ "$RESULT" = "null" ]; then
   echo "[$(date -Iseconds)] EMPTY: no results" >> "$LOG"
   exit 0
 fi
 
-COUNT=$(echo "$RESULT" | jq 'length' 2>/dev/null || echo "?")
-echo "[$(date -Iseconds)] OK: $COUNT results" >> "$LOG"
+COUNT=$(echo "$RESULT" | jq '.results | length' 2>/dev/null || echo "0")
+TOTAL_HITS=$(echo "$RESULT" | jq '.total_hits // 0' 2>/dev/null || echo "0")
+echo "[$(date -Iseconds)] OK: $COUNT results (total_hits: $TOTAL_HITS)" >> "$LOG"
+
+if [ "$COUNT" = "0" ]; then
+  exit 0
+fi
+
+BUDGET="${TSM_SNIPPET_BUDGET:-1000}"
+
+# Build XML output following Anthropic prompting best practices
+# See: docs/claude-code/claude-code-prompt-format.md
+XML=$(echo "$RESULT" | jq -r --arg query "$QUERY" --argjson budget "$BUDGET" --argjson total_hits "$TOTAL_HITS" '
+  .results | length as $count |
+  reduce to_entries[] as $entry (
+    {xml: "", used: 0};
+    $entry.value as $item |
+    ($entry.key + 1) as $idx |
+    ($item.snippet | length) as $slen |
+
+    # snippet budget check
+    (if (.used + $slen) <= $budget then true else false end) as $ok |
+
+    # source attributes
+    (if $item.status != null and $item.status != ""
+     then " status=\"\($item.status)\""
+     else "" end) as $st |
+
+    # related element (omit when empty)
+    (if ($item.related_docs // [] | length) > 0
+     then "<related>" + ($item.related_docs | map(.file_path) | join(", ")) + "</related>\n"
+     else "" end) as $rel |
+
+    # snippet element (self-closing when over budget)
+    (if $ok
+     then "<snippet>\n\($item.snippet)\n</snippet>\n"
+     else "<snippet/>\n" end) as $snip |
+
+    # score: truncate to 3 decimal places
+    ($item.score | tostring | split(".") |
+     .[0] + "." + ((.[1] // "000") | .[0:3])) as $score |
+
+    {
+      xml: (.xml
+        + "<result index=\"\($idx)\" score=\"\($score)\">\n"
+        + "<source type=\"\($item.source_type // "unknown")\"\($st)>\($item.source_file)</source>\n"
+        + "<section>\($item.section_path)</section>\n"
+        + $snip + $rel
+        + "</result>\n"),
+      used: (if $ok then .used + $slen else .used end)
+    }
+  ) |
+  "<knowledge_search query=\"\($query | gsub("\""; "&quot;") | gsub("&"; "&amp;") | gsub("<"; "&lt;"))\" count=\"\($count)\" total=\"\($total_hits)\">\n\(.xml)</knowledge_search>"
+')
 
 # additionalContext 形式で出力
-jq -n --argjson results "$RESULT" '{
+jq -n --arg context "$XML" '{
   hookSpecificOutput: {
     hookEventName: "UserPromptSubmit",
-    additionalContext: ("ナレッジ検索結果 (自動):\n" + ($results | map(
-      "- [\(.source_file)] \(.section_path): \(.snippet[0:100])"
-      + (if (.related_docs // [] | length) > 0
-         then "\n  関連: " + (.related_docs | map("[\(.file_path)](\(.link_type))") | join(", "))
-         else "" end)
-    ) | join("\n")))
+    additionalContext: $context
   }
 }'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -199,7 +199,7 @@ pub struct SearchOptions<'a> {
 pub fn run_search(
     conn: &rusqlite::Connection,
     opts: &SearchOptions,
-) -> anyhow::Result<Vec<searcher::SearchResult>> {
+) -> anyhow::Result<searcher::SearchOutput> {
     use crate::temporal;
 
     // Resolve fallback policy: CLI flag > config > default (Error)
@@ -242,19 +242,23 @@ pub fn cmd_search(opts: SearchOptions) -> anyhow::Result<()> {
     let db_path = config::db_path();
     let conn = db::get_connection(&db_path)?;
 
-    let results = run_search(&conn, &opts)?;
+    let output = run_search(&conn, &opts)?;
     match opts.format {
-        "json" => print_json(&results, opts.include_content)?,
-        _ => print_text(&results),
+        "json" => print_json(&output.results, output.total_hits, opts.include_content)?,
+        _ => print_text(&output.results, output.total_hits),
     }
     Ok(())
 }
 
-pub fn format_text(results: &[searcher::SearchResult]) -> String {
+pub fn format_text(results: &[searcher::SearchResult], total_hits: usize) -> String {
     if results.is_empty() {
         return "No results found.".to_string();
     }
-    let mut out = String::new();
+    let mut out = format!(
+        "Showing {} of {} results\n\n",
+        results.len(),
+        total_hits
+    );
     for (i, r) in results.iter().enumerate() {
         out.push_str(&format!(
             "{}. [{}] {} — {} (score: {:.4})\n",
@@ -282,12 +286,13 @@ pub fn format_text(results: &[searcher::SearchResult]) -> String {
     out
 }
 
-fn print_text(results: &[searcher::SearchResult]) {
-    print!("{}", format_text(results));
+fn print_text(results: &[searcher::SearchResult], total_hits: usize) {
+    print!("{}", format_text(results, total_hits));
 }
 
 pub fn format_json(
     results: &[searcher::SearchResult],
+    total_hits: usize,
     include_content: Option<usize>,
     index_root: &Path,
 ) -> anyhow::Result<String> {
@@ -328,15 +333,24 @@ pub fn format_json(
         json_results.push(obj);
     }
 
-    Ok(serde_json::to_string_pretty(&json_results)?)
+    let envelope = serde_json::json!({
+        "total_hits": total_hits,
+        "results": json_results,
+    });
+
+    Ok(serde_json::to_string_pretty(&envelope)?)
 }
 
 fn print_json(
     results: &[searcher::SearchResult],
+    total_hits: usize,
     include_content: Option<usize>,
 ) -> anyhow::Result<()> {
     let index_root = config::index_root();
-    println!("{}", format_json(results, include_content, &index_root)?);
+    println!(
+        "{}",
+        format_json(results, total_hits, include_content, &index_root)?
+    );
     Ok(())
 }
 
@@ -1595,7 +1609,7 @@ mod tests {
 
     #[test]
     fn test_format_text_empty() {
-        let result = format_text(&[]);
+        let result = format_text(&[], 0);
         assert_eq!(result, "No results found.");
     }
 
@@ -1610,7 +1624,7 @@ mod tests {
             status: Some("current".to_string()),
             related_docs: vec![],
         }];
-        let text = format_text(&results);
+        let text = format_text(&results, results.len());
         assert!(text.contains("1. [note]"));
         assert!(text.contains("daily/notes/test.md"));
         assert!(text.contains("0.5000"));
@@ -1628,14 +1642,16 @@ mod tests {
             status: None,
             related_docs: vec![],
         }];
-        let text = format_text(&results);
+        let text = format_text(&results, results.len());
         assert!(!text.contains("status:"));
     }
 
     #[test]
     fn test_format_json_empty() {
-        let result = format_json(&[], None, Path::new("/tmp")).unwrap();
-        assert_eq!(result, "[]");
+        let result = format_json(&[], 0, None, Path::new("/tmp")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["total_hits"], 0);
+        assert_eq!(parsed["results"].as_array().unwrap().len(), 0);
     }
 
     #[test]
@@ -1649,13 +1665,15 @@ mod tests {
             status: None,
             related_docs: vec![],
         }];
-        let json = format_json(&results, None, Path::new("/tmp")).unwrap();
-        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0]["source_file"], "test.md");
-        assert_eq!(parsed[0]["score"], 0.5);
+        let json = format_json(&results, 10, None, Path::new("/tmp")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["total_hits"], 10);
+        let arr = parsed["results"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["source_file"], "test.md");
+        assert_eq!(arr[0]["score"], 0.5);
         // No content field when include_content is None
-        assert!(parsed[0].get("content").is_none());
+        assert!(arr[0].get("content").is_none());
     }
 
     #[test]
@@ -1673,9 +1691,9 @@ mod tests {
             status: None,
             related_docs: vec![],
         }];
-        let json = format_json(&results, Some(1), dir.path()).unwrap();
-        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed[0]["content"], "# Hello\n\nWorld.");
+        let json = format_json(&results, 1, Some(1), dir.path()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["results"][0]["content"], "# Hello\n\nWorld.");
     }
 
     #[test]
@@ -1741,9 +1759,9 @@ mod tests {
             related_docs: vec![],
         }];
         // File doesn't exist, so content field should not be present
-        let json = format_json(&results, Some(1), Path::new("/tmp/empty")).unwrap();
-        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
-        assert!(parsed[0].get("content").is_none());
+        let json = format_json(&results, 1, Some(1), Path::new("/tmp/empty")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed["results"][0].get("content").is_none());
     }
 
     #[test]
@@ -1773,10 +1791,11 @@ mod tests {
             },
         ];
         // include_content=1, so only first result gets content
-        let json = format_json(&results, Some(1), dir.path()).unwrap();
-        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed[0]["content"], "aaa");
-        assert!(parsed[1].get("content").is_none());
+        let json = format_json(&results, 2, Some(1), dir.path()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed["results"].as_array().unwrap();
+        assert_eq!(arr[0]["content"], "aaa");
+        assert!(arr[1].get("content").is_none());
     }
 
     #[test]
@@ -1801,7 +1820,7 @@ mod tests {
                 related_docs: vec![],
             },
         ];
-        let text = format_text(&results);
+        let text = format_text(&results, results.len());
         assert!(text.contains("1. [note]"));
         assert!(text.contains("2. [research]"));
         assert!(text.contains("status: outdated"));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -254,11 +254,7 @@ pub fn format_text(results: &[searcher::SearchResult], total_hits: usize) -> Str
     if results.is_empty() {
         return "No results found.".to_string();
     }
-    let mut out = format!(
-        "Showing {} of {} results\n\n",
-        results.len(),
-        total_hits
-    );
+    let mut out = format!("Showing {} of {} results\n\n", results.len(), total_hits);
     for (i, r) in results.iter().enumerate() {
         out.push_str(&format!(
             "{}. [{}] {} — {} (score: {:.4})\n",

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -49,8 +49,13 @@ pub fn handle_request(
                 paths: paths.as_deref(),
             };
             match cli::run_search(conn, &opts) {
-                Ok(results) => {
-                    let json_str = cli::format_json(&results, include_content, index_root);
+                Ok(output) => {
+                    let json_str = cli::format_json(
+                        &output.results,
+                        output.total_hits,
+                        include_content,
+                        index_root,
+                    );
                     match json_str {
                         Ok(s) => match serde_json::from_str::<serde_json::Value>(&s) {
                             Ok(v) => DaemonResponse::success(v),
@@ -191,10 +196,10 @@ mod tests {
         };
         let resp = handle_request(&conn, req, dir.path(), &flag);
         assert!(resp.ok);
-        // Empty DB returns empty array
+        // Empty DB returns envelope with empty results
         let payload = resp.payload.unwrap();
-        assert!(payload.is_array());
-        assert_eq!(payload.as_array().unwrap().len(), 0);
+        assert_eq!(payload["total_hits"], 0);
+        assert_eq!(payload["results"].as_array().unwrap().len(), 0);
     }
 
     #[test]
@@ -241,8 +246,8 @@ mod tests {
         };
         let resp = handle_request(&conn, req, dir.path(), &flag);
         assert!(resp.ok);
-        let results = resp.payload.unwrap();
-        let arr = results.as_array().unwrap();
+        let payload = resp.payload.unwrap();
+        let arr = payload["results"].as_array().unwrap();
         for item in arr {
             let path = item["source_file"].as_str().unwrap();
             assert!(
@@ -486,7 +491,9 @@ mod tests {
         )
         .unwrap();
         assert!(resp.ok);
-        assert!(resp.payload.unwrap().is_array());
+        let payload = resp.payload.unwrap();
+        assert!(payload["results"].is_array());
+        assert!(payload["total_hits"].is_number());
 
         server.join().unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -383,10 +383,11 @@ fn render_search(resp: DaemonResponse, format: &str) -> anyhow::Result<()> {
     match format {
         "json" => print_json(&payload),
         _ => {
+            let total_hits = payload["total_hits"].as_u64().unwrap_or(0) as usize;
             let results: Vec<the_space_memory::searcher::SearchResult> =
-                serde_json::from_value(payload)
+                serde_json::from_value(payload["results"].clone())
                     .map_err(|e| anyhow::anyhow!("Failed to parse search results: {e}"))?;
-            print!("{}", cli::format_text(&results));
+            print!("{}", cli::format_text(&results, total_hits));
         }
     }
     Ok(())

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -592,7 +592,8 @@ mod tests {
     #[test]
     fn test_search_no_results() {
         let conn = db::get_memory_connection().unwrap();
-        let SearchOutput { results, .. } = search(&conn, "存在しないキーワード", 5, None, false, None).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "存在しないキーワード", 5, None, false, None).unwrap();
         assert!(results.is_empty());
     }
 
@@ -645,7 +646,8 @@ mod tests {
             after: Some("2020-01-01".to_string()),
             before: Some("2099-01-01".to_string()),
         };
-        let SearchOutput { results, .. } = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
         assert!(!results.is_empty());
     }
 
@@ -673,7 +675,8 @@ mod tests {
             after: Some("2099-01-01".to_string()),
             before: None,
         };
-        let SearchOutput { results, .. } = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
         assert!(results.is_empty());
     }
 
@@ -697,7 +700,8 @@ mod tests {
             after: Some("2025-01-01".to_string()),
             before: None,
         };
-        let SearchOutput { results, .. } = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
         assert!(!results.is_empty());
     }
 
@@ -729,7 +733,8 @@ mod tests {
     fn test_search_noise_query_returns_empty() {
         let conn = db::get_memory_connection().unwrap();
         // Pure interjection/greeting should return empty results
-        let SearchOutput { results, .. } = search(&conn, "よかったーーー", 5, None, false, None).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "よかったーーー", 5, None, false, None).unwrap();
         assert!(
             results.is_empty(),
             "Noise query should return empty results"
@@ -763,7 +768,8 @@ mod tests {
         indexer::index_file(&conn, &full, dir.path()).unwrap();
 
         // A meaningful query should still find results
-        let SearchOutput { results, .. } = search(&conn, "LoRaモジュール", 5, None, false, None).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "LoRaモジュール", 5, None, false, None).unwrap();
         assert!(!results.is_empty(), "Meaningful query should find results");
     }
 
@@ -794,7 +800,8 @@ mod tests {
 
         // Filter to daily/ only
         let paths = vec!["daily/".to_string()];
-        let SearchOutput { results, .. } = search(&conn, "MTG", 5, None, false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "MTG", 5, None, false, Some(&paths)).unwrap();
         assert!(!results.is_empty());
         for r in &results {
             assert!(
@@ -822,7 +829,8 @@ mod tests {
 
         // Filter to projects/ — should exclude daily/
         let paths = vec!["projects/".to_string()];
-        let SearchOutput { results, .. } = search(&conn, "MTG", 5, None, false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "MTG", 5, None, false, Some(&paths)).unwrap();
         assert!(results.is_empty());
     }
 
@@ -850,7 +858,8 @@ mod tests {
 
         // Filter to daily/ and docs/ (OR)
         let paths = vec!["daily/".to_string(), "docs/".to_string()];
-        let SearchOutput { results, .. } = search(&conn, "MTG", 10, None, false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "MTG", 10, None, false, Some(&paths)).unwrap();
         assert!(!results.is_empty());
         for r in &results {
             assert!(
@@ -905,7 +914,8 @@ mod tests {
 
         // Filter to a specific file
         let paths = vec!["docs/api.md".to_string()];
-        let SearchOutput { results, .. } = search(&conn, "Authentication", 10, None, false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "Authentication", 10, None, false, Some(&paths)).unwrap();
         assert!(!results.is_empty());
         for r in &results {
             assert_eq!(r.source_file, "docs/api.md");
@@ -936,7 +946,8 @@ mod tests {
 
         // _ in path must be literal, not a wildcard
         let paths = vec!["daily_notes/".to_string()];
-        let SearchOutput { results, .. } = search(&conn, "MTG", 10, None, false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "MTG", 10, None, false, Some(&paths)).unwrap();
         assert!(!results.is_empty());
         for r in &results {
             assert!(
@@ -978,7 +989,8 @@ mod tests {
             after: Some("2025-01-01".to_string()),
             before: None,
         };
-        let SearchOutput { results, .. } = search(&conn, "MTG", 10, Some(&filter), false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } =
+            search(&conn, "MTG", 10, Some(&filter), false, Some(&paths)).unwrap();
         for r in &results {
             assert!(
                 r.source_file.starts_with("daily/"),

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -25,6 +25,13 @@ pub struct SearchResult {
     pub related_docs: Vec<doc_links::RelatedDoc>,
 }
 
+/// Search output with total hit count (before top_k truncation).
+#[derive(Debug)]
+pub struct SearchOutput {
+    pub results: Vec<SearchResult>,
+    pub total_hits: usize,
+}
+
 /// Search for documents matching the query, with optional time filtering.
 ///
 /// When `require_vector` is true, returns an error if vector search is
@@ -36,11 +43,14 @@ pub fn search(
     time_filter: Option<&TimeFilter>,
     require_vector: bool,
     path_prefixes: Option<&[String]>,
-) -> anyhow::Result<Vec<SearchResult>> {
+) -> anyhow::Result<SearchOutput> {
     // Query preprocessing: extract meaningful keywords, skip noise-only queries
     let keywords = extract_search_keywords(query);
     if keywords.len() < config::MIN_QUERY_KEYWORDS {
-        return Ok(Vec::new());
+        return Ok(SearchOutput {
+            results: Vec::new(),
+            total_hits: 0,
+        });
     }
     let query = &keywords.join(" ");
 
@@ -90,7 +100,10 @@ pub fn search(
         .collect();
 
     if all_chunk_ids.is_empty() {
-        return Ok(Vec::new());
+        return Ok(SearchOutput {
+            results: Vec::new(),
+            total_hits: 0,
+        });
     }
 
     let placeholders = all_chunk_ids
@@ -210,6 +223,7 @@ pub fn search(
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
+    let total_hits = results.len();
     results.truncate(top_k);
 
     // Enrich with related documents
@@ -239,7 +253,10 @@ pub fn search(
         }
     }
 
-    Ok(results)
+    Ok(SearchOutput {
+        results,
+        total_hits,
+    })
 }
 
 pub(crate) fn time_decay(updated: Option<&str>, file_path: &str, source_type: &str) -> f64 {
@@ -558,7 +575,7 @@ mod tests {
         indexer::index_file(&conn, &full, dir.path()).unwrap();
 
         // Search should find it
-        let results = search(&conn, "射撃", 5, None, false, None).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "射撃", 5, None, false, None).unwrap();
         assert!(!results.is_empty());
         assert!(results[0].source_file.contains("shooting"));
         assert!(results[0].score > 0.0);
@@ -568,14 +585,14 @@ mod tests {
     #[test]
     fn test_search_empty_query() {
         let conn = db::get_memory_connection().unwrap();
-        let results = search(&conn, "", 5, None, false, None).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "", 5, None, false, None).unwrap();
         assert!(results.is_empty());
     }
 
     #[test]
     fn test_search_no_results() {
         let conn = db::get_memory_connection().unwrap();
-        let results = search(&conn, "存在しないキーワード", 5, None, false, None).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "存在しないキーワード", 5, None, false, None).unwrap();
         assert!(results.is_empty());
     }
 
@@ -600,7 +617,7 @@ mod tests {
             indexer::index_file(&conn, &full, dir.path()).unwrap();
         }
 
-        let results = search(&conn, "テスト", 3, None, false, None).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "テスト", 3, None, false, None).unwrap();
         assert!(results.len() <= 3);
     }
 
@@ -628,7 +645,7 @@ mod tests {
             after: Some("2020-01-01".to_string()),
             before: Some("2099-01-01".to_string()),
         };
-        let results = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
         assert!(!results.is_empty());
     }
 
@@ -656,7 +673,7 @@ mod tests {
             after: Some("2099-01-01".to_string()),
             before: None,
         };
-        let results = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
         assert!(results.is_empty());
     }
 
@@ -680,7 +697,7 @@ mod tests {
             after: Some("2025-01-01".to_string()),
             before: None,
         };
-        let results = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "射撃", 5, Some(&filter), false, None).unwrap();
         assert!(!results.is_empty());
     }
 
@@ -712,7 +729,7 @@ mod tests {
     fn test_search_noise_query_returns_empty() {
         let conn = db::get_memory_connection().unwrap();
         // Pure interjection/greeting should return empty results
-        let results = search(&conn, "よかったーーー", 5, None, false, None).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "よかったーーー", 5, None, false, None).unwrap();
         assert!(
             results.is_empty(),
             "Noise query should return empty results"
@@ -722,7 +739,7 @@ mod tests {
     #[test]
     fn test_search_stopword_query_returns_empty() {
         let conn = db::get_memory_connection().unwrap();
-        let results = search(&conn, "なるほど", 5, None, false, None).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "なるほど", 5, None, false, None).unwrap();
         assert!(
             results.is_empty(),
             "Stopword-only query should return empty results"
@@ -746,7 +763,7 @@ mod tests {
         indexer::index_file(&conn, &full, dir.path()).unwrap();
 
         // A meaningful query should still find results
-        let results = search(&conn, "LoRaモジュール", 5, None, false, None).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "LoRaモジュール", 5, None, false, None).unwrap();
         assert!(!results.is_empty(), "Meaningful query should find results");
     }
 
@@ -777,7 +794,7 @@ mod tests {
 
         // Filter to daily/ only
         let paths = vec!["daily/".to_string()];
-        let results = search(&conn, "MTG", 5, None, false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "MTG", 5, None, false, Some(&paths)).unwrap();
         assert!(!results.is_empty());
         for r in &results {
             assert!(
@@ -805,7 +822,7 @@ mod tests {
 
         // Filter to projects/ — should exclude daily/
         let paths = vec!["projects/".to_string()];
-        let results = search(&conn, "MTG", 5, None, false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "MTG", 5, None, false, Some(&paths)).unwrap();
         assert!(results.is_empty());
     }
 
@@ -833,7 +850,7 @@ mod tests {
 
         // Filter to daily/ and docs/ (OR)
         let paths = vec!["daily/".to_string(), "docs/".to_string()];
-        let results = search(&conn, "MTG", 10, None, false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "MTG", 10, None, false, Some(&paths)).unwrap();
         assert!(!results.is_empty());
         for r in &results {
             assert!(
@@ -862,7 +879,7 @@ mod tests {
         }
 
         // No path filter — should return results from both directories
-        let results = search(&conn, "MTG", 10, None, false, None).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "MTG", 10, None, false, None).unwrap();
         assert!(results.len() >= 2);
     }
 
@@ -888,7 +905,7 @@ mod tests {
 
         // Filter to a specific file
         let paths = vec!["docs/api.md".to_string()];
-        let results = search(&conn, "Authentication", 10, None, false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "Authentication", 10, None, false, Some(&paths)).unwrap();
         assert!(!results.is_empty());
         for r in &results {
             assert_eq!(r.source_file, "docs/api.md");
@@ -919,7 +936,7 @@ mod tests {
 
         // _ in path must be literal, not a wildcard
         let paths = vec!["daily_notes/".to_string()];
-        let results = search(&conn, "MTG", 10, None, false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "MTG", 10, None, false, Some(&paths)).unwrap();
         assert!(!results.is_empty());
         for r in &results {
             assert!(
@@ -961,7 +978,7 @@ mod tests {
             after: Some("2025-01-01".to_string()),
             before: None,
         };
-        let results = search(&conn, "MTG", 10, Some(&filter), false, Some(&paths)).unwrap();
+        let SearchOutput { results, .. } = search(&conn, "MTG", 10, Some(&filter), false, Some(&paths)).unwrap();
         for r in &results {
             assert!(
                 r.source_file.starts_with("daily/"),

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -87,7 +87,7 @@ poll_search_hit() {
     local query="$1" file="$2" timeout="$3"
     local elapsed=0
     while [[ $elapsed -lt $timeout ]]; do
-        if search_json "$query" 2>/dev/null | jq -e "any(.[]; .source_file | contains(\"$file\"))" >/dev/null 2>&1; then
+        if search_json "$query" 2>/dev/null | jq -e "any(.results[]; .source_file | contains(\"$file\"))" >/dev/null 2>&1; then
             return 0
         fi
         sleep 2
@@ -101,7 +101,7 @@ poll_search_miss() {
     local query="$1" file="$2" timeout="$3"
     local elapsed=0
     while [[ $elapsed -lt $timeout ]]; do
-        if ! search_json "$query" 2>/dev/null | jq -e "any(.[]; .source_file | contains(\"$file\"))" >/dev/null 2>&1; then
+        if ! search_json "$query" 2>/dev/null | jq -e "any(.results[]; .source_file | contains(\"$file\"))" >/dev/null 2>&1; then
             return 0
         fi
         sleep 2
@@ -207,7 +207,7 @@ log "=== Index → Search round-trip ==="
 
 run search_json "親譲り 無鉄砲"
 assert_json "index-search: botchan hit" \
-    'any(.[]; .source_file | contains("botchan"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("botchan"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 # ── FTS5 search ───────────────────────────────────────────────────────
 
@@ -216,11 +216,11 @@ log "=== FTS5 search ==="
 
 run search_json "ジョバンニ カムパネルラ"
 assert_json "fts5: gingatetsudo hit" \
-    'any(.[]; .source_file | contains("gingatetsudo"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("gingatetsudo"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 run search_json "メロス 激怒"
 assert_json "fts5: hashire-melos hit" \
-    'any(.[]; .source_file | contains("hashire-melos"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("hashire-melos"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 # ── Search options (--top-k, --include-content, text format) ────────
 
@@ -230,12 +230,12 @@ log "=== Search options ==="
 # --top-k: request 1 result, verify exactly 1 returned
 run search_json "メロス" -k 1
 assert_json "options: -k 1 returns exactly 1 result" \
-    'length == 1' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    '.results | length == 1' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 # --include-content: verify content field is present
 run search_json "メロス" -k 1 --include-content 1
 assert_json "options: --include-content adds content field" \
-    '.[0].content != null and (.[0].content | length > 0)' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    '.results[0].content != null and (.results[0].content | length > 0)' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 # text format (default): verify human-readable output contains score and file
 set +e; CAPTURED_OUTPUT=$(tsm search -q "メロス" -k 1 2>/dev/null); CAPTURED_EXIT=$?; set -e
@@ -248,15 +248,15 @@ log "=== Entity search ==="
 
 run search_json "漱石"
 assert_json "entity: 漱石 → botchan" \
-    'any(.[]; .source_file | contains("botchan"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("botchan"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 run search_json "賢治"
 assert_json "entity: 賢治 → gingatetsudo" \
-    'any(.[]; .source_file | contains("gingatetsudo"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("gingatetsudo"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 run search_json "太宰"
 assert_json "entity: 太宰 → hashire-melos" \
-    'any(.[]; .source_file | contains("hashire-melos"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("hashire-melos"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 # ── Temporal search ───────────────────────────────────────────────────
 
@@ -265,16 +265,16 @@ log "=== Temporal search ==="
 
 run search_json "猫" --recent 30d
 assert_json "temporal: --recent 30d excludes old-text" \
-    '[.[] | select(.source_file | contains("old-text"))] | length == 0' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    '[.results[] | select(.source_file | contains("old-text"))] | length == 0' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 THIS_YEAR=$(date +%Y)
 run search_json "吾輩 猫" --year "$THIS_YEAR"
 assert_json "temporal: --year THIS_YEAR excludes old-text" \
-    '[.[] | select(.source_file | contains("old-text"))] | length == 0' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    '[.results[] | select(.source_file | contains("old-text"))] | length == 0' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 run search_json "紳士 料理店" --after "$THREE_MONTHS_AGO_START" --before "$THREE_MONTHS_AGO_END"
 assert_json "temporal: --after/--before hits seasonal-text" \
-    'any(.[]; .source_file | contains("seasonal-text"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("seasonal-text"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 # ── Vector search (semantic similarity) ───────────────────────────────
 
@@ -283,11 +283,11 @@ log "=== Vector search ==="
 
 run search_json "学校の先生と生徒"
 assert_json "vector: 学校の先生と生徒 → botchan" \
-    'any(.[]; .source_file | contains("botchan"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("botchan"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 run search_json "宇宙と星の旅"
 assert_json "vector: 宇宙と星の旅 → gingatetsudo" \
-    'any(.[]; .source_file | contains("gingatetsudo"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("gingatetsudo"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 # ── Dictionary test ───────────────────────────────────────────────────
 
@@ -322,17 +322,17 @@ done
 
 # Verify search before dict registration found results
 assert_json "dict: '$DICT_WORD' found before dict (via constituent tokens)" \
-    'any(.[]; .source_file | contains("hashire-melos"))' "$OUTPUT_BEFORE" "0"
+    'any(.results[]; .source_file | contains("hashire-melos"))' "$OUTPUT_BEFORE" "0"
 
 # Verify search still works after reindex
 run search_json "メロス 激怒" --fallback fts-only
 assert_json "dict: search works after reindex" \
-    'any(.[]; .source_file | contains("hashire-melos"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("hashire-melos"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 # Verify dict-registered word works as a standalone search query (#104)
 run search_json "$DICT_WORD" --fallback fts-only
 assert_json "dict: standalone search for dict term '$DICT_WORD' hits hashire-melos" \
-    'any(.[]; .source_file | contains("hashire-melos"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("hashire-melos"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 # ── Edge cases ────────────────────────────────────────────────────────
 
@@ -343,7 +343,7 @@ log "=== Edge cases ==="
 run search_json ""
 if [[ "$CAPTURED_EXIT" -eq 0 ]]; then
     assert_json "edge: empty query → 0 results or valid json" \
-        'if type == "array" then true else false end' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+        '.results | type == "array"' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 else
     # Empty query might be rejected by clap, that's OK too
     pass "edge: empty query → handled (exit $CAPTURED_EXIT)"
@@ -352,7 +352,7 @@ fi
 # EC4: Single character — must exit 0 and return valid JSON
 run search_json "a"
 assert_json "edge: single char 'a' → valid json (exit $CAPTURED_EXIT)" \
-    'type == "array"' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    '.results | type == "array"' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 # EC5: Invalid --recent value
 set +e; CAPTURED_OUTPUT=$(tsm search -q "test" --recent garbage 2>&1); CAPTURED_EXIT=$?; set -e
@@ -370,7 +370,7 @@ assert_contains "ingest-session: succeeds" "session indexed" "$CAPTURED_OUTPUT" 
 # Search for session-specific content (use fts-only; embedder may not be ready)
 run search_json "量子もつれ" --fallback fts-only
 assert_json "ingest-session: search hits session content" \
-    'any(.[]; .source_file | contains("test-session"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
+    'any(.results[]; .source_file | contains("test-session"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 
 # Re-ingest same file should be a no-op (already indexed)
 set +e; CAPTURED_OUTPUT=$(tsm ingest-session "$SESSION_FILE" 2>&1); CAPTURED_EXIT=$?; set -e
@@ -403,7 +403,7 @@ else
     tsm index 2>/dev/null
     sleep 2
     run search_json "幻想水滸伝"
-    if echo "$CAPTURED_OUTPUT" | jq -e 'any(.[]; .source_file | contains("watcher-test"))' >/dev/null 2>&1; then
+    if echo "$CAPTURED_OUTPUT" | jq -e 'any(.results[]; .source_file | contains("watcher-test"))' >/dev/null 2>&1; then
         pass "watcher: new file indexed (after manual index fallback)"
     else
         fail "watcher: new file not detected" "watcher-test.md not found in search results"
@@ -420,7 +420,7 @@ else
     tsm index 2>/dev/null
     sleep 2
     run search_json "幻想水滸伝"
-    if ! echo "$CAPTURED_OUTPUT" | jq -e 'any(.[]; .source_file | contains("watcher-test"))' >/dev/null 2>&1; then
+    if ! echo "$CAPTURED_OUTPUT" | jq -e 'any(.results[]; .source_file | contains("watcher-test"))' >/dev/null 2>&1; then
         pass "watcher: deleted file removed (after manual index fallback)"
     else
         fail "watcher: deleted file still in index" "watcher-test.md still appears in search results"


### PR DESCRIPTION
## Summary

- `tsm search --format json` の出力をエンベロープ構造 `{ "total_hits": N, "results": [...] }` に変更 (#130)
- `search.sh` の出力を Anthropic プロンプティングベストプラクティス準拠の XML フォーマットに変更 (#128)
- `TSM_SNIPPET_BUDGET` 環境変数でスニペット予算を制御可能に

### Breaking change

JSON 出力がベア配列からエンベロープオブジェクトに変更。

### XML output example

```xml
<knowledge_search query="LoRa モジュール" count="5" total="48">
<result index="1" score="0.017">
<source type="daily">daily/daily/research/vhf-tracker-radio-options.md</source>
<section>VHFドッグトラッカー > 比較マトリクス</section>
<snippet>...</snippet>
</result>
</knowledge_search>
```

Closes #130
Refs #128

## Test plan

- [x] `cargo test search` — 50 tests passed
- [x] `cargo test format` — 13 tests passed
- [x] `shellcheck hooks/scripts/search.sh` — no warnings
- [x] 実機テストで `total="48"` が正しく表示される
- [ ] CI green
