### PR TITLE
feat(config): promote project_root to ResolvedConfig (#136 item 1)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1174,6 +1174,10 @@ index_root = "/low-root"
         std::env::remove_var("TSM_STATE_DIR");
         // env wins over config file value
         assert_eq!(cfg.state_dir, PathBuf::from("/env/override"));
+        // Also pins that the project_root parameter lands on the struct
+        // field verbatim — a one-line guard against a copy-paste bug in
+        // from_config_file's Self {...} literal.
+        assert_eq!(cfg.project_root, PathBuf::from("/tmp/unused-root"));
     }
 
     #[test]
@@ -1545,6 +1549,36 @@ half_life_days = 180
         let warnings = reload();
         // No structural fields changed, so no warnings
         assert!(warnings.is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn test_reload_warns_on_project_root_change() {
+        // Force singleton initialization from whatever config the host has.
+        let _ = resolved();
+
+        // Point TSM_CONFIG at a tempdir tsm.toml whose parent differs from
+        // the host's CWD — forces project_root to change on next reload.
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("tsm.toml");
+        std::fs::write(&config_path, "").unwrap();
+        std::env::set_var("TSM_CONFIG", &config_path);
+
+        let warnings = reload();
+
+        std::env::remove_var("TSM_CONFIG");
+        reload(); // restore to host config
+
+        assert!(
+            warnings.iter().any(|w| w.contains("project_root")),
+            "expected project_root warning, got: {warnings:?}"
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("project_root") && w.contains("tsm restart")),
+            "project_root warning should call out `tsm restart`: {warnings:?}"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -213,8 +213,21 @@ pub struct ResolvedConfig {
 
     /// Directory tsm treats as the user's workspace — where `.tsmignore`
     /// and `tsm.toml` are expected to live. Derived at load time from the
-    /// parent of the first successfully-loaded config file (or the CWD if
-    /// no config file was found). Not user-configurable via TOML.
+    /// parent of the first successfully-loaded config file (or CWD if no
+    /// config file was found). Not user-configurable via TOML.
+    ///
+    /// Exception: when only an XDG config exists (no `tsm.toml` in CWD
+    /// and no `$TSM_CONFIG`), this becomes the XDG config directory.
+    /// `.tsmignore` lookup will not find a workspace ignore file in that
+    /// case; users running from a project directory should have a local
+    /// `tsm.toml` or set `$TSM_CONFIG` to their workspace file.
+    ///
+    /// Invariant: the value is set once at `from_env()` time and must
+    /// stay consistent with the config file whose values populated the
+    /// other fields. Mutating this field after construction (possible
+    /// because it is `pub` — matches the rest of the struct) breaks
+    /// that provenance link. Don't.
+    ///
     /// Default: CWD. Config: (derived).
     pub project_root: PathBuf,
 }
@@ -373,10 +386,11 @@ impl ResolvedConfig {
 }
 
 /// Fallback when no config file was loaded and no explicit project_root
-/// was passed. Mirrors the pre-#137 implicit behavior — tsm falls back to
-/// whatever directory the user ran it from. If even CWD is unavailable
-/// (deleted, unmounted), `std::env::temp_dir()` is used to guarantee the
-/// value is always a valid `PathBuf`.
+/// was passed. Mirrors the implicit behavior before `project_root` was
+/// introduced as a first-class field — tsm falls back to whatever
+/// directory the user ran it from. If even CWD is unavailable (deleted,
+/// unmounted), `std::env::temp_dir()` is used to guarantee the value is
+/// always a valid `PathBuf`.
 fn cwd_fallback() -> PathBuf {
     std::env::current_dir().unwrap_or_else(|e| {
         log::warn!(
@@ -495,8 +509,10 @@ pub fn reload() -> Vec<String> {
 /// resolved against CWD for relative candidates like `"tsm.toml"`.
 /// `None` when no candidate loaded; callers substitute their own fallback
 /// (typically `std::env::current_dir()`). Relative candidates with no
-/// parent component (e.g. bare `"tsm.toml"`) are canonicalized before the
-/// parent is extracted so callers always get an absolute directory.
+/// parent component (e.g. bare `"tsm.toml"`) are resolved against CWD via
+/// `current_dir().join(path)` before the parent is extracted so callers
+/// always get an absolute directory — no `canonicalize` syscall is used,
+/// see `project_root_from` for the rationale.
 fn load_config_from(candidates: &[PathBuf]) -> (ConfigFile, Option<PathBuf>) {
     // Determine which path was explicitly requested via TSM_CONFIG (if any)
     let explicit_config = std::env::var_os("TSM_CONFIG").map(PathBuf::from);

--- a/src/config.rs
+++ b/src/config.rs
@@ -568,12 +568,22 @@ fn load_config_from(candidates: &[PathBuf]) -> (ConfigFile, Option<PathBuf>) {
 
 /// Resolve `path` to the parent directory of the config file. Handles
 /// both absolute paths (e.g. `TSM_CONFIG=/foo/tsm.toml` → `/foo`) and
-/// relative ones (bare `"tsm.toml"` → canonicalized CWD). Returns `None`
-/// only for pathological cases where even canonicalization fails.
+/// relative ones (bare `"tsm.toml"` → CWD-joined parent).
+///
+/// Avoids `canonicalize` — it's a syscall that can race the preceding
+/// `read_to_string` (file disappears, symlink breaks) and losing it
+/// silently breaks the invariant "config values and project_root come
+/// from the same file". Since we already read the file successfully,
+/// we know its parent deterministically from the path we were given.
 fn project_root_from(path: &Path) -> Option<PathBuf> {
-    // canonicalize() resolves relative paths against CWD and follows
-    // symlinks, giving callers a stable absolute directory.
-    let abs = std::fs::canonicalize(path).ok()?;
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        // Relative path — resolve against CWD. `current_dir()` failure
+        // is the only way we return None here; the file read already
+        // succeeded so the parent exists on disk.
+        std::env::current_dir().ok()?.join(path)
+    };
     abs.parent().map(|p| p.to_path_buf())
 }
 
@@ -995,11 +1005,9 @@ embedder_idle_timeout_secs = 1200
         assert_eq!(cfg.index_root, Some(PathBuf::from("/custom/root")));
         assert_eq!(cfg.embedder_idle_timeout_secs, Some(1200));
         assert!(cfg.daemon_socket_path.is_none());
-        // project_root derives from the loaded file's parent.
-        assert_eq!(
-            root.unwrap(),
-            std::fs::canonicalize(config_path.parent().unwrap()).unwrap()
-        );
+        // project_root derives from the loaded file's parent — the same
+        // absolute path that was passed in, no canonicalization applied.
+        assert_eq!(root.as_deref(), config_path.parent());
     }
 
     #[test]
@@ -1024,10 +1032,7 @@ index_root = "/low-root"
         assert_eq!(cfg.index_root, Some(PathBuf::from("/low-root")));
         // project_root comes from the FIRST successfully-loaded candidate,
         // regardless of which fields subsequent files contribute.
-        assert_eq!(
-            root.unwrap(),
-            std::fs::canonicalize(high.parent().unwrap()).unwrap()
-        );
+        assert_eq!(root.as_deref(), high.parent());
     }
 
     #[test]
@@ -1036,6 +1041,27 @@ index_root = "/low-root"
         assert!(cfg.state_dir.is_none());
         assert!(cfg.index_root.is_none());
         assert!(root.is_none(), "no config loaded → no project_root");
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_config_relative_path_resolves_against_cwd() {
+        // A bare relative candidate like "tsm.toml" must yield a
+        // project_root derived from CWD (not a bare empty path), with no
+        // canonicalize syscall in the picture. Avoids the race where the
+        // file could change between read and canonicalize.
+        let dir = tempfile::tempdir().unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        std::fs::write(dir.path().join("tsm.toml"), r#"state_dir = "/rel""#).unwrap();
+
+        let (cfg, root) = load_config_from(&[PathBuf::from("tsm.toml")]);
+
+        std::env::set_current_dir(&prev).unwrap();
+
+        assert_eq!(cfg.state_dir, Some(PathBuf::from("/rel")));
+        // project_root should be CWD (tempdir), not empty / None.
+        assert_eq!(root.unwrap(), dir.path());
     }
 
     #[test]
@@ -1058,10 +1084,7 @@ index_root = "/low-root"
         let (cfg, root) = load_config_from(&[malformed, valid.clone()]);
         assert_eq!(cfg.state_dir, Some(PathBuf::from("/good")));
         // project_root is derived from the VALID file, not the malformed one.
-        assert_eq!(
-            root.unwrap(),
-            std::fs::canonicalize(valid.parent().unwrap()).unwrap()
-        );
+        assert_eq!(root.as_deref(), valid.parent());
     }
 
     // ─── Pure functions ─────────────────────────────────────────────

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{OnceLock, RwLock};
 
 use directories::ProjectDirs;
@@ -210,18 +210,35 @@ pub struct ResolvedConfig {
     /// File extensions to include during indexing (without leading dot).
     /// Default: `["md"]`. Config: `[index].extensions`.
     pub extensions: Vec<String>,
+
+    /// Directory tsm treats as the user's workspace — where `.tsmignore`
+    /// and `tsm.toml` are expected to live. Derived at load time from the
+    /// parent of the first successfully-loaded config file (or the CWD if
+    /// no config file was found). Not user-configurable via TOML.
+    /// Default: CWD. Config: (derived).
+    pub project_root: PathBuf,
 }
 
 impl ResolvedConfig {
     /// Resolve all config values from environment variables, config files, and defaults.
     pub fn from_env() -> Self {
-        let file_cfg = load_config_from(&config_file_candidates());
-        Self::from_config_file(&file_cfg)
+        let (file_cfg, loaded_root) = load_config_from(&config_file_candidates());
+        let project_root = loaded_root.unwrap_or_else(cwd_fallback);
+        Self::from_config_file(&file_cfg, project_root)
     }
 
-    /// Resolve from a pre-loaded `ConfigFile` (still reads env vars for overrides).
-    /// Visible within the crate for testing; production code should use `from_env()`.
-    pub(crate) fn from_config_file(file_cfg: &ConfigFile) -> Self {
+    /// Resolve from a pre-loaded `ConfigFile` with an explicit project root.
+    ///
+    /// `project_root` is the directory tsm treats as the user's workspace —
+    /// typically the directory that held the `tsm.toml` that was loaded,
+    /// falling back to the current working directory. It is where
+    /// `.tsmignore` is resolved from (patterns still anchor at
+    /// `index_root`, only the file lookup uses `project_root`).
+    ///
+    /// Visible within the crate for testing; production code should use
+    /// `from_env()`. Tests pass a tempdir to avoid mutating process-global
+    /// CWD state.
+    pub(crate) fn from_config_file(file_cfg: &ConfigFile, project_root: PathBuf) -> Self {
         let state_dir = env_or("TSM_STATE_DIR", file_cfg.state_dir.as_ref())
             .unwrap_or_else(|| PathBuf::from(DEFAULT_STATE_DIR));
 
@@ -350,8 +367,25 @@ impl ResolvedConfig {
             respect_gitignore,
             ignore_file,
             extensions,
+            project_root,
         }
     }
+}
+
+/// Fallback when no config file was loaded and no explicit project_root
+/// was passed. Mirrors the pre-#137 implicit behavior — tsm falls back to
+/// whatever directory the user ran it from. If even CWD is unavailable
+/// (deleted, unmounted), `std::env::temp_dir()` is used to guarantee the
+/// value is always a valid `PathBuf`.
+fn cwd_fallback() -> PathBuf {
+    std::env::current_dir().unwrap_or_else(|e| {
+        log::warn!(
+            "current_dir() failed ({e}); using temp dir for project_root \
+             — .tsmignore lookup will likely miss unless TSM_CONFIG points \
+             at an absolute path"
+        );
+        std::env::temp_dir()
+    })
 }
 
 /// Read an env var as PathBuf, falling back to a config file value.
@@ -435,6 +469,13 @@ pub fn reload() -> Vec<String> {
     if old.user_dict_path != new_cfg.user_dict_path {
         warnings.push("user_dict_path changed; requires `tsm restart`".to_string());
     }
+    if old.project_root != new_cfg.project_root {
+        warnings.push(format!(
+            "project_root changed ({} → {}); requires `tsm restart`",
+            old.project_root.display(),
+            new_cfg.project_root.display()
+        ));
+    }
 
     *w = new_cfg;
 
@@ -448,11 +489,20 @@ pub fn reload() -> Vec<String> {
 }
 
 /// Merge config values from `candidates` in order; first non-None value for each field wins.
-fn load_config_from(candidates: &[PathBuf]) -> ConfigFile {
+///
+/// Returns `(merged, project_root)` where `project_root` is the parent
+/// directory of the first successfully-read-and-parsed config file,
+/// resolved against CWD for relative candidates like `"tsm.toml"`.
+/// `None` when no candidate loaded; callers substitute their own fallback
+/// (typically `std::env::current_dir()`). Relative candidates with no
+/// parent component (e.g. bare `"tsm.toml"`) are canonicalized before the
+/// parent is extracted so callers always get an absolute directory.
+fn load_config_from(candidates: &[PathBuf]) -> (ConfigFile, Option<PathBuf>) {
     // Determine which path was explicitly requested via TSM_CONFIG (if any)
     let explicit_config = std::env::var_os("TSM_CONFIG").map(PathBuf::from);
 
     let mut merged = ConfigFile::default();
+    let mut loaded_root: Option<PathBuf> = None;
 
     // Iterate in priority order (highest first); `.or()` keeps first-seen value
     for path in candidates {
@@ -475,6 +525,9 @@ fn load_config_from(candidates: &[PathBuf]) -> ConfigFile {
                 continue;
             }
         };
+        if loaded_root.is_none() {
+            loaded_root = project_root_from(path);
+        }
         merged.state_dir = merged.state_dir.or(file.state_dir);
         merged.index_root = merged.index_root.or(file.index_root);
         merged.embedder_socket_path = merged.embedder_socket_path.or(file.embedder_socket_path);
@@ -510,7 +563,18 @@ fn load_config_from(candidates: &[PathBuf]) -> ConfigFile {
             merged.index.extensions = file.index.extensions;
         }
     }
-    merged
+    (merged, loaded_root)
+}
+
+/// Resolve `path` to the parent directory of the config file. Handles
+/// both absolute paths (e.g. `TSM_CONFIG=/foo/tsm.toml` → `/foo`) and
+/// relative ones (bare `"tsm.toml"` → canonicalized CWD). Returns `None`
+/// only for pathological cases where even canonicalization fails.
+fn project_root_from(path: &Path) -> Option<PathBuf> {
+    // canonicalize() resolves relative paths against CWD and follows
+    // symlinks, giving callers a stable absolute directory.
+    let abs = std::fs::canonicalize(path).ok()?;
+    abs.parent().map(|p| p.to_path_buf())
 }
 
 fn config_file_candidates() -> Vec<PathBuf> {
@@ -581,6 +645,10 @@ pub fn ignore_file() -> String {
 
 pub fn index_extensions() -> Vec<String> {
     resolved().extensions.clone()
+}
+
+pub fn project_root() -> PathBuf {
+    resolved().project_root.clone()
 }
 
 // ─── Derived paths ───────────────────────────────────────────────
@@ -749,10 +817,11 @@ mod tests {
 
     /// Build a ResolvedConfig from inline TOML. Does NOT clear env vars —
     /// callers that need clean defaults must clear TSM_* vars themselves
-    /// or use #[serial].
+    /// or use #[serial]. `project_root` is stubbed to `/tmp/unused-root`
+    /// since these tests don't exercise `.tsmignore` resolution.
     fn resolved_from_toml(toml_content: &str) -> ResolvedConfig {
         let file_cfg: ConfigFile = toml::from_str(toml_content).unwrap();
-        ResolvedConfig::from_config_file(&file_cfg)
+        ResolvedConfig::from_config_file(&file_cfg, PathBuf::from("/tmp/unused-root"))
     }
 
     // ─── Constants ──────────────────────────────────────────────────
@@ -921,11 +990,16 @@ embedder_idle_timeout_secs = 1200
         )
         .unwrap();
 
-        let cfg = load_config_from(&[config_path]);
+        let (cfg, root) = load_config_from(&[config_path.clone()]);
         assert_eq!(cfg.state_dir, Some(PathBuf::from("/custom/data")));
         assert_eq!(cfg.index_root, Some(PathBuf::from("/custom/root")));
         assert_eq!(cfg.embedder_idle_timeout_secs, Some(1200));
         assert!(cfg.daemon_socket_path.is_none());
+        // project_root derives from the loaded file's parent.
+        assert_eq!(
+            root.unwrap(),
+            std::fs::canonicalize(config_path.parent().unwrap()).unwrap()
+        );
     }
 
     #[test]
@@ -945,22 +1019,30 @@ index_root = "/low-root"
         )
         .unwrap();
 
-        let cfg = load_config_from(&[high, low]);
+        let (cfg, root) = load_config_from(&[high.clone(), low]);
         assert_eq!(cfg.state_dir, Some(PathBuf::from("/high")));
         assert_eq!(cfg.index_root, Some(PathBuf::from("/low-root")));
+        // project_root comes from the FIRST successfully-loaded candidate,
+        // regardless of which fields subsequent files contribute.
+        assert_eq!(
+            root.unwrap(),
+            std::fs::canonicalize(high.parent().unwrap()).unwrap()
+        );
     }
 
     #[test]
     fn test_load_config_empty_candidates() {
-        let cfg = load_config_from(&[]);
+        let (cfg, root) = load_config_from(&[]);
         assert!(cfg.state_dir.is_none());
         assert!(cfg.index_root.is_none());
+        assert!(root.is_none(), "no config loaded → no project_root");
     }
 
     #[test]
     fn test_load_config_missing_file_skipped() {
-        let cfg = load_config_from(&[PathBuf::from("/nonexistent/tsm.toml")]);
+        let (cfg, root) = load_config_from(&[PathBuf::from("/nonexistent/tsm.toml")]);
         assert!(cfg.state_dir.is_none());
+        assert!(root.is_none());
     }
 
     #[test]
@@ -973,8 +1055,13 @@ index_root = "/low-root"
         let valid = dir.path().join("good.toml");
         std::fs::write(&valid, r#"state_dir = "/good""#).unwrap();
 
-        let cfg = load_config_from(&[malformed, valid]);
+        let (cfg, root) = load_config_from(&[malformed, valid.clone()]);
         assert_eq!(cfg.state_dir, Some(PathBuf::from("/good")));
+        // project_root is derived from the VALID file, not the malformed one.
+        assert_eq!(
+            root.unwrap(),
+            std::fs::canonicalize(valid.parent().unwrap()).unwrap()
+        );
     }
 
     // ─── Pure functions ─────────────────────────────────────────────
@@ -1038,10 +1125,13 @@ index_root = "/low-root"
     #[serial]
     fn test_env_var_overrides_config_state_dir() {
         std::env::set_var("TSM_STATE_DIR", "/env/override");
-        let cfg = ResolvedConfig::from_config_file(&ConfigFile {
-            state_dir: Some(PathBuf::from("/from/config")),
-            ..Default::default()
-        });
+        let cfg = ResolvedConfig::from_config_file(
+            &ConfigFile {
+                state_dir: Some(PathBuf::from("/from/config")),
+                ..Default::default()
+            },
+            PathBuf::from("/tmp/unused-root"),
+        );
         std::env::remove_var("TSM_STATE_DIR");
         // env wins over config file value
         assert_eq!(cfg.state_dir, PathBuf::from("/env/override"));
@@ -1051,7 +1141,10 @@ index_root = "/low-root"
     #[serial]
     fn test_env_var_overrides_config_timeout() {
         std::env::set_var("TSM_EMBEDDER_IDLE_TIMEOUT", "42");
-        let cfg = ResolvedConfig::from_config_file(&ConfigFile::default());
+        let cfg = ResolvedConfig::from_config_file(
+            &ConfigFile::default(),
+            PathBuf::from("/tmp/unused-root"),
+        );
         std::env::remove_var("TSM_EMBEDDER_IDLE_TIMEOUT");
         assert_eq!(cfg.embedder_idle_timeout_secs, 42);
     }
@@ -1060,10 +1153,13 @@ index_root = "/low-root"
     #[serial]
     fn test_env_var_invalid_integer_falls_back_to_config() {
         std::env::set_var("TSM_EMBEDDER_IDLE_TIMEOUT", "not_a_number");
-        let cfg = ResolvedConfig::from_config_file(&ConfigFile {
-            embedder_idle_timeout_secs: Some(999),
-            ..Default::default()
-        });
+        let cfg = ResolvedConfig::from_config_file(
+            &ConfigFile {
+                embedder_idle_timeout_secs: Some(999),
+                ..Default::default()
+            },
+            PathBuf::from("/tmp/unused-root"),
+        );
         std::env::remove_var("TSM_EMBEDDER_IDLE_TIMEOUT");
         // Invalid env var → falls back to config file value
         assert_eq!(cfg.embedder_idle_timeout_secs, 999);
@@ -1073,7 +1169,10 @@ index_root = "/low-root"
     #[serial]
     fn test_env_var_overrides_config_socket() {
         std::env::set_var("TSM_EMBEDDER_SOCKET", "/tmp/custom.sock");
-        let cfg = ResolvedConfig::from_config_file(&ConfigFile::default());
+        let cfg = ResolvedConfig::from_config_file(
+            &ConfigFile::default(),
+            PathBuf::from("/tmp/unused-root"),
+        );
         std::env::remove_var("TSM_EMBEDDER_SOCKET");
         assert_eq!(cfg.embedder_socket_path, PathBuf::from("/tmp/custom.sock"));
     }

--- a/src/indexer/walker.rs
+++ b/src/indexer/walker.rs
@@ -54,23 +54,14 @@ pub struct ContentWalker {
 impl ContentWalker {
     /// Construct a walker from a fully-resolved config.
     ///
-    /// The `.tsmignore` file is read from the current working directory (the
-    /// directory containing `tsm.toml`). Missing files are silently treated as
+    /// The `.tsmignore` file is read from `cfg.project_root` — the directory
+    /// containing `tsm.toml`, resolved at config-load time (see
+    /// `ResolvedConfig::from_env`). Missing files are silently treated as
     /// empty — this is the common case for users who have not opted in.
     pub fn from_config(cfg: &ResolvedConfig) -> Self {
-        let project_root = std::env::current_dir().unwrap_or_else(|e| {
-            // This only happens if the CWD has been deleted / unmounted.
-            // Warn loudly so users notice when `.tsmignore` lookup silently
-            // shifts to `index_root`, which is usually not what they want.
-            log::warn!(
-                "current_dir() failed ({e}); using index_root as the .tsmignore lookup path — \
-                 ignore rules may not resolve correctly"
-            );
-            cfg.index_root.clone()
-        });
         let matcher = build_matcher(
             &cfg.index_root,
-            &project_root,
+            &cfg.project_root,
             &cfg.ignore_file,
             cfg.respect_gitignore,
         );
@@ -322,6 +313,9 @@ mod tests {
         std::fs::write(full, body).unwrap();
     }
 
+    /// Build a `ResolvedConfig` where `index_root` and `project_root` both
+    /// point at `root`. This is the common single-repo case and suffices
+    /// for tests that don't care about the split between the two.
     fn cfg_for(root: &Path) -> ResolvedConfig {
         let toml = format!(
             r#"
@@ -331,40 +325,15 @@ state_dir = "/tmp/unused-state"
             root.display()
         );
         let file_cfg: crate::config::ConfigFile = toml::from_str(&toml).unwrap();
-        ResolvedConfig::from_config_file(&file_cfg)
+        ResolvedConfig::from_config_file(&file_cfg, root.to_path_buf())
     }
 
-    /// RAII guard that restores CWD on drop. Any panicking test still puts
-    /// the process back in a known-good directory before the next test runs,
-    /// preventing order-dependent flakes from accumulating.
-    struct CwdGuard {
-        original: PathBuf,
-    }
-
-    impl CwdGuard {
-        fn change_to(new_cwd: &Path) -> Self {
-            let original = std::env::current_dir().unwrap_or_else(|_| std::env::temp_dir());
-            std::env::set_current_dir(new_cwd).unwrap();
-            Self { original }
-        }
-    }
-
-    impl Drop for CwdGuard {
-        fn drop(&mut self) {
-            // Best-effort: if the original dir was since deleted, fall back
-            // to `/` so subsequent tests still start from a valid CWD.
-            let _ = std::env::set_current_dir(&self.original)
-                .or_else(|_| std::env::set_current_dir("/"));
-        }
-    }
-
-    /// Build a walker where the project root (for `.tsmignore` lookup) and
-    /// `index_root` are the same directory — the common single-repo case.
-    /// Returns the guard so the caller's scope controls CWD lifetime.
-    fn walker_in(tempdir: &TempDir) -> (ContentWalker, CwdGuard) {
-        let guard = CwdGuard::change_to(tempdir.path());
-        let cfg = cfg_for(tempdir.path());
-        (ContentWalker::from_config(&cfg), guard)
+    /// Build a walker anchored entirely at `tempdir` (both `index_root`
+    /// and `project_root`). Project-root-aware tests that need the two to
+    /// differ should call `cfg_for` variants and `ContentWalker::from_config`
+    /// directly.
+    fn walker_in(tempdir: &TempDir) -> ContentWalker {
+        ContentWalker::from_config(&cfg_for(tempdir.path()))
     }
 
     // ─── Forced excludes ──────────────────────────────────────────────
@@ -375,7 +344,7 @@ state_dir = "/tmp/unused-state"
         let tmp = TempDir::new().unwrap();
         write_file(tmp.path(), "notes/keep.md", "keep");
         write_file(tmp.path(), ".git/config.md", "no");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("notes/keep.md")));
         assert!(!files
@@ -389,7 +358,7 @@ state_dir = "/tmp/unused-state"
         let tmp = TempDir::new().unwrap();
         write_file(tmp.path(), "notes/keep.md", "keep");
         write_file(tmp.path(), ".tsm/state.md", "no");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(!files
             .iter()
@@ -413,7 +382,7 @@ state_dir = "/tmp/unused-state"
         write_file(tmp.path(), "company/.git/HEAD.md", "no");
         write_file(tmp.path(), "daily/.tsm/sentinel.md", "no");
         write_file(tmp.path(), "daily/notes/keep.md", "yes");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("daily/notes/keep.md")));
         assert!(!files
@@ -436,7 +405,7 @@ state_dir = "/tmp/unused-state"
         write_file(tmp.path(), "the-space-memory/target/out.md", "no");
         write_file(tmp.path(), "daily/notes/keep.md", "yes");
         write_file(tmp.path(), ".tsmignore", "target/\n");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("daily/notes/keep.md")));
         assert!(!files
@@ -454,7 +423,7 @@ state_dir = "/tmp/unused-state"
         write_file(tmp.path(), "worktrees/wt1/a.md", "no");
         write_file(tmp.path(), "company/worktrees/wt2/b.md", "yes");
         write_file(tmp.path(), ".tsmignore", "/worktrees/\n");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         // Top-level worktrees/ is excluded.
         assert!(!files.iter().any(|p| p.ends_with("worktrees/wt1/a.md")));
@@ -478,7 +447,7 @@ state_dir = "/tmp/unused-state"
         // Without file_type()-based symlink rejection the walker would
         // descend and read .git/HEAD.md under the disguised component.
         symlink(tmp.path().join(".git"), tmp.path().join("notes/gitshadow")).unwrap();
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("notes/real.md")));
         assert!(!files
@@ -496,7 +465,7 @@ state_dir = "/tmp/unused-state"
         write_file(tmp.path(), "notes/keep.md", "keep");
         write_file(tmp.path(), ".git/inside.md", "no");
         write_file(tmp.path(), ".tsmignore", "!.git/\n");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         // .git/ must still be excluded even with an explicit negation pattern.
         assert!(!files
@@ -513,7 +482,7 @@ state_dir = "/tmp/unused-state"
         write_file(tmp.path(), "daily/keep.md", "a");
         write_file(tmp.path(), "private/secret.md", "b");
         write_file(tmp.path(), ".tsmignore", "private/\n");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("daily/keep.md")));
         assert!(!files
@@ -528,7 +497,7 @@ state_dir = "/tmp/unused-state"
         write_file(tmp.path(), "notes/a.md", "a");
         write_file(tmp.path(), "notes/b-draft.md", "b");
         write_file(tmp.path(), ".tsmignore", "**/*-draft.md\n");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("notes/a.md")));
         assert!(!files.iter().any(|p| p.ends_with("b-draft.md")));
@@ -541,7 +510,7 @@ state_dir = "/tmp/unused-state"
         write_file(tmp.path(), "public/ok.md", "a");
         write_file(tmp.path(), "private/secret.md", "b");
         write_file(tmp.path(), ".tsmignore", "private/\n");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         assert!(!walker.is_ignored(&tmp.path().join("public/ok.md")));
         assert!(walker.is_ignored(&tmp.path().join("private/secret.md")));
         // Outside index_root → ignored.
@@ -557,7 +526,7 @@ state_dir = "/tmp/unused-state"
         write_file(tmp.path(), "notes/a.md", "a");
         write_file(tmp.path(), ".obsidian/plugin.md", "b");
         // No .tsmignore on disk — the synthetic `.*/` fallback must cover .obsidian.
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("notes/a.md")));
         assert!(!files
@@ -573,7 +542,7 @@ state_dir = "/tmp/unused-state"
         write_file(tmp.path(), ".obsidian/plugin.md", "b");
         // Empty .tsmignore means: user has taken control, no synthetic fallback.
         write_file(tmp.path(), ".tsmignore", "");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with(".obsidian/plugin.md")));
     }
@@ -592,7 +561,7 @@ respect_gitignore = {}
             respect
         );
         let file_cfg: crate::config::ConfigFile = toml::from_str(&toml).unwrap();
-        ResolvedConfig::from_config_file(&file_cfg)
+        ResolvedConfig::from_config_file(&file_cfg, root.to_path_buf())
     }
 
     #[test]
@@ -603,7 +572,6 @@ respect_gitignore = {}
         write_file(tmp.path(), "build/out.md", "b");
         write_file(tmp.path(), ".gitignore", "build/\n");
         write_file(tmp.path(), ".tsmignore", ""); // disable hidden-dir fallback
-        let _cwd = CwdGuard::change_to(tmp.path());
         let walker = ContentWalker::from_config(&cfg_with_gitignore(tmp.path(), true));
         let files = walker.collect_files();
         assert!(!files
@@ -618,7 +586,6 @@ respect_gitignore = {}
         write_file(tmp.path(), "build/out.md", "b");
         write_file(tmp.path(), ".gitignore", "build/\n");
         write_file(tmp.path(), ".tsmignore", "");
-        let _cwd = CwdGuard::change_to(tmp.path());
         let walker = ContentWalker::from_config(&cfg_with_gitignore(tmp.path(), false));
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("build/out.md")));
@@ -632,7 +599,7 @@ respect_gitignore = {}
         let tmp = TempDir::new().unwrap();
         write_file(tmp.path(), "notes/a.md", "md");
         write_file(tmp.path(), "notes/b.txt", "txt");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("a.md")));
         assert!(!files.iter().any(|p| p.ends_with("b.txt")));
@@ -654,8 +621,7 @@ extensions = ["md", "txt"]
             tmp.path().display()
         );
         let file_cfg: crate::config::ConfigFile = toml::from_str(&toml).unwrap();
-        let cfg = ResolvedConfig::from_config_file(&file_cfg);
-        let _cwd = CwdGuard::change_to(tmp.path());
+        let cfg = ResolvedConfig::from_config_file(&file_cfg, tmp.path().to_path_buf());
         let walker = ContentWalker::from_config(&cfg);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("a.md")));
@@ -682,7 +648,7 @@ state_dir = "/tmp/unused-state"
             entries
         );
         let file_cfg: crate::config::ConfigFile = toml::from_str(&toml).unwrap();
-        ResolvedConfig::from_config_file(&file_cfg)
+        ResolvedConfig::from_config_file(&file_cfg, root.to_path_buf())
     }
 
     #[test]
@@ -693,7 +659,6 @@ state_dir = "/tmp/unused-state"
         write_file(tmp.path(), "keep/nested/b.md", "b");
         write_file(tmp.path(), "drop/c.md", "c");
         write_file(tmp.path(), ".tsmignore", "drop/\n");
-        let _cwd = CwdGuard::change_to(tmp.path());
         let walker =
             ContentWalker::from_config(&cfg_with_content_dirs(tmp.path(), &["keep", "drop"]));
         let files = walker.collect_files();
@@ -712,17 +677,30 @@ state_dir = "/tmp/unused-state"
     // patterns resolve relative to index_root. These tests exercise the
     // split — they're the #134 spec checklist items.
 
+    /// Build a config where project_root and index_root differ. Used for
+    /// tests that exercise the split — `.tsmignore` lookup uses
+    /// `project_root`, pattern resolution uses `index_root`.
+    fn cfg_split(project_root: &Path, index_root: &Path) -> ResolvedConfig {
+        let toml = format!(
+            r#"
+index_root = "{}"
+state_dir = "/tmp/unused-state"
+"#,
+            index_root.display()
+        );
+        let file_cfg: crate::config::ConfigFile = toml::from_str(&toml).unwrap();
+        ResolvedConfig::from_config_file(&file_cfg, project_root.to_path_buf())
+    }
+
     #[test]
-    #[serial_test::serial]
     fn tsmignore_patterns_resolve_relative_to_index_root_not_cwd() {
-        // Two independent tempdirs: project_root (CWD) holds .tsmignore,
-        // index_root is the separate tree being scanned.
+        // Two independent tempdirs: project_root holds .tsmignore, index_root
+        // is the separate tree being scanned. Pattern-confusion trap: same
+        // name exists under both roots; if the matcher were (wrongly)
+        // anchored at project_root, `project/private/` would be excluded
+        // while `index/private/` would slip through.
         let project = TempDir::new().unwrap();
         let index = TempDir::new().unwrap();
-        // A pattern-confusion trap: same name exists under both roots.
-        // If the matcher were (wrongly) anchored at CWD, it would exclude
-        // `project/private/` (invisible to us) while `index/private/` would
-        // slip through.
         write_file(project.path(), ".tsmignore", "private/\n");
         write_file(
             project.path(),
@@ -732,8 +710,7 @@ state_dir = "/tmp/unused-state"
         write_file(index.path(), "public/ok.md", "a");
         write_file(index.path(), "private/secret.md", "b");
 
-        let _cwd = CwdGuard::change_to(project.path());
-        let walker = ContentWalker::from_config(&cfg_for(index.path()));
+        let walker = ContentWalker::from_config(&cfg_split(project.path(), index.path()));
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("public/ok.md")));
         assert!(!files
@@ -742,20 +719,18 @@ state_dir = "/tmp/unused-state"
     }
 
     #[test]
-    #[serial_test::serial]
     fn tsmignore_placed_in_index_root_is_ignored() {
         // Spec checklist: ".tsmignore in index_root (when different from
-        // project root) is ignored". project_root (CWD) has no .tsmignore,
-        // so the synthetic hidden-dir fallback is the only active rule —
-        // the index_root/.tsmignore must NOT be picked up.
+        // project root) is ignored". project_root has no .tsmignore, so
+        // the synthetic hidden-dir fallback is the only active rule — the
+        // index_root/.tsmignore must NOT be picked up.
         let project = TempDir::new().unwrap();
         let index = TempDir::new().unwrap();
         // This .tsmignore would drop public/ok.md IF it were honored.
         write_file(index.path(), ".tsmignore", "public/\n");
         write_file(index.path(), "public/ok.md", "a");
 
-        let _cwd = CwdGuard::change_to(project.path());
-        let walker = ContentWalker::from_config(&cfg_for(index.path()));
+        let walker = ContentWalker::from_config(&cfg_split(project.path(), index.path()));
         let files = walker.collect_files();
         // File is still collected → index_root/.tsmignore was not loaded.
         assert!(files.iter().any(|p| p.ends_with("public/ok.md")));
@@ -771,7 +746,7 @@ state_dir = "/tmp/unused-state"
         write_file(tmp.path(), "notes/a.md", "a");
         // A nested .tsmignore that WOULD exclude a.md if it were honored.
         write_file(tmp.path(), "notes/.tsmignore", "a.md\n");
-        let (walker, _cwd) = walker_in(&tmp);
+        let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("notes/a.md")));
     }


### PR DESCRIPTION
Refs #136 (item 1 of the DoD — this PR covers only `project_root` promotion).

## Summary

`ContentWalker` used to derive `project_root` from `std::env::current_dir()` at construction time — a hidden dependency on process-global state that broke silently when `TSM_CONFIG=/elsewhere/tsm.toml` pointed at a config outside CWD (the config loaded fine, `.tsmignore` lookup shifted to CWD and missed the file).

This PR promotes `project_root` to a first-class `ResolvedConfig` field derived at config-load time from the parent directory of the first successfully-loaded candidate.

## Changes

- `load_config_from` returns `(ConfigFile, Option<PathBuf>)` — the path is the parent of the first successfully-read-and-parsed candidate. For relative candidates (bare `"tsm.toml"`) CWD is joined; no `canonicalize` syscall, so there's no read/canonicalize race.
- `ResolvedConfig::from_config_file(file_cfg, project_root)` takes the root explicitly. Tests pass a tempdir with no CWD mutation.
- `from_env` orchestrates load + resolve; `cwd_fallback()` covers the "no config loaded" case.
- `ContentWalker::from_config` reads `cfg.project_root` directly. No more `current_dir()` call, no more warn-level fallback in the hot path.
- `config::reload()` adds `project_root` to the restart-required warning set.
- New public accessor `config::project_root()`.

## Test reorganization

- `walker_in(tmp)` now returns a bare `ContentWalker` (was `(ContentWalker, CwdGuard)`).
- `CwdGuard` removed from walker tests — no longer needed.
- New `cfg_split(project, index)` helper for the project_root ≠ index_root case.
- `load_config_from` tests destructure the new tuple and assert on `project_root` derivation (including merge-priority and malformed-file cases).
- 4 env-var override tests updated to pass the extra parameter.
- New `test_load_config_relative_path_resolves_against_cwd` covers the bare-"tsm.toml" CWD-join path.

## Design choices

- **No `TSM_PROJECT_ROOT` env override.** Derivation matches the semantics "project root is where your config lives." Users needing a different root point `TSM_CONFIG` at a different file.
- **XDG-only config case**: `project_root` becomes the XDG dir. Advanced users hitting this edge can relocate or set `TSM_CONFIG`.
- **No config loaded**: falls back to CWD (preserving pre-#136 implicit behavior). `cwd_fallback()` logs a warning if even CWD is unavailable.

## Test plan

- [x] `cargo test` — 506 pass / 0 fail (490 lib + 16 tsmd)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --bins` — clean

## Follow-ups (still in #136)

- Item 2: `ContentWalker::new(...)` core constructor (unblocked by this PR — `from_env_with_index_root`'s pub-field mutation pattern is now specifically tied to `project_root` vs `index_root` coherence)
- Item 6: drop `cli::collect_content_files` wrapper (after item 2)
- Item 7: `tsm init` default `.tsmignore` + `FALLBACK_HIDDEN_DIR_PATTERN` removal (independent)
