### PR TITLE
refactor(walker): ContentWalker::new core constructor + drop dead wrapper (#136 items 2,6)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1591,8 +1591,9 @@ mod tests {
         assert_eq!(parsed["results"][0]["content"], "# Hello\n\nWorld.");
     }
 
-    // Walker behavior is covered by indexer::walker::tests. Callers in this
-    // module construct ContentWalker directly via from_env_with_index_root.
+    // Walker behavior is covered by indexer::walker::tests. In this module
+    // `cmd_rebuild` constructs ContentWalker via from_env_with_index_root
+    // (explicit index_root override); other commands use from_env().
 
     #[test]
     fn test_format_json_include_content_file_missing() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,17 +74,6 @@ pub fn read_paths_from_stdin(index_root: &Path) -> Vec<PathBuf> {
         .collect()
 }
 
-/// Collect all files under `index_root` that should be indexed.
-///
-/// The `index_root` argument overrides the value that would otherwise be
-/// read from `tsm.toml` — important in tests that exercise `cmd_rebuild`
-/// with a tempdir. All other config fields are still resolved fresh from
-/// disk via `ResolvedConfig::from_env()`; neither this function nor the
-/// walker it builds consults the `config::RESOLVED` singleton.
-pub fn collect_content_files(index_root: &Path) -> Vec<PathBuf> {
-    indexer::ContentWalker::from_env_with_index_root(index_root).collect_files()
-}
-
 pub struct SearchOptions<'a> {
     pub query: &'a str,
     pub top_k: usize,
@@ -1602,9 +1591,8 @@ mod tests {
         assert_eq!(parsed["results"][0]["content"], "# Hello\n\nWorld.");
     }
 
-    // Walker behavior is now covered by indexer::walker::tests. The
-    // `collect_content_files` wrapper in this file is a thin forward that
-    // builds a ContentWalker from the passed `index_root`.
+    // Walker behavior is covered by indexer::walker::tests. Callers in this
+    // module construct ContentWalker directly via from_env_with_index_root.
 
     #[test]
     fn test_format_json_include_content_file_missing() {

--- a/src/indexer/walker.rs
+++ b/src/indexer/walker.rs
@@ -55,13 +55,11 @@ impl ContentWalker {
     /// Core constructor taking raw values. Every other `from_*` constructor
     /// funnels through this — there is exactly one place where a walker is
     /// assembled, and exactly one place that owns the `.tsmignore` lookup
-    /// against `project_root`.
-    ///
-    /// Centralizing here lets `from_env_with_index_root` build a walker
-    /// whose `index_root` differs from the loaded config without mutating
-    /// `ResolvedConfig` through its `pub` fields — that mutation pattern
-    /// silently broke whenever a new field (like `project_root`) needed
-    /// to stay coherent with `index_root`.
+    /// against `project_root`. The `.tsmignore` file is read from
+    /// `project_root` (the directory containing `tsm.toml`); a missing file
+    /// is silently treated as empty — the common case for users who have
+    /// not opted in. See the module-level doc for the rationale on routing
+    /// every constructor through `new` instead of mutating `ResolvedConfig`.
     pub fn new(
         index_root: PathBuf,
         project_root: &Path,
@@ -79,12 +77,9 @@ impl ContentWalker {
         }
     }
 
-    /// Construct a walker from a fully-resolved config.
-    ///
-    /// The `.tsmignore` file is read from `cfg.project_root` — the directory
-    /// containing `tsm.toml`, resolved at config-load time (see
-    /// `ResolvedConfig::from_env`). Missing files are silently treated as
-    /// empty — this is the common case for users who have not opted in.
+    /// Construct a walker from a fully-resolved config. Thin wrapper that
+    /// unpacks `cfg` and forwards to `new`. See `new` for `.tsmignore`
+    /// lookup semantics.
     pub fn from_config(cfg: &ResolvedConfig) -> Self {
         Self::new(
             cfg.index_root.clone(),
@@ -130,8 +125,9 @@ impl ContentWalker {
     /// Crate-internal because the combined gate — ignore rules *and*
     /// extension allowlist — is exposed via the `IngestPolicy::accepts`
     /// impl. Bypassing that composition (e.g. calling only `is_ignored`)
-    /// would silently re-introduce the drift this PR set out to fix, so
-    /// production callers must go through `accepts()`.
+    /// would let a path skip the extension allowlist — the historical
+    /// drift fixed in #134 / #135. Production callers must go through
+    /// `accepts()`.
     pub(crate) fn is_ignored(&self, path: &Path) -> bool {
         let Ok(rel) = path.strip_prefix(&self.index_root) else {
             return true;

--- a/src/indexer/walker.rs
+++ b/src/indexer/walker.rs
@@ -3,8 +3,8 @@
 //! `ContentWalker` is the single source of truth for "which files should tsm
 //! index?" It centralizes the ad-hoc walker logic that used to be split
 //! across `cli::discover_watch_dirs` (now deleted), the watcher event
-//! filter, and the stdin path. `cli::collect_content_files` is retained as
-//! a thin wrapper for callers that supply an explicit `index_root`.
+//! filter, and the stdin path. Callers needing an `index_root` override
+//! (the daemon, `cmd_rebuild`) use `from_env_with_index_root` directly.
 //!
 //! ## Ignore resolution
 //!
@@ -52,6 +52,33 @@ pub struct ContentWalker {
 }
 
 impl ContentWalker {
+    /// Core constructor taking raw values. Every other `from_*` constructor
+    /// funnels through this — there is exactly one place where a walker is
+    /// assembled, and exactly one place that owns the `.tsmignore` lookup
+    /// against `project_root`.
+    ///
+    /// Centralizing here lets `from_env_with_index_root` build a walker
+    /// whose `index_root` differs from the loaded config without mutating
+    /// `ResolvedConfig` through its `pub` fields — that mutation pattern
+    /// silently broke whenever a new field (like `project_root`) needed
+    /// to stay coherent with `index_root`.
+    pub fn new(
+        index_root: PathBuf,
+        project_root: &Path,
+        extensions: Vec<String>,
+        content_dirs: Vec<ContentDir>,
+        respect_gitignore: bool,
+        ignore_file: &str,
+    ) -> Self {
+        let matcher = build_matcher(&index_root, project_root, ignore_file, respect_gitignore);
+        Self {
+            index_root,
+            content_dirs,
+            extensions,
+            matcher,
+        }
+    }
+
     /// Construct a walker from a fully-resolved config.
     ///
     /// The `.tsmignore` file is read from `cfg.project_root` — the directory
@@ -59,18 +86,14 @@ impl ContentWalker {
     /// `ResolvedConfig::from_env`). Missing files are silently treated as
     /// empty — this is the common case for users who have not opted in.
     pub fn from_config(cfg: &ResolvedConfig) -> Self {
-        let matcher = build_matcher(
-            &cfg.index_root,
+        Self::new(
+            cfg.index_root.clone(),
             &cfg.project_root,
-            &cfg.ignore_file,
+            cfg.extensions.clone(),
+            cfg.content_dirs.clone(),
             cfg.respect_gitignore,
-        );
-        Self {
-            index_root: cfg.index_root.clone(),
-            content_dirs: cfg.content_dirs.clone(),
-            extensions: cfg.extensions.clone(),
-            matcher,
-        }
+            &cfg.ignore_file,
+        )
     }
 
     /// Convenience constructor that rebuilds `ResolvedConfig` from disk + env.
@@ -87,10 +110,19 @@ impl ContentWalker {
     /// value in `ResolvedConfig`. Used by the daemon handler whose
     /// `index_root` argument is the authoritative one per request (and by
     /// tests that exercise the handler with a tempdir).
+    ///
+    /// `project_root` (and therefore `.tsmignore` location) still comes from
+    /// the loaded config — only `index_root` is overridden.
     pub fn from_env_with_index_root(index_root: &Path) -> Self {
-        let mut cfg = crate::config::ResolvedConfig::from_env();
-        cfg.index_root = index_root.to_path_buf();
-        Self::from_config(&cfg)
+        let cfg = crate::config::ResolvedConfig::from_env();
+        Self::new(
+            index_root.to_path_buf(),
+            &cfg.project_root,
+            cfg.extensions,
+            cfg.content_dirs,
+            cfg.respect_gitignore,
+            &cfg.ignore_file,
+        )
     }
 
     /// True when `path` must not be indexed.
@@ -734,6 +766,36 @@ state_dir = "/tmp/unused-state"
         let files = walker.collect_files();
         // File is still collected → index_root/.tsmignore was not loaded.
         assert!(files.iter().any(|p| p.ends_with("public/ok.md")));
+    }
+
+    // ─── new() constructor ─────────────────────────────────────────────
+
+    #[test]
+    fn new_takes_raw_params_without_resolved_config() {
+        // The point of `new()` is to let callers (notably the daemon's
+        // per-request handler) construct a walker with an `index_root` that
+        // differs from the loaded config WITHOUT mutating the singleton's
+        // pub fields. Verify the constructor accepts raw params and produces
+        // a working walker.
+        let project = TempDir::new().unwrap();
+        let index = TempDir::new().unwrap();
+        write_file(project.path(), ".tsmignore", "skip/\n");
+        write_file(index.path(), "keep/a.md", "a");
+        write_file(index.path(), "skip/b.md", "b");
+
+        let walker = ContentWalker::new(
+            index.path().to_path_buf(),
+            project.path(),
+            vec!["md".into()],
+            vec![],
+            false,
+            ".tsmignore",
+        );
+        let files = walker.collect_files();
+        assert!(files.iter().any(|p| p.ends_with("keep/a.md")));
+        assert!(!files
+            .iter()
+            .any(|p| p.components().any(|c| c.as_os_str() == "skip")));
     }
 
     #[test]


### PR DESCRIPTION
Refs #136 (DoD items 2 + 6 — combined since item 6 is unblocked by item 2 and is a 1-deletion follow-up).

## Summary

`ContentWalker::from_env_with_index_root` mutated `ResolvedConfig`'s `pub index_root` field directly. That worked only as long as `index_root` was the sole field needing per-request override — but #137 introduced `project_root`, and the silent divergence trap from the issue ("if a second field joins, the pattern silently diverges") was now baked in.

This PR introduces `ContentWalker::new(...)` as the **single** assembly point. Every other constructor funnels through it.

## Item 2: `ContentWalker::new(...)` core constructor

```rust
ContentWalker::new(
    index_root: PathBuf,
    project_root: &Path,
    extensions: Vec<String>,
    content_dirs: Vec<ContentDir>,
    respect_gitignore: bool,
    ignore_file: &str,
) -> Self
```

- `from_config(cfg)` → `Self::new(cfg.index_root.clone(), &cfg.project_root, ...)`
- `from_env()` → `Self::from_config(&ResolvedConfig::from_env())`
- `from_env_with_index_root(idx)` → loads cfg, then `Self::new(idx.to_path_buf(), &cfg.project_root, ...)` — **no more `pub` field write**.

## Item 6: drop `cli::collect_content_files` wrapper

Already unused — `cmd_rebuild` inlines `ContentWalker::from_env_with_index_root(&index_root).collect_files()` directly. Pure dead code removal. Stale doc comments referencing the wrapper updated.

## Tests

- New `new_takes_raw_params_without_resolved_config` locks in the constructor contract end-to-end: pass project_root + index_root explicitly, verify `.tsmignore` is read from project_root and patterns resolve against index_root.
- All existing tests untouched (constructor signatures preserved).

## Test plan

- [x] `cargo test --lib` — 492 pass / 0 fail (was 491; +1 new)
- [x] `cargo test --bins` — 16 pass / 0 fail
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --bins` — clean

## After this PR

Issue #136 DoD remaining:
- [ ] Item 7: `tsm init` ships default `.tsmignore` + `FALLBACK_HIDDEN_DIR_PATTERN` removal (independent, user-visible)
