### PR TITLE
feat(init): ship default .tsmignore, drop synthetic fallback (#136 item 7)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -51,7 +51,8 @@ tsm setup
 # 3. ドキュメントのルートディレクトリを設定
 export TSM_INDEX_ROOT=~/my-notes
 
-# 4. データベースの初期化
+# 4. データベースの初期化（プロジェクトルートに default .tsmignore を
+#    同時に配置する。既存ファイルがある場合は上書きしない）
 tsm init
 
 # 5. デーモンの起動（embedder + ファイル監視）

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ tsm setup
 # 3. Set the document root directory
 export TSM_INDEX_ROOT=~/my-notes
 
-# 4. Initialize the database
+# 4. Initialize the database (also writes a default .tsmignore at the
+#    project root if one does not already exist — edit to taste)
 tsm init
 
 # 5. Start the daemon (embedder + file watcher)

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -37,14 +37,22 @@ These commands run directly (not routed through the daemon).
 
 ### tsm init
 
-Initialize the database.
+Initialize the database and write a default `.tsmignore`.
 
 ```text
 tsm init
 ```
 
-Creates the SQLite database at the location specified by `TSM_DB_PATH`
-(default: `$TSM_INDEX_ROOT/.tsm/tsm.db`). Must be run once before indexing.
+Performs two steps:
+
+1. Creates the SQLite database at the location specified by `TSM_DB_PATH`
+   (default: `$TSM_INDEX_ROOT/.tsm/tsm.db`). Must be run once before indexing.
+2. Writes a default `.tsmignore` to the project root (the directory
+   containing `tsm.toml`) if one does not already exist. The default
+   excludes hidden directories (`.git/`, `.obsidian/`, `.venv/`, etc.),
+   common build directories (`target/`, `node_modules/`, `dist/`), and
+   large binary artifacts (`*.parquet`, `*.zip`, `*.db`). An existing
+   `.tsmignore` is never overwritten — re-running `tsm init` is safe.
 
 **Flags:** none
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, Read};
+use std::io::{BufRead, ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
 
 use crate::config;
@@ -33,28 +33,53 @@ dist/
 *.db
 ";
 
+/// Convenience wrapper that pulls `db_path` and `project_root` from the
+/// config singleton and forwards to `cmd_init_with`. Tests bypass this by
+/// calling `cmd_init_with` directly with a tempdir, so the dispatch from
+/// `main.rs` stays trivial here.
 pub fn cmd_init() -> anyhow::Result<()> {
-    let db_path = config::db_path();
-    db::init_db(&db_path)?;
+    cmd_init_with(&config::db_path(), &config::project_root())
+}
+
+/// Initialize the DB and install the default `.tsmignore`. Both arguments
+/// are explicit so the function is testable end-to-end without touching the
+/// config singleton — the regression "someone removes the .tsmignore step
+/// from cmd_init" is caught by the integration test below.
+pub fn cmd_init_with(db_path: &Path, project_root: &Path) -> anyhow::Result<()> {
+    db::init_db(db_path)?;
     log::info!("Database initialized at {}", db_path.display());
-    install_default_tsmignore(&config::project_root())?;
+    install_default_tsmignore(project_root)?;
     Ok(())
 }
 
 /// Write `DEFAULT_TSMIGNORE` to `<project_root>/.tsmignore` if no file
 /// exists there. Idempotent — re-running `tsm init` never overwrites a
 /// user-customized file. Returns Ok in both the wrote-it and skipped-it
-/// cases; only filesystem errors propagate.
+/// cases; only unexpected filesystem errors propagate.
+///
+/// Uses `OpenOptions::create_new` rather than `exists()` + `write()` so the
+/// no-overwrite guarantee holds atomically — if `.tsmignore` is created by
+/// another process between the check and the write, `create_new` returns
+/// `AlreadyExists` and we treat that as the skip case rather than silently
+/// clobbering the file.
 fn install_default_tsmignore(project_root: &Path) -> anyhow::Result<()> {
     let tsmignore_path = project_root.join(".tsmignore");
-    if tsmignore_path.exists() {
-        log::info!(
-            ".tsmignore already exists at {} — leaving untouched",
-            tsmignore_path.display()
-        );
-    } else {
-        std::fs::write(&tsmignore_path, DEFAULT_TSMIGNORE)?;
-        log::info!("Wrote default .tsmignore to {}", tsmignore_path.display());
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tsmignore_path)
+    {
+        Ok(mut f) => {
+            f.write_all(DEFAULT_TSMIGNORE.as_bytes())?;
+            log::info!("Wrote default .tsmignore to {}", tsmignore_path.display());
+        }
+        Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+            log::info!(
+                ".tsmignore already exists at {} — leaving untouched",
+                tsmignore_path.display()
+            );
+        }
+        Err(e) => return Err(e.into()),
     }
     Ok(())
 }
@@ -1649,6 +1674,24 @@ mod tests {
         assert!(written.contains(".*/"));
         assert!(written.contains("target/"));
         assert!(written.contains("*.parquet"));
+    }
+
+    #[test]
+    fn cmd_init_with_creates_db_and_tsmignore() {
+        // End-to-end regression test: cmd_init_with must run BOTH steps
+        // (db init AND .tsmignore install). Without this test, removing the
+        // install_default_tsmignore call from cmd_init would still leave
+        // unit tests passing — silently shipping installs without the
+        // default ignore file.
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let project_root = dir.path();
+        super::cmd_init_with(&db_path, project_root).unwrap();
+        assert!(db_path.is_file(), "DB file was not created");
+        assert!(
+            project_root.join(".tsmignore").is_file(),
+            ".tsmignore was not created"
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,10 +8,54 @@ use crate::indexer;
 use crate::searcher;
 use crate::user_dict;
 
+/// Default `.tsmignore` shipped by `tsm init`. Patterns are
+/// `.gitignore`-syntax and resolve relative to `index_root`.
+///
+/// Hidden directories (`.*/`) and common build/dependency directories are
+/// excluded by default — the historical "fallback hidden-dir pattern"
+/// behavior is now expressed here, where users can see and edit it.
+const DEFAULT_TSMIGNORE: &str = "\
+# tsm default ignore patterns. Edit to taste — `tsm init` will not
+# overwrite an existing file.
+
+# Hidden directories (.git/, .obsidian/, .venv/, etc.)
+.*/
+
+# Build / dependency directories
+target/
+node_modules/
+.venv/
+dist/
+
+# Large binary artifacts that bloat the index
+*.parquet
+*.zip
+*.db
+";
+
 pub fn cmd_init() -> anyhow::Result<()> {
     let db_path = config::db_path();
     db::init_db(&db_path)?;
     log::info!("Database initialized at {}", db_path.display());
+    install_default_tsmignore(&config::project_root())?;
+    Ok(())
+}
+
+/// Write `DEFAULT_TSMIGNORE` to `<project_root>/.tsmignore` if no file
+/// exists there. Idempotent — re-running `tsm init` never overwrites a
+/// user-customized file. Returns Ok in both the wrote-it and skipped-it
+/// cases; only filesystem errors propagate.
+fn install_default_tsmignore(project_root: &Path) -> anyhow::Result<()> {
+    let tsmignore_path = project_root.join(".tsmignore");
+    if tsmignore_path.exists() {
+        log::info!(
+            ".tsmignore already exists at {} — leaving untouched",
+            tsmignore_path.display()
+        );
+    } else {
+        std::fs::write(&tsmignore_path, DEFAULT_TSMIGNORE)?;
+        log::info!("Wrote default .tsmignore to {}", tsmignore_path.display());
+    }
     Ok(())
 }
 
@@ -1594,6 +1638,28 @@ mod tests {
     // Walker behavior is covered by indexer::walker::tests. In this module
     // `cmd_rebuild` constructs ContentWalker via from_env_with_index_root
     // (explicit index_root override); other commands use from_env().
+
+    #[test]
+    fn install_default_tsmignore_writes_when_absent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        super::install_default_tsmignore(dir.path()).unwrap();
+        let written = std::fs::read_to_string(dir.path().join(".tsmignore")).unwrap();
+        // Spot-check a few patterns from the shipped template — full byte
+        // match would be brittle.
+        assert!(written.contains(".*/"));
+        assert!(written.contains("target/"));
+        assert!(written.contains("*.parquet"));
+    }
+
+    #[test]
+    fn install_default_tsmignore_does_not_overwrite_existing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tsmignore = dir.path().join(".tsmignore");
+        std::fs::write(&tsmignore, "user_custom_pattern/\n").unwrap();
+        super::install_default_tsmignore(dir.path()).unwrap();
+        let after = std::fs::read_to_string(&tsmignore).unwrap();
+        assert_eq!(after, "user_custom_pattern/\n");
+    }
 
     #[test]
     fn test_format_json_include_content_file_missing() {

--- a/src/indexer/walker.rs
+++ b/src/indexer/walker.rs
@@ -16,11 +16,10 @@
 //! 2. **`.tsmignore` patterns** — read from the tsm project root (the
 //!    directory containing `tsm.toml`). Patterns are resolved relative
 //!    to `index_root`, not relative to the physical `.tsmignore` file.
+//!    When `.tsmignore` is absent, no exclusion patterns are applied —
+//!    run `tsm init` to create the default file (which excludes hidden
+//!    dirs and common build artifacts).
 //! 3. **Root `.gitignore`** — only when `respect_gitignore = true`.
-//! 4. **Backward-compat default** — when `.tsmignore` is absent, a
-//!    synthetic `.*/` pattern is injected so hidden directories like
-//!    `.obsidian` keep the pre-#134 behavior without user action. Once
-//!    a user creates `.tsmignore`, they take full control.
 //!
 //! ## Extension filter
 //!
@@ -38,11 +37,6 @@ use crate::indexer::IngestPolicy;
 /// Directory names that must never be indexed, regardless of configuration.
 /// Prevents DB corruption (`.tsm/tsm.db`) and git metadata pollution.
 const FORCED_EXCLUDED_DIRS: &[&str] = &[".git", ".tsm"];
-
-/// Injected when `.tsmignore` is absent. Preserves the pre-#134 behavior of
-/// skipping hidden directories across all traversal paths without forcing
-/// existing users to create an ignore file.
-const FALLBACK_HIDDEN_DIR_PATTERN: &str = ".*/";
 
 pub struct ContentWalker {
     index_root: PathBuf,
@@ -267,10 +261,12 @@ impl IngestPolicy for ContentWalker {
     }
 }
 
-/// Build the combined `.tsmignore` + (optional) `.gitignore` + fallback
-/// matcher. The builder is anchored at `index_root` so pattern resolution
-/// matches the spec, even when `.tsmignore` physically lives in a different
-/// directory (the tsm project root).
+/// Build the combined `.tsmignore` + (optional) `.gitignore` matcher. The
+/// builder is anchored at `index_root` so pattern resolution matches the
+/// spec, even when `.tsmignore` physically lives in a different directory
+/// (the tsm project root). When `.tsmignore` is absent, no patterns from
+/// it are loaded — `tsm init` is the migration path for users coming from
+/// the old fallback.
 fn build_matcher(
     index_root: &Path,
     project_root: &Path,
@@ -278,8 +274,6 @@ fn build_matcher(
     respect_gitignore: bool,
 ) -> Gitignore {
     let mut builder = GitignoreBuilder::new(index_root);
-    let tsmignore_path = project_root.join(ignore_file);
-    let tsmignore_exists = tsmignore_path.is_file();
 
     if respect_gitignore {
         let gi = index_root.join(".gitignore");
@@ -290,7 +284,8 @@ fn build_matcher(
         }
     }
 
-    if tsmignore_exists {
+    let tsmignore_path = project_root.join(ignore_file);
+    if tsmignore_path.is_file() {
         if let Some(err) = builder.add(&tsmignore_path) {
             // `GitignoreBuilder::add` returns `Some(err)` on the first
             // problem line but still applies the parseable patterns above
@@ -302,9 +297,6 @@ fn build_matcher(
                 tsmignore_path.display()
             );
         }
-    } else if let Err(err) = builder.add_line(None, FALLBACK_HIDDEN_DIR_PATTERN) {
-        // This should never fail for a hard-coded literal pattern.
-        log::warn!("failed to install fallback hidden-dir pattern: {err}");
     }
 
     builder.build().unwrap_or_else(|err| {
@@ -545,34 +537,42 @@ state_dir = "/tmp/unused-state"
         assert!(walker.is_ignored(Path::new("/etc/passwd")));
     }
 
-    // ─── Backward compatibility with hidden dirs ──────────────────────
+    // ─── No synthetic fallback (post-#136 item 7) ──────────────────────
 
     #[test]
     #[serial_test::serial]
-    fn fallback_excludes_hidden_dirs_when_no_tsmignore() {
+    fn hidden_dirs_are_indexed_when_no_tsmignore() {
+        // Inverted from the pre-#136-item-7 behavior: when `.tsmignore` is
+        // absent, no exclusion patterns are loaded. Hidden directories like
+        // `.obsidian` are now traversed. Users opt back in to the historical
+        // exclusion by running `tsm init`, which writes a default `.tsmignore`
+        // containing `.*/` (and other common ignores).
         let tmp = TempDir::new().unwrap();
         write_file(tmp.path(), "notes/a.md", "a");
         write_file(tmp.path(), ".obsidian/plugin.md", "b");
-        // No .tsmignore on disk — the synthetic `.*/` fallback must cover .obsidian.
+        let walker = walker_in(&tmp);
+        let files = walker.collect_files();
+        assert!(files.iter().any(|p| p.ends_with("notes/a.md")));
+        assert!(files.iter().any(|p| p.ends_with(".obsidian/plugin.md")));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn user_tsmignore_with_hidden_pattern_excludes_hidden_dirs() {
+        // Demonstrates the migration target: a user-supplied `.tsmignore`
+        // with `.*/` (the pattern that `tsm init` ships by default)
+        // restores the old fallback behavior. This is the contract the
+        // default-template install in `cmd_init` is built on.
+        let tmp = TempDir::new().unwrap();
+        write_file(tmp.path(), "notes/a.md", "a");
+        write_file(tmp.path(), ".obsidian/plugin.md", "b");
+        write_file(tmp.path(), ".tsmignore", ".*/\n");
         let walker = walker_in(&tmp);
         let files = walker.collect_files();
         assert!(files.iter().any(|p| p.ends_with("notes/a.md")));
         assert!(!files
             .iter()
             .any(|p| p.components().any(|c| c.as_os_str() == ".obsidian")));
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn tsmignore_presence_disables_hidden_fallback() {
-        let tmp = TempDir::new().unwrap();
-        write_file(tmp.path(), "notes/a.md", "a");
-        write_file(tmp.path(), ".obsidian/plugin.md", "b");
-        // Empty .tsmignore means: user has taken control, no synthetic fallback.
-        write_file(tmp.path(), ".tsmignore", "");
-        let walker = walker_in(&tmp);
-        let files = walker.collect_files();
-        assert!(files.iter().any(|p| p.ends_with(".obsidian/plugin.md")));
     }
 
     // ─── respect_gitignore ────────────────────────────────────────────


### PR DESCRIPTION
Closes #136 (final DoD item).

## Summary

`tsm init` now writes a default `.tsmignore` to the project root after initializing the database. The historical "synthetic `.*/` pattern when `.tsmignore` is absent" behavior is replaced with an explicit, user-visible default file.

**Why:** the synthetic fallback was implicit — users couldn't see it, couldn't selectively override individual patterns, and the only escape hatch (an empty `.tsmignore`) was tested but surprising. Promoting the patterns to a real file makes the behavior obvious, editable, and version-controllable.

## Default `.tsmignore` shipped

```gitignore
# Hidden directories (.git/, .obsidian/, .venv/, etc.)
.*/

# Build / dependency directories
target/
node_modules/
.venv/
dist/

# Large binary artifacts that bloat the index
*.parquet
*.zip
*.db
```

(Section comments included so users see what each block is for. Forced excludes `.git/` and `.tsm/` remain hardcoded outside the matcher — DB safety must not be user-overridable.)

## Changes

- **`src/cli.rs`**:
  - `DEFAULT_TSMIGNORE` constant ships the spec patterns.
  - `cmd_init()` runs `db::init_db` then `install_default_tsmignore()`.
  - `install_default_tsmignore()` is **idempotent** — if `.tsmignore` exists, log INFO and leave it alone. Re-running `tsm init` never clobbers user customization.
- **`src/indexer/walker.rs`**:
  - `FALLBACK_HIDDEN_DIR_PATTERN` removed.
  - `build_matcher`'s no-tsmignore branch removed — single codepath now.
  - Module-level `//!` updated: "when `.tsmignore` is absent, no exclusion patterns are loaded — run `tsm init` to create the default file."
- **`docs/command-reference.md`**: `tsm init` section expanded with the install behavior + no-overwrite guarantee.

## Tests

- **New** `install_default_tsmignore_writes_when_absent` — file is written, contains expected key patterns
- **New** `install_default_tsmignore_does_not_overwrite_existing` — idempotency: user's custom file preserved byte-for-byte
- **Replaced** `fallback_excludes_hidden_dirs_when_no_tsmignore` → `hidden_dirs_are_indexed_when_no_tsmignore` (asserts new default-of-no-exclusions)
- **Replaced** `tsmignore_presence_disables_hidden_fallback` → `user_tsmignore_with_hidden_pattern_excludes_hidden_dirs` (asserts the migration target — a `.*/` line restores old behavior)

## ⚠ Behavior change for existing installs

Users who upgrade and **never run `tsm init`** will see hidden directories indexed where they were previously skipped. The migration is one command:

```bash
tsm init
```

This is the explicit cost of removing implicit behavior — the alternative (silently keep injecting `.*/`) was the exact problem this change addresses.

## Test plan

- [x] `cargo test --lib` — 494 pass / 0 fail (was 492; +2 new)
- [x] `cargo test --bins` — 16 pass / 0 fail
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --bins` — clean
- [x] `cargo build --release` — clean
- [x] `rumdl check docs/command-reference.md` — clean

## Issue #136 status after this PR

All DoD items resolved:
- [x] **1.** `project_root` → `ResolvedConfig` first-class field (#137)
- [x] **2.** `ContentWalker::new(...)` core constructor (#138)
- [x] ~~**3.** Fail-open on matcher build failure~~ (#135)
- [x] ~~**4.** `.tsmignore` auto-reload~~ (N/A)
- [x] ~~**5.** IPC volume optimization~~ (out of scope)
- [x] **6.** drop `cli::collect_content_files` wrapper (#138)
- [x] **7.** `tsm init` default `.tsmignore` + `FALLBACK_HIDDEN_DIR_PATTERN` removal (this PR)
