### PR TITLE
docs(config): refresh tsm.toml.example comments after embedder consolidation

### DIFF
--- a/tsm.toml.example
+++ b/tsm.toml.example
@@ -13,7 +13,7 @@
 # Env: TSM_INDEX_ROOT
 # index_root = "/workspaces"
 
-# UNIX socket path for tsm-embedder (encode requests).
+# UNIX socket path for the embedder child process (encode requests).
 # Default: "{state_dir}/embedder.sock"
 # Env: TSM_EMBEDDER_SOCKET
 # embedder_socket_path = ".tsm/embedder.sock"
@@ -23,12 +23,12 @@
 # Env: TSM_DAEMON_SOCKET
 # daemon_socket_path = ".tsm/daemon.sock"
 
-# Directory for daemon log files (tsmd, tsm-embedder).
+# Directory for daemon log files (tsmd, tsmd --embedder, tsmd --fs-watcher).
 # Default: "{state_dir}/logs"
 # Env: TSM_LOG_DIR
 # log_dir = ".tsm/logs"
 
-# Seconds of inactivity before tsm-embedder shuts down. 0 = never.
+# Seconds of inactivity before the embedder child shuts down. 0 = never.
 # Default: 600
 # Env: TSM_EMBEDDER_IDLE_TIMEOUT
 # embedder_idle_timeout_secs = 600


### PR DESCRIPTION
## Summary

ADR-0005 (2026-04-07) consolidated `tsm-embedder` into `tsmd --embedder` — the embedder is now a subcommand of the daemon binary, not a separate executable. Three stale references in `tsm.toml.example` still called out the old binary name.

## Changes

- `embedder_socket_path` comment: `tsm-embedder` → `the embedder child process` (matches config.rs:157)
- `log_dir` comment: `(tsmd, tsm-embedder)` → `(tsmd, tsmd --embedder, tsmd --fs-watcher)` (matches config.rs:165)
- `embedder_idle_timeout_secs` comment: `tsm-embedder shuts down` → `the embedder child shuts down`

No code changes. Config keys unchanged — only descriptive comments.

## Test plan

- [x] `taplo check tsm.toml.example` — clean