### PR TITLE
chore(release): bump tsm 0.3.0 → 0.4.0, plugin 0.10.0 → 0.11.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "the-space-memory",
   "description": "Cross-workspace knowledge search engine with hybrid FTS5 + vector search",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "author": {
     "name": "Mitsukuni Sato"
   },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "the-space-memory"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "the-space-memory"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary

Minor-version bumps for the accumulated feature work since **v0.2.1**.

- `Cargo.toml`: **0.3.0 → 0.4.0**
- `.claude-plugin/plugin.json`: **0.10.0 → 0.11.0**
- `Cargo.lock` updated

## What's in 0.4.0

### `.tsmignore` support (#134 + #136)

- `ContentWalker` — single traversal entry point (CLI / daemon / watcher all funnel through it)
- `IngestPolicy` trait — correctness gate at indexer entry, no upstream pre-filters
- `project_root` promoted to `ResolvedConfig` (#137) — CWD dependency removed
- `ContentWalker::new(...)` core constructor (#138) — no more `pub` field mutation
- `tsm init` ships default `.tsmignore` (#139) — `FALLBACK_HIDDEN_DIR_PATTERN` retired

### Search output (#128, #130, #131)

- JSON envelope with `version` / `query` / `results`
- XML prompt format for LLM context injection

### User dictionary (#123, #127)

- CSV-driven synonym sync
- WordNet import progress via callback (testable)

### Model management (#122)

- Model files under `state_dir/.tsm/models/` (no HuggingFace Hub cache dependency)

## Breaking change from 0.2.x

`.tsmignore` absence no longer implies hidden-dir exclusion. Existing users should run `tsm init` on upgrade to install the default ignore file.

## Test plan

- [x] `cargo check --lib` — clean
- Post-merge: tag `v0.4.0`, rebuild local binaries