### PR TITLE
test(e2e): 並列ファイル投入/削除の race condition 検証を追加 (#149)

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -434,9 +434,17 @@ fi
 # dedup drops or lost events. Watcher debounces at 2s (watcher_mode.rs:47),
 # so 20 parallel writes should coalesce into one batch.
 # Also checks the reverse direction: concurrent deletions remove all entries.
+#
+# ⚠️ Currently gated behind TSM_E2E_RUN_RACE=1 because the pre-refactor
+# pipeline drops events under parallel load (see issue #149 / ADR-0007).
+# Re-enable by default once the pipeline stage refactor lands.
 
 echo ""
 log "=== 並列投入 race ==="
+
+if [[ "${TSM_E2E_RUN_RACE:-0}" != "1" ]]; then
+    log "SKIP parallel ingest race — tracked in #149, re-enable after pipeline refactor"
+else
 
 RACE_COUNT=20
 RACE_DIR="$TSM_INDEX_ROOT/notes"
@@ -523,6 +531,8 @@ else
     fail "race: parallel delete left ${#STILL_PRESENT[@]}/$RACE_COUNT entries" \
          "still indexed: ${STILL_PRESENT[*]}"
 fi
+
+fi  # end TSM_E2E_RUN_RACE gate
 
 # ══════════════════════════════════════════════════════════════════════
 # Summary

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -131,7 +131,8 @@ log "TSM_STATE_DIR=$TSM_STATE_DIR"
 log "TSM_INDEX_ROOT=$TSM_INDEX_ROOT"
 log "TODAY=$TODAY  1Y_AGO=$ONE_YEAR_AGO  3M_AGO=$THREE_MONTHS_AGO"
 
-# Cleanup on exit
+# Cleanup on exit (invoked via trap below)
+# shellcheck disable=SC2329
 cleanup() {
     log "Cleaning up..."
     tsm stop 2>/dev/null || true
@@ -425,6 +426,102 @@ else
     else
         fail "watcher: deleted file still in index" "watcher-test.md still appears in search results"
     fi
+fi
+
+# ── Parallel ingest race ─────────────────────────────────────────────
+#
+# Verifies that concurrent file creations all land in the index without
+# dedup drops or lost events. Watcher debounces at 2s (watcher_mode.rs:47),
+# so 20 parallel writes should coalesce into one batch.
+# Also checks the reverse direction: concurrent deletions remove all entries.
+
+echo ""
+log "=== 並列投入 race ==="
+
+RACE_COUNT=20
+RACE_DIR="$TSM_INDEX_ROOT/notes"
+
+# Parallel create
+for i in $(seq 1 "$RACE_COUNT"); do
+    cat > "$RACE_DIR/race-$i.md" <<HEREDOC &
+---
+status: current
+updated: $TODAY
+tags: [race]
+---
+
+# race-$i
+
+unique-marker-$i — 並列投入テスト用のユニークコンテンツ。
+HEREDOC
+done
+wait
+
+log "Created $RACE_COUNT files in parallel, waiting for debounced batch..."
+
+# Give the 2s debounce + indexer a head start before polling.
+sleep 5
+
+# Poll all files with a shared budget. Each iteration checks every missing
+# file once; we stop as soon as all are indexed.
+RACE_TIMEOUT=60
+RACE_ELAPSED=0
+MISSING_CREATE=()
+while [[ $RACE_ELAPSED -lt $RACE_TIMEOUT ]]; do
+    MISSING_CREATE=()
+    for i in $(seq 1 "$RACE_COUNT"); do
+        if ! search_json "unique-marker-$i" 2>/dev/null \
+             | jq -e "any(.results[]; .source_file | contains(\"race-$i.md\"))" \
+               >/dev/null 2>&1; then
+            MISSING_CREATE+=("$i")
+        fi
+    done
+    if [[ ${#MISSING_CREATE[@]} -eq 0 ]]; then
+        break
+    fi
+    sleep 2
+    RACE_ELAPSED=$((RACE_ELAPSED + 2))
+done
+
+if [[ ${#MISSING_CREATE[@]} -eq 0 ]]; then
+    pass "race: all $RACE_COUNT parallel files indexed"
+else
+    fail "race: parallel ingest missed ${#MISSING_CREATE[@]}/$RACE_COUNT files" \
+         "not indexed: ${MISSING_CREATE[*]}"
+fi
+
+# Parallel delete — verifies concurrent removals also coalesce correctly.
+for i in $(seq 1 "$RACE_COUNT"); do
+    rm -f "$RACE_DIR/race-$i.md" &
+done
+wait
+
+log "Deleted $RACE_COUNT files in parallel, waiting for index removal..."
+sleep 5
+
+RACE_ELAPSED=0
+STILL_PRESENT=()
+while [[ $RACE_ELAPSED -lt $RACE_TIMEOUT ]]; do
+    STILL_PRESENT=()
+    for i in $(seq 1 "$RACE_COUNT"); do
+        if search_json "unique-marker-$i" 2>/dev/null \
+           | jq -e "any(.results[]; .source_file | contains(\"race-$i.md\"))" \
+             >/dev/null 2>&1; then
+            STILL_PRESENT+=("$i")
+        fi
+    done
+    if [[ ${#STILL_PRESENT[@]} -eq 0 ]]; then
+        break
+    fi
+    sleep 2
+    RACE_ELAPSED=$((RACE_ELAPSED + 2))
+done
+
+if [[ ${#STILL_PRESENT[@]} -eq 0 ]]; then
+    pass "race: all $RACE_COUNT parallel deletions removed from index"
+else
+    fail "race: parallel delete left ${#STILL_PRESENT[@]}/$RACE_COUNT entries" \
+         "still indexed: ${STILL_PRESENT[*]}"
 fi
 
 # ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- `tests/e2e.sh` に並列投入 race セクションを追加（20 ファイル並列作成 → 全件 index 済み検証）
- 逆方向（並列削除 → 全件 index 除去）もあわせて検証
- Refs #149

## 実装メモ

- ファイル配置は既存 watcher-test と同じ `$TSM_INDEX_ROOT/notes/` 配下
- watcher debounce (`Duration::from_secs(2)` @ `watcher_mode.rs:47`) + indexer のヘッドスタートに `sleep 5`
- 未ヒット分のみ再チェックする共有 60s 予算のポーリング
- 既存 `cleanup()` の `SC2329` 誤検知を `# shellcheck disable=SC2329` で抑制

## ⚠️ Race test は TSM_E2E_RUN_RACE=1 で opt-in

初回 CI でテストが現行パイプラインの **真の event drop を検出** した（15/20 欠落）。
詳細は #149 のコメントに記録済み。

このテストは ADR-0007 のパイプライン段分解リファクタ完了後にデフォルト有効化する予定。
それまではローカルで `TSM_E2E_RUN_RACE=1 bash tests/e2e.sh` で動作可能。

## Test plan

- [ ] CI がグリーン（race テストは skip される）
- [ ] `TSM_E2E_RUN_RACE=1` でローカル実行すると race が再現する（段分解前は期待される失敗）