### PR TITLE
fix: replace sort_by with sort_by_key for clippy::unnecessary_sort_by

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -333,7 +333,7 @@ impl ResolvedConfig {
             })
             .collect();
         // Sort longest-first so more-specific paths match before shorter prefixes
-        content_dirs.sort_by(|a, b| b.path.len().cmp(&a.path.len()));
+        content_dirs.sort_by_key(|d| std::cmp::Reverse(d.path.len()));
 
         let session_weight = file_cfg
             .index


### PR DESCRIPTION
## Summary

- rustc 1.95.0 で新規追加された `clippy::unnecessary_sort_by` lint に対応
- `src/config.rs:336` の content_dirs ソートを `sort_by(|a, b| b.path.len().cmp(&a.path.len()))` から `sort_by_key(|d| std::cmp::Reverse(d.path.len()))` に書き換え
- これにより PR #157 含む dependabot PR 群の `test` ジョブが通るようになる（参考: https://github.com/key/the-space-memory/pull/157 で発覚）

## Test plan

- [x] `cargo clippy -- -D warnings` がローカル（rust 1.95.0）でクリーン
- [x] `cargo fmt --check` クリーン
- [x] `cargo test --lib config` でソート関連テスト含め通過（macOS symlink 由来の既存失敗 1 件は本変更と無関係）
- [ ] CI で `test` / `e2e` ジョブの結果を確認