### PR TITLE
debug(e2e): dump session search ranking

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -378,6 +378,10 @@ assert_contains "ingest-session: succeeds" "session indexed" "$CAPTURED_OUTPUT" 
 
 # Search for session-specific content (use fts-only; embedder may not be ready)
 run search_json "量子もつれ" --fallback fts-only
+# DEBUG: dump full top-50 ranking to disambiguate decay vs tokenization vs FTS race
+log "DEBUG ranking for '量子もつれ' (top 50, fts-only):"
+search_json "量子もつれ" --fallback fts-only -k 50 \
+    | jq -c '.results[] | {source_file, score, source_type}' || true
 assert_json "ingest-session: search hits session content" \
     'any(.results[]; .source_file | contains("test-session"))' "$CAPTURED_OUTPUT" "$CAPTURED_EXIT"
 


### PR DESCRIPTION
診断用 PR（マージ予定なし）。

PR #157 や #164 で発生していた e2e の `ingest-session: search hits session content` 失敗の真因を切り分けるため、`assert_json` の直前で `tsm search ... -k 50` の結果を JSON 1 行ずつダンプする。

候補仮説:
1. **Decay-pushed-out** — session の half-life が 30 日のため `2026-04-01` 固定 timestamp の test data が時間経過で top_k=5 から押し出されている
2. **Tokenization mismatch** — lindera の形態素解析で `量子もつれ` のクエリと session 本文のトークンが噛み合わない
3. **FTS race** — `[backfill] reindex fts: 28 chunks re-tokenized` と ingest-session のタイミングが衝突

ランキングを見て真因を確定したら、本 PR は close、別 PR で本修正を入れる。