### PR TITLE
fix(ci): prevent hard-coded date rot in e2e testdata

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
-      - run: shellcheck .devcontainer/*.sh
+      - run: shellcheck .devcontainer/*.sh scripts/*.sh
+
+  testdata-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: bash scripts/lint-testdata-dates.sh
 
   toml-lint:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,10 @@ src/
 - DB tests use in-memory SQLite (`:memory:`) to prevent state leakage
 - Embedder tests should use mockable trait design
 - Tests must not depend on external daemon state (embedder, etc.)
+- **E2E testdata の日付は placeholder 化必須** — `tests/e2e/testdata/**` 内で
+  日付を直書きしない。`__TODAY__` / `__1Y_AGO__` / `__3M_AGO__` 等を使い、
+  `tests/e2e.sh` の sed で実行時に置換する。直書きは time-decay スコアで
+  flake する（session half-life は 30 日）。CI の `testdata-lint` job が機械的に検出する
 
 ## Branch Naming
 

--- a/scripts/lint-testdata-dates.sh
+++ b/scripts/lint-testdata-dates.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Detect hard-coded ISO dates (YYYY-MM-DD) in tests/e2e/testdata/**.
+#
+# Why: time-decay scoring (session half-life 30d, note half-life 90d) makes
+# fixed-date testdata flaky as the calendar advances. Use placeholders
+# (__TODAY__, __1Y_AGO__, __3M_AGO__, ...) which `tests/e2e.sh` substitutes
+# at runtime. See CLAUDE.md "Testing" section.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TESTDATA_DIR="$REPO_ROOT/tests/e2e/testdata"
+
+if [[ ! -d "$TESTDATA_DIR" ]]; then
+    echo "ERROR: testdata dir not found at $TESTDATA_DIR" >&2
+    exit 2
+fi
+
+# Find ISO dates that are NOT inside a __PLACEHOLDER__ token.
+# Allowed forms:  __TODAY__, __1Y_AGO__, __3M_AGO__, __<UPPER_SNAKE>__
+# Disallowed:     2026-04-01, 2025-12-31, ...
+violations=$(grep -rEn '[0-9]{4}-[0-9]{2}-[0-9]{2}' "$TESTDATA_DIR" || true)
+
+if [[ -z "$violations" ]]; then
+    echo "OK: no hard-coded dates in $TESTDATA_DIR"
+    exit 0
+fi
+
+echo "ERROR: hard-coded ISO dates found in tests/e2e/testdata/" >&2
+echo "Use placeholders like __TODAY__ / __1Y_AGO__ / __3M_AGO__ instead." >&2
+echo "See CLAUDE.md 'Testing' section for rationale." >&2
+echo "" >&2
+echo "$violations" >&2
+exit 1


### PR DESCRIPTION
## Summary

PR #166 で対処した「session timestamp 直書きが time-decay で flake」を**再発防止する 2 層**を追加。

### A: CLAUDE.md ガイダンス

Testing 節に「`tests/e2e/testdata/**` の日付は `__TODAY__` / `__1Y_AGO__` / `__3M_AGO__` 等のプレースホルダーで書く」ルールを追記。session half-life が 30 日であること、CI が機械的に検出することも併記して、AI と人間の双方が今後 testdata を追加する際の判断材料にする。

### B: CI lint

`scripts/lint-testdata-dates.sh` を新設し、`tests/e2e/testdata/**` 配下にハードコードされた ISO 日付 (`YYYY-MM-DD`) を `grep -rE` で検出。`.github/workflows/lint.yml` に `testdata-lint` job を追加し、`shell-lint` の対象も `scripts/*.sh` に拡張。

実装ノート:
- 検出パターンは `[0-9]{4}-[0-9]{2}-[0-9]{2}`。`__TODAY__` 等のプレースホルダーには ISO 日付が現れないので false positive はない
- `tests/e2e/testdata/` 以外（src/, tests/ の Rust 側）は対象外。Rust 側の固定日付テストはユニットテスト内で完結するため

## Test plan

- [x] `bash scripts/lint-testdata-dates.sh` がクリーン (現状)
- [x] 一時的に testdata に `2026-01-01` を埋め込んで script が exit 1 を返すこと、違反箇所が出ること、を手元で確認
- [x] `shellcheck scripts/lint-testdata-dates.sh` clean
- [x] `yamllint .github/workflows/lint.yml` clean
- [ ] CI の `testdata-lint` job が green であること

## Related

- 元になった flake と修正: #166
- セッションの議論ログ: 「PR をマージしたあとの再発防止策ブレスト」