### PR TITLE
ci: SHA-pin remaining tag-pinned GitHub Actions

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -13,11 +13,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Create dummy .env
         run: touch .env
       - name: Build DevContainer
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@b63b30de439b47a52267f241112c5b453b673db5  # v0.3
         with:
           runCmd: |
             rumdl --version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,42 +9,42 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
       - run: rumdl check .
 
   yaml-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
       - run: yamllint .
 
   shell-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
       - run: shellcheck .devcontainer/*.sh scripts/*.sh
 
   testdata-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - run: bash scripts/lint-testdata-dates.sh
 
   toml-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
       - run: taplo check
 
   mise-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
         id: mise
       - name: Check for mise warnings
         run: |


### PR DESCRIPTION
## Summary

CLAUDE.md の License Compatibility 節にある「GitHub Actions must pin actions by full commit SHA (not tags)」ポリシーに未準拠だった以下の workflow を修正。

### 対象

- \`.github/workflows/lint.yml\` — \`actions/checkout@v6\`, \`jdx/mise-action@v4\` がタグ pin
- \`.github/workflows/devcontainer.yml\` — \`actions/checkout@v6\`, \`devcontainers/ci@v0.3\` がタグ pin

それ以外（ci.yml / e2e.yml / metrics.yml / release.yml / labeler.yml）はすでに SHA pin 済み。

### 置換

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | \`@v6\` | \`@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2\` |
| jdx/mise-action | \`@v4\` | \`@1648a7812b9aeae629881980618f079932869151  # v4.0.1\` |
| devcontainers/ci | \`@v0.3\` | \`@b63b30de439b47a52267f241112c5b453b673db5  # v0.3\` |

dependabot.yml の \`github-actions\` ecosystem が weekly で動いているため、SHA を固定しても今後の更新は自動で PR 化される。

## Test plan

- [x] \`grep -rE 'uses:\s+[^@]+@(v[0-9]|main|master|HEAD)' .github/workflows/\` がヒット 0
- [x] \`yamllint .github/workflows/lint.yml .github/workflows/devcontainer.yml\` clean
- [ ] CI green