### PR TITLE
feat(installer): add curl-bash installer script (docs/install.sh)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151  # v4.0.1
-      - run: shellcheck .devcontainer/*.sh scripts/*.sh
+      - run: shellcheck .devcontainer/*.sh scripts/*.sh docs/install.sh
 
   testdata-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,16 @@ jobs:
         with:
           merge-multiple: true
 
+      - name: Generate checksums
+        run: |
+          for f in tsm-*.tar.gz; do
+            sha256sum "${f}" > "${f}.sha256"
+          done
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           generate_release_notes: true
-          files: tsm-*.tar.gz
+          files: |
+            tsm-*.tar.gz
+            tsm-*.tar.gz.sha256

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -106,18 +106,24 @@ fetch() {
 }
 
 #
-# Confirm overwrite if a binary already exists at INSTALL_DIR.
+# Confirm overwrite if either tsm or tsmd already exists at INSTALL_DIR.
+# Both binaries are part of one logical installation — skipping the prompt
+# when only tsmd is present would silently overwrite a partial install.
 #
 confirm_overwrite() {
     local install_dir="$1"
-    local existing="${install_dir}/tsm"
-    if [ ! -e "${existing}" ]; then
+    local tsm_path="${install_dir}/tsm"
+    local tsmd_path="${install_dir}/tsmd"
+    if [ ! -e "${tsm_path}" ] && [ ! -e "${tsmd_path}" ]; then
         return 0
     fi
 
+    # Pick whichever exists for the version banner; prefer tsm.
+    local probe="${tsm_path}"
+    [ -e "${probe}" ] || probe="${tsmd_path}"
     local current_version
-    current_version=$("${existing}" --version 2>/dev/null || echo "unknown")
-    warn "existing tsm found at ${existing} (${current_version})"
+    current_version=$("${probe}" --version 2>/dev/null || echo "unknown")
+    warn "existing installation found at ${install_dir} (${current_version})"
 
     if [ "${TSM_FORCE:-}" = "1" ]; then
         warn "TSM_FORCE=1 — overwriting"
@@ -128,8 +134,12 @@ confirm_overwrite() {
         fatal "non-interactive shell — re-run with TSM_FORCE=1 to overwrite"
     fi
 
-    printf "Overwrite? [y/N] "
-    read -r reply
+    # `read -r` can return non-zero on EOF (Ctrl-D) or stream error. Without
+    # explicit handling, set -e would exit the script silently.
+    local reply=""
+    if ! read -r reply; then
+        fatal "could not read response — aborting (use TSM_FORCE=1 to bypass)"
+    fi
     case "${reply}" in
         [yY]|[yY][eE][sS]) return 0 ;;
         *) fatal "aborted by user" ;;

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# tsm installer — downloads the latest tsm release and installs it locally.
+#
+#   curl -fsSL https://key.github.io/the-space-memory/install.sh | bash
+#
+# Environment variables:
+#   TSM_VERSION    Specific release tag to install (default: latest)
+#   INSTALL_DIR    Where to place binaries     (default: $HOME/.local/bin)
+#   TSM_FORCE      Set to "1" to overwrite an existing installation without prompt
+#
+# See ADR-0019 for the design rationale.
+set -euo pipefail
+
+readonly REPO="key/the-space-memory"
+readonly DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
+
+#
+# Logging helpers
+#
+info()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33m!!\033[0m %s\n' "$*" >&2; }
+fatal() { printf '\033[1;31mxx\033[0m %s\n' "$*" >&2; exit 1; }
+
+#
+# Pre-flight: required commands
+#
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || fatal "required command not found: $1"
+}
+require_cmd curl
+require_cmd tar
+require_cmd uname
+require_cmd install
+require_cmd mktemp
+
+# Use shasum if available (macOS), else sha256sum (Linux).
+if command -v shasum >/dev/null 2>&1; then
+    SHA256_CHECK=(shasum -a 256 -c)
+elif command -v sha256sum >/dev/null 2>&1; then
+    SHA256_CHECK=(sha256sum -c)
+else
+    fatal "neither shasum nor sha256sum is available"
+fi
+
+#
+# Detect platform → archive_name (matches .github/workflows/release.yml matrix)
+#
+detect_arch() {
+    local kernel machine
+    kernel=$(uname -s)
+    machine=$(uname -m)
+
+    case "${kernel}-${machine}" in
+        Linux-x86_64)        echo "linux-x86_64" ;;
+        Linux-aarch64|Linux-arm64) echo "linux-arm64" ;;
+        Darwin-arm64)        echo "darwin-arm64" ;;
+        Darwin-x86_64)
+            fatal "Intel Mac is not supported by binary releases. Build from source: https://github.com/${REPO}"
+            ;;
+        *)
+            fatal "unsupported platform: ${kernel} ${machine}"
+            ;;
+    esac
+}
+
+#
+# Resolve the release tag — env override or latest from GitHub API
+#
+resolve_tag() {
+    if [ -n "${TSM_VERSION:-}" ]; then
+        echo "${TSM_VERSION}"
+        return
+    fi
+    # Use the GitHub API. Don't depend on jq.
+    curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+        | grep -oE '"tag_name": *"[^"]+"' \
+        | head -n1 \
+        | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/'
+}
+
+#
+# Download a URL into a path; abort the script on any HTTP failure.
+#
+fetch() {
+    local url="$1" dest="$2"
+    curl -fsSL --proto '=https' --tlsv1.2 -o "${dest}" "${url}"
+}
+
+#
+# Confirm overwrite if a binary already exists at INSTALL_DIR.
+#
+confirm_overwrite() {
+    local install_dir="$1"
+    local existing="${install_dir}/tsm"
+    if [ ! -e "${existing}" ]; then
+        return 0
+    fi
+
+    local current_version
+    current_version=$("${existing}" --version 2>/dev/null || echo "unknown")
+    warn "existing tsm found at ${existing} (${current_version})"
+
+    if [ "${TSM_FORCE:-}" = "1" ]; then
+        warn "TSM_FORCE=1 — overwriting"
+        return 0
+    fi
+
+    if [ ! -t 0 ]; then
+        fatal "non-interactive shell — re-run with TSM_FORCE=1 to overwrite"
+    fi
+
+    printf "Overwrite? [y/N] "
+    read -r reply
+    case "${reply}" in
+        [yY]|[yY][eE][sS]) return 0 ;;
+        *) fatal "aborted by user" ;;
+    esac
+}
+
+#
+# Print the post-install message — what to run next.
+#
+print_next_steps() {
+    local install_dir="$1"
+    cat <<EOF
+
+✓ tsm installed at ${install_dir}
+
+Next steps:
+  1. tsm setup         # Download embedding model and WordNet (one-time, system-wide)
+  2. tsm init          # Initialize this workspace's database
+  3. tsm doctor        # Verify everything is in order
+
+Documentation: https://github.com/${REPO}
+EOF
+
+    case ":${PATH}:" in
+        *":${install_dir}:"*) ;;
+        *)
+            warn "${install_dir} is not on your PATH"
+            cat <<EOF
+   Add it to your shell profile:
+     echo 'export PATH="${install_dir}:\$PATH"' >> ~/.bashrc   # or ~/.zshrc
+     source ~/.bashrc
+EOF
+            ;;
+    esac
+}
+
+main() {
+    local install_dir="${INSTALL_DIR:-${DEFAULT_INSTALL_DIR}}"
+    info "tsm installer"
+
+    local arch tag
+    arch=$(detect_arch)
+    info "platform: ${arch}"
+
+    tag=$(resolve_tag)
+    [ -n "${tag}" ] || fatal "could not resolve release tag (set TSM_VERSION manually)"
+    info "version: ${tag}"
+
+    confirm_overwrite "${install_dir}"
+
+    local archive_name="tsm-${tag}-${arch}.tar.gz"
+    local archive_url="https://github.com/${REPO}/releases/download/${tag}/${archive_name}"
+    local sha_url="${archive_url}.sha256"
+
+    local tmp
+    tmp=$(mktemp -d)
+    trap 'rm -rf "${tmp}"' EXIT
+
+    info "downloading ${archive_name}"
+    fetch "${archive_url}" "${tmp}/${archive_name}"
+
+    info "verifying checksum"
+    fetch "${sha_url}" "${tmp}/${archive_name}.sha256"
+    (cd "${tmp}" && "${SHA256_CHECK[@]}" "${archive_name}.sha256" >/dev/null) \
+        || fatal "checksum mismatch — aborting"
+
+    info "extracting"
+    tar -xzf "${tmp}/${archive_name}" -C "${tmp}"
+    local extracted_dir="${tmp}/tsm-${tag}-${arch}"
+
+    info "installing to ${install_dir}"
+    mkdir -p "${install_dir}"
+    install -m 755 "${extracted_dir}/bin/tsm"  "${install_dir}/"
+    install -m 755 "${extracted_dir}/bin/tsmd" "${install_dir}/"
+
+    print_next_steps "${install_dir}"
+}
+
+main "$@"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -8,12 +8,17 @@
 #   TSM_VERSION    Specific release tag to install (default: latest)
 #   INSTALL_DIR    Where to place binaries     (default: $HOME/.local/bin)
 #   TSM_FORCE      Set to "1" to overwrite an existing installation without prompt
-#
-# See ADR-0019 for the design rationale.
 set -euo pipefail
 
 readonly REPO="key/the-space-memory"
 readonly DEFAULT_INSTALL_DIR="${HOME}/.local/bin"
+
+# Global temp dir, populated by main(). Declared here so the EXIT trap
+# (registered before mktemp) can reference it without `set -u` complaints
+# even if the script aborts before mktemp succeeds.
+TMP_DIR=""
+cleanup() { [ -n "${TMP_DIR:-}" ] && rm -rf "${TMP_DIR}"; }
+trap cleanup EXIT
 
 #
 # Logging helpers
@@ -65,18 +70,31 @@ detect_arch() {
 }
 
 #
-# Resolve the release tag — env override or latest from GitHub API
+# Resolve the release tag — env override or latest from GitHub API.
+#
+# The curl call is split out so that a non-zero grep exit (no tag_name in the
+# response — rate-limited, network outage, schema change) does not abort the
+# script via pipefail before the empty-tag guard in main() runs.
 #
 resolve_tag() {
     if [ -n "${TSM_VERSION:-}" ]; then
         echo "${TSM_VERSION}"
         return
     fi
-    # Use the GitHub API. Don't depend on jq.
-    curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    local response
+    response=$(curl -fsSL --proto '=https' --tlsv1.2 \
+        "https://api.github.com/repos/${REPO}/releases/latest") \
+        || fatal "failed to reach GitHub API — check your network connection"
+    if printf '%s' "${response}" | grep -q '"message"'; then
+        local api_msg
+        api_msg=$(printf '%s' "${response}" | grep -oE '"message": *"[^"]+"' | head -n1 || true)
+        fatal "GitHub API returned an error (${api_msg:-unknown}) — set TSM_VERSION to bypass"
+    fi
+    printf '%s' "${response}" \
         | grep -oE '"tag_name": *"[^"]+"' \
         | head -n1 \
-        | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/'
+        | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' \
+        || true
 }
 
 #
@@ -128,7 +146,7 @@ print_next_steps() {
 ✓ tsm installed at ${install_dir}
 
 Next steps:
-  1. tsm setup         # Download embedding model and WordNet (one-time, system-wide)
+  1. tsm setup         # Download embedding model and WordNet into .tsm/
   2. tsm init          # Initialize this workspace's database
   3. tsm doctor        # Verify everything is in order
 
@@ -166,26 +184,32 @@ main() {
     local archive_url="https://github.com/${REPO}/releases/download/${tag}/${archive_name}"
     local sha_url="${archive_url}.sha256"
 
-    local tmp
-    tmp=$(mktemp -d)
-    trap 'rm -rf "${tmp}"' EXIT
+    TMP_DIR=$(mktemp -d)
 
     info "downloading ${archive_name}"
-    fetch "${archive_url}" "${tmp}/${archive_name}"
+    fetch "${archive_url}" "${TMP_DIR}/${archive_name}"
 
     info "verifying checksum"
-    fetch "${sha_url}" "${tmp}/${archive_name}.sha256"
-    (cd "${tmp}" && "${SHA256_CHECK[@]}" "${archive_name}.sha256" >/dev/null) \
-        || fatal "checksum mismatch — aborting"
+    fetch "${sha_url}" "${TMP_DIR}/${archive_name}.sha256"
+    # Don't redirect output — preserve forensic detail (which file failed,
+    # expected vs actual hash) for security-relevant failures.
+    (cd "${TMP_DIR}" && "${SHA256_CHECK[@]}" "${archive_name}.sha256") \
+        || fatal "checksum mismatch for ${archive_name} — the downloaded file may be corrupt or tampered with"
 
     info "extracting"
-    tar -xzf "${tmp}/${archive_name}" -C "${tmp}"
-    local extracted_dir="${tmp}/tsm-${tag}-${arch}"
+    tar -xzf "${TMP_DIR}/${archive_name}" -C "${TMP_DIR}"
+    local extracted_dir="${TMP_DIR}/tsm-${tag}-${arch}"
+    [ -d "${extracted_dir}" ] \
+        || fatal "expected directory ${extracted_dir} not found in archive — release layout may have changed"
 
     info "installing to ${install_dir}"
     mkdir -p "${install_dir}"
-    install -m 755 "${extracted_dir}/bin/tsm"  "${install_dir}/"
-    install -m 755 "${extracted_dir}/bin/tsmd" "${install_dir}/"
+    # Stage both binaries first, then move atomically. Avoids leaving the
+    # system in a half-installed state if the second copy fails.
+    install -m 755 "${extracted_dir}/bin/tsm"  "${TMP_DIR}/tsm.new"
+    install -m 755 "${extracted_dir}/bin/tsmd" "${TMP_DIR}/tsmd.new"
+    mv "${TMP_DIR}/tsm.new"  "${install_dir}/tsm"
+    mv "${TMP_DIR}/tsmd.new" "${install_dir}/tsmd"
 
     print_next_steps "${install_dir}"
 }


### PR DESCRIPTION
## Summary

Adds a curl-bash installer script as `docs/install.sh`, per ADR-0019.

## User flow

```bash
curl -fsSL https://key.github.io/the-space-memory/install.sh | bash
```

A single command:
1. Detects platform (`linux-x86_64` / `linux-arm64` / `darwin-arm64`)
2. Resolves the latest release tag (overridable via `TSM_VERSION`)
3. Downloads the archive and verifies it against `*.sha256`
4. Installs `tsm` and `tsmd` into `~/.local/bin/` (overridable via `INSTALL_DIR`)
5. Warns if `INSTALL_DIR` is not on `PATH`
6. Prints next-step guidance (`tsm setup` → `tsm init` → `tsm doctor`)

## Why this is a draft

Three prerequisites must be in place before this script is announced to users:

- [ ] **`release.yml` updated** — emit `*.sha256` files alongside each `tsm-*.tar.gz` and upload them as release assets (separate PR)
- [ ] **GitHub Pages enabled** — repo Settings → Pages → Source: `main` branch / `/docs` folder (manual)
- [ ] **End-to-end validation** on each supported platform once Pages serves the script

## Design highlights

- `set -euo pipefail` — partial-failure cleanup
- `curl --proto '=https' --tlsv1.2` — explicit TLS minimum
- Auto-selects between `shasum` (macOS) and `sha256sum` (Linux)
- Detects an existing install and confirms before overwriting; `TSM_FORCE=1` skips the prompt
- Aborts cleanly in non-interactive shells when an existing install is detected and `TSM_FORCE` is unset
- Temp directory created via `mktemp -d`, removed via `trap` on exit
- Intel Mac (`darwin-x86_64`) is not supported by the binary releases — the script tells the user to build from source instead

## Background

The design rationale is captured in ADR-0019 ("`tsm install.sh` curl-bash installer"). Summary of the relevant decisions:

- **Hosting**: GitHub Pages from this repo's `/docs` folder, served at `key.github.io/the-space-memory/install.sh`. `.sh` files are not Jekyll-processed and are served verbatim.
- **Checksum verification is mandatory** — `curl | bash` requires it for safety. The companion `*.sha256` is fetched from the same release asset set.
- **`INSTALL_DIR` overridable**, default `~/.local/bin/` (XDG-aligned and PATH-friendly on most setups).
- **Tag resolution**: `TSM_VERSION` env var > GitHub API `releases/latest`. No `jq` dependency.

## Test plan

- [x] `shellcheck docs/install.sh` passes
- [x] `bash -n docs/install.sh` syntax check passes
- [x] Smoke test with `TSM_VERSION=v0.0.0-test` — platform detected, URL constructed correctly, exits with the expected 404 on a non-existent release
- [ ] End-to-end test once Pages is enabled
- [ ] Verify on Linux x86_64, Linux ARM64, and macOS ARM64

## Related

- Issue #170 — implementation tracking for the `tsm init` / `tsm setup` responsibility split (related onboarding work, ADR-0017)