### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "the-space-memory"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "the-space-memory"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Bumps the workspace crate to **0.5.0**.

## Notable in this release

- **Breaking** — #172: `tsm setup` no longer touches the workspace DB. WordNet synonym import and user-synonym CSV sync moved to `tsm init`. Existing users should re-run \`tsm init\` once after upgrading; the operation is idempotent.
- **Plugin extracted** — #171: the Claude Code plugin definition moved out to [`key/claude-code-plugins`](https://github.com/key/claude-code-plugins/tree/main/plugins/the-space-memory). Release tarballs no longer bundle plugin files.
- **Onboarding** — #169: curl-bash installer script at \`docs/install.sh\`.

## Release procedure

After this PR merges:

\`\`\`bash
git checkout main && git pull
git tag v0.5.0
git push origin v0.5.0
\`\`\`

The \`Release\` workflow (triggered on \`v*\` tags) builds Linux x86_64 / arm64 + macOS arm64 archives and creates a GitHub Release with auto-generated notes.

## Test plan

- [x] \`cargo update -p the-space-memory\` regenerated \`Cargo.lock\` cleanly
- [ ] CI green