### PR TITLE
docs(pages): add docs/README.md as the GitHub Pages landing page

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 ![The Space Memory](docs/assets/cover.png)
 
-[English](README.md)
+[English](README.md) · [ドキュメント](https://key.github.io/the-space-memory/)
 
 ## 概要
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![The Space Memory](docs/assets/cover.png)
 
-[日本語](README.ja.md)
+[日本語](README.ja.md) · [Documentation](https://key.github.io/the-space-memory/)
 
 ## Overview
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
-# tsm Documentation
+# The Space Memory Documentation
 
 Reference documentation for
-[The Space Memory](https://github.com/key/the-space-memory) (`tsm`) —
-a cross-workspace knowledge search engine combining FTS5 and vector
-retrieval.
+[The Space Memory](https://github.com/key/the-space-memory) — a
+cross-workspace knowledge search engine combining FTS5 and vector
+retrieval. The CLI is installed as the `tsm` binary.
 
 ## Install
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,7 @@ retrieval. The CLI is installed as the `tsm` binary.
 The recommended install path is:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/key/the-space-memory/main/docs/install.sh \
-  | bash
+curl -fsSL https://key.github.io/the-space-memory/install.sh | bash
 ```
 
 The script picks the right archive for your platform, verifies the

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,48 @@
+# tsm Documentation
+
+Reference documentation for
+[The Space Memory](https://github.com/key/the-space-memory) (`tsm`) —
+a cross-workspace knowledge search engine combining FTS5 and vector
+retrieval.
+
+## Install
+
+`tsm` is distributed as prebuilt binaries on the
+[Releases page](https://github.com/key/the-space-memory/releases).
+The recommended install path is:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/key/the-space-memory/main/docs/install.sh \
+  | bash
+```
+
+The script picks the right archive for your platform, verifies the
+checksum, and copies `tsm` and `tsmd` into `~/.local/bin/`.
+
+After install, run the one-time setup and the per-workspace
+initialization:
+
+```bash
+tsm setup        # download embedding model + WordNet DB (system-wide)
+cd ~/my-notes
+export TSM_INDEX_ROOT=$PWD
+tsm init         # workspace bootstrap: schema, scaffold, synonym import
+tsm start        # start the daemon (embedder + file watcher)
+tsm index        # index your documents
+tsm search -q "query" -k 5
+```
+
+For the full quick-start tour, see the project
+[README](https://github.com/key/the-space-memory#readme)
+([日本語版](https://github.com/key/the-space-memory/blob/main/README.ja.md)).
+
+## Contents
+
+| Document | Description |
+|---|---|
+| [Architecture](architecture.md) | Daemon / embedder / watcher topology and IPC layout |
+| [Data Flow](data-flow.md) | Indexing and search pipelines end-to-end |
+| [Configuration](configuration.md) | `tsm.toml` and environment variable reference |
+| [Command Reference](command-reference.md) | Every `tsm` subcommand, flags, and examples |
+| [User Dictionary](user-dictionary.md) | Custom terminology for the lindera tokenizer |
+| [Claude Code prompt format](claude-code/claude-code-prompt-format.md) | Output format used by the auto-search hook |


### PR DESCRIPTION
## Summary

GitHub Pages is configured to serve from `main:/docs`, but no index existed there, so [the deployed site](https://key.github.io/the-space-memory/) returned 404. This adds a landing page.

## Contents

- **Install** is the first section: curl-bash from `docs/install.sh`, then the `tsm setup` -> `tsm init` quick flow.
- **Contents** indexes the existing reference docs (architecture, data flow, configuration, command reference, user dictionary, Claude Code prompt format).

`docs/README.md` doubles as the landing page for the `/docs` directory when browsing on GitHub.

## Test plan

- [x] `rumdl check docs/README.md` — clean
- [ ] After merge, https://key.github.io/the-space-memory/ resolves and the install snippet copies cleanly