### PR TITLE
deps: bump rand from 0.10.0 to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,7 +1943,7 @@ dependencies = [
  "memmap2",
  "num_cpus",
  "once_cell",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "reqwest 0.13.2",
  "rkyv",
@@ -2578,9 +2578,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "rand_core 0.10.0",
 ]


### PR DESCRIPTION
Closes the only open Dependabot alert ([GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc)).

## Advisory

**Rand is unsound with a custom logger using rand::rng()** — low severity. The unsoundness triggers only when all of the following hold:

- The \`log\` and \`thread_rng\` features are enabled.
- A custom logger is defined.
- The custom logger accesses \`rand::rng()\` and calls \`TryRng\` methods on \`ThreadRng\`.

\`tsm\` does not use \`rand\` directly; the dependency comes in transitively via \`lindera-dictionary\` -> \`lindera-ipadic\` -> \`lindera\`, and the affected pattern is not exercised. Even so, the fix is a one-line \`Cargo.lock\` bump and there is no reason to leave the alert open.

## Change

\`\`\`text
rand v0.10.0 -> rand v0.10.1
\`\`\`

## Test plan

- [x] \`cargo build --release\` succeeds
- [x] \`cargo test --lib\` — 499 passed
- [ ] CI green
- [ ] Dependabot alert auto-dismisses after merge