### PR TITLE
fix(release): build x86_64 via cross for glibc compatibility (v0.5.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,17 @@ jobs:
     strategy:
       matrix:
         include:
+          # Both Linux targets build via `cross` (Docker, Ubuntu 20.04
+          # base, glibc 2.31). Building x86_64 natively on
+          # ubuntu-latest pulls in the runner's glibc (currently 2.39),
+          # which produces binaries that fail to start on Debian 11 /
+          # Ubuntu 20.04 / RHEL 8 with `version 'GLIBC_2.34' not found`.
+          # The cross image stays pinned to glibc 2.31, so the same
+          # archive runs on the older long-term-support distros.
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             archive_name: linux-x86_64
+            use_cross: true
           - os: macos-latest
             target: aarch64-apple-darwin
             archive_name: darwin-arm64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,7 +3431,7 @@ dependencies = [
 
 [[package]]
 name = "the-space-memory"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "the-space-memory"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Symptom

\`tsm\` v0.5.0 fails to start on the long-term-support distros that ship glibc 2.31 (Debian 11 / Ubuntu 20.04 / RHEL 8):

\`\`\`text
tsm: /lib/x86_64-linux-gnu/libc.so.6: version \`GLIBC_2.32' not found (required by tsm)
\`\`\`

## Root cause

The release matrix builds \`x86_64-unknown-linux-gnu\` natively on \`ubuntu-latest\`. As of GitHub's current image, that runner ships glibc 2.39, which leaks into the produced binary as \`GLIBC_2.34\` symbol references. The arm64 build already runs through \`cross\` (Docker, default image based on Ubuntu 20.04 / glibc 2.31), so it is not affected.

## Fix

Switch the x86_64 job to \`use_cross: true\`, mirroring the arm64 job. \`cross\`'s default GNU image is pinned to glibc 2.31, so produced binaries link against the older symbol set and run on every supported distro.

Bumps the crate to **v0.5.1** so the fix ships as a fresh release artifact — overwriting v0.5.0's tag would be worse than cutting a follow-up.

## Affected users (and workaround until release)

Anyone who installed v0.5.0 on a distro with glibc < 2.34 hit this. Workaround until v0.5.1 ships:

\`\`\`bash
git clone https://github.com/key/the-space-memory && cd the-space-memory
cargo build --release
cp target/release/{tsm,tsmd} ~/.local/bin/
\`\`\`

## Test plan

- [ ] CI green
- [ ] After merge, tag \`v0.5.1\` -> release workflow uploads the cross-built x86_64 archive
- [ ] Re-install via \`curl -fsSL https://key.github.io/the-space-memory/install.sh | bash\` on a glibc 2.31 host -> \`tsm --version\` runs without error