### PR TITLE
docs: install via mise from GitHub Releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,8 +184,9 @@ For local development (testing unreleased changes):
 cargo build --release   # Binaries land in ./target/release/{tsm,tsmd}
 ```
 
-Releases are published by CI on tagged commits with `tsm-<version>-<os>-<arch>.tar.gz`
-artifacts containing `bin/{tsm,tsmd}`.
+Releases are published by CI on tagged commits as
+`tsm-v<version>-<os>-<arch>.tar.gz` (e.g. `tsm-v0.5.1-linux-x86_64.tar.gz`)
+containing `bin/{tsm,tsmd}` plus `LICENSE`, `README.md`, and `tsm.toml.example`.
 
 ## DevContainer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,11 +169,23 @@ plugins repo and ensure `tsm` is on `PATH`.
 
 ## Build & Deploy
 
-Build from a host container via Docker, then reference the binary from hooks/skills.
+End users install via mise from GitHub Releases:
+
+```toml
+# In consumer .mise.toml
+"github:key/the-space-memory" = { version = "latest", extract_all = true }
+```
+
+mise verifies SLSA provenance + GitHub artifact attestations during install.
+
+For local development (testing unreleased changes):
 
 ```bash
-docker build -t the-space-memory /path/to/the-space-memory
+cargo build --release   # Binaries land in ./target/release/{tsm,tsmd}
 ```
+
+Releases are published by CI on tagged commits with `tsm-<version>-<os>-<arch>.tar.gz`
+artifacts containing `bin/{tsm,tsmd}`.
 
 ## DevContainer
 


### PR DESCRIPTION
## Summary

- Replace the Docker-based local build instructions in `CLAUDE.md` with mise-based install from published GitHub Release artifacts
- The mise github backend handles download, checksum verification, SLSA provenance, and artifact attestation checks automatically
- Local \`cargo build --release\` remains documented for developers testing unreleased changes

## Why

End users had to run a Docker build to get \`tsm\` / \`tsmd\` binaries, which required Docker daemon access and rebuilt the binaries even when an official Release was available. With v0.5.1 fixing glibc compatibility, the published x86_64 tarball works on standard Ubuntu hosts. mise can now install directly from Releases:

\`\`\`toml
"github:key/the-space-memory" = { version = "latest", extract_all = true }
\`\`\`

## Test plan

- [x] Verified that \`mise install\` extracts both \`bin/tsm\` and \`bin/tsmd\` correctly
- [x] Verified \`tsm --version\` and \`tsmd --version\` report 0.5.1
- [x] Verified \`tsm doctor\` is green after restart with mise-managed binaries
- [x] \`rumdl check CLAUDE.md\` passes