### PR TITLE
docs(adr): accept ADR-0007 pipeline stages

### DIFF
--- a/decisions/0007-pipeline-stages.md
+++ b/decisions/0007-pipeline-stages.md
@@ -1,7 +1,7 @@
 # ADR-0007: tsm の処理を Index / Search の 2 パイプラインに分解し段を明示する
 
-- **Status**: **Proposed**
-- **Date**: 2026-04-15
+- **Status**: **Accepted**
+- **Date**: 2026-04-15 (Proposed) / 2026-05-07 (Accepted)
 - **Deciders**: key
 - **Related**:
   [ADR-0001](./0001-process-roles-and-responsibilities.md),


### PR DESCRIPTION
## Summary

- ADR-0007 (Index/Search パイプライン段分解) を Proposed → Accepted に昇格
- Date 行に Proposed/Accepted の両日付を併記し、起案から承認までの履歴を残す

## Background

key とのディスカッションで `.md.gz` 透過インデクシングの実装方針を詰める中で、
ADR-0007 が定義する Prepare 段の Load サブステップ、および将来の indexer
transformer プラグインのフック点と完全に一致することを確認した。
これを受けて、後続作業の前に ADR を承認しておく方針で合意。

承認後、以下の issue を立てる予定:

- ADR-0007 段分解 epic と子 issue 群 (ベースラインベンチ、段間データ型、
  Prepare/Embed/Persist 切り出し、bounded queue、transformer trait)
- \`.md.gz\` 透過インデクシング (ADR-0007 を Refs に持つ独立 issue)

## Test plan

- [ ] \`decisions/0007-pipeline-stages.md\` の Status が **Accepted** になっている
- [ ] Date 行に \`2026-04-15 (Proposed) / 2026-05-07 (Accepted)\` が入っている