### PR TITLE
feat(bench): add search_latency bench harness + bench-counters feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +376,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -535,6 +574,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1726,6 +1796,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2318,6 +2397,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,7 +2731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -3439,6 +3524,7 @@ dependencies = [
  "candle-transformers",
  "chrono",
  "clap",
+ "criterion",
  "directories",
  "flate2",
  "flexi_logger",
@@ -3545,6 +3631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3573,7 +3669,7 @@ dependencies = [
  "esaxx-rs",
  "getrandom 0.3.4",
  "indicatif",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,13 @@ flate2 = "1"
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"
+criterion = { version = "0.7", default-features = false }
+
+[features]
+# Enables atomic counters in production code (e.g. embedder client) for bench instrumentation.
+# Off by default; release builds compile the counters out entirely.
+bench-counters = []
+
+[[bench]]
+name = "search_latency"
+harness = false

--- a/README.md
+++ b/README.md
@@ -105,6 +105,47 @@ tsm rebuild --apply   # Delete DB and rebuild
 
 Use `tsm doctor` to check system health and daemon status.
 
+## Benchmarks
+
+Performance benches for the search/index pipeline. Currently only the
+search latency bench is implemented; indexing benches and the CI
+regression gate ship in a follow-up PR (see [#181](https://github.com/key/the-space-memory/issues/181)).
+
+### Prerequisites
+
+- `tsmd` running with embedder ready (`tsm start` and verify via `tsm status`)
+- The standard testdata corpus indexed:
+
+  ```bash
+  export TSM_INDEX_ROOT=$(pwd)/tests/e2e/testdata
+  tsm init && tsm index
+  ```
+
+### Running
+
+```bash
+# Search latency (hybrid: FTS5 + vector + entity)
+cargo bench --bench search_latency
+```
+
+### Embedder call counter
+
+For benches that need to verify embedder call counts, build with the
+`bench-counters` feature. Off by default; release builds compile the
+counters out entirely.
+
+```bash
+cargo build --features bench-counters
+```
+
+```rust
+use the_space_memory::embedder::counters;
+
+counters::reset_embedder_calls();
+// ... run code that calls embed_via_socket_at ...
+println!("calls: {}", counters::embedder_call_count());
+```
+
 ## Documentation
 
 - [Command Reference](docs/command-reference.md) — CLI commands, flags, and usage examples

--- a/benches/search_latency.rs
+++ b/benches/search_latency.rs
@@ -1,0 +1,47 @@
+//! Search latency bench (hybrid: FTS5 + vector + entity).
+//!
+//! Measures `searcher::search()` latency for the standard query set over
+//! the e2e testdata corpus. Hybrid only — FTS5-only mode requires API
+//! extension and is deferred.
+//!
+//! Prerequisites (see README "Running benches"):
+//!   1. tsmd running (`tsm start`) with embedder ready
+//!   2. testdata indexed (`tsm init` + `tsm index` against `tests/e2e/testdata`)
+//!
+//! Usage:
+//!   cargo bench --bench search_latency
+
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use the_space_memory::{config, db, searcher};
+
+const QUERIES: &[&str] = &["銀河", "坊っちゃん", "メロス", "夏目", "走れ"];
+const TOP_K: usize = 5;
+
+fn bench_search_hybrid(c: &mut Criterion) {
+    let db_path = config::db_path();
+    let conn = db::get_connection(&db_path).unwrap_or_else(|e| {
+        panic!(
+            "DB not available at {}: {e}\n\
+             Run `tsm init` and `tsm index` against tests/e2e/testdata before benching.",
+            db_path.display()
+        );
+    });
+
+    let mut group = c.benchmark_group("search_hybrid");
+    group.measurement_time(Duration::from_secs(10));
+    group.sample_size(50);
+
+    for query in QUERIES {
+        group.bench_with_input(BenchmarkId::from_parameter(query), query, |b, q| {
+            b.iter(|| searcher::search(&conn, q, TOP_K, None, false, None).unwrap());
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_search_hybrid);
+criterion_main!(benches);

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -14,6 +14,32 @@ use crate::ipc::{read_message, write_message};
 
 const MODEL_ID: &str = "cl-nagoya/ruri-v3-30m";
 
+/// Bench-only instrumentation. Compiled out unless `bench-counters` feature is enabled.
+///
+/// Counts client-side `embed_via_socket_at` calls. Used by bench harness to verify
+/// the regression invariant "embedder is not called more often than expected"
+/// (ADR-0007 metric #4).
+#[cfg(feature = "bench-counters")]
+pub mod counters {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static EMBEDDER_CALLS: AtomicU64 = AtomicU64::new(0);
+
+    pub(super) fn increment_embedder_calls() {
+        EMBEDDER_CALLS.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Total number of `embed_via_socket_at` calls since process start (or last reset).
+    pub fn embedder_call_count() -> u64 {
+        EMBEDDER_CALLS.load(Ordering::Relaxed)
+    }
+
+    /// Reset the counter to zero. For bench setup.
+    pub fn reset_embedder_calls() {
+        EMBEDDER_CALLS.store(0, Ordering::Relaxed);
+    }
+}
+
 /// The embedder engine: loads model and produces embeddings.
 pub struct Embedder {
     model: ModernBert,
@@ -203,6 +229,9 @@ pub fn embed_via_socket(texts: &[String]) -> Option<Vec<Vec<f32>>> {
 
 /// Send texts to the embedder daemon at a specific socket path.
 pub fn embed_via_socket_at(socket_path: &Path, texts: &[String]) -> Option<Vec<Vec<f32>>> {
+    #[cfg(feature = "bench-counters")]
+    counters::increment_embedder_calls();
+
     if !socket_path.exists() {
         return None;
     }
@@ -289,6 +318,23 @@ mod tests {
     fn test_embed_via_socket_nonexistent_path() {
         let result = embed_via_socket_at(Path::new("/tmp/nonexistent.sock"), &[]);
         assert!(result.is_none());
+    }
+
+    #[cfg(feature = "bench-counters")]
+    #[test]
+    #[serial_test::serial(embedder_counter)]
+    fn test_embedder_call_counter_increments() {
+        counters::reset_embedder_calls();
+        let _ = embed_via_socket_at(Path::new("/tmp/nonexistent.sock"), &[]);
+        assert_eq!(counters::embedder_call_count(), 1);
+    }
+
+    #[cfg(feature = "bench-counters")]
+    #[test]
+    #[serial_test::serial(embedder_counter)]
+    fn test_embedder_call_counter_reset_zeroes() {
+        counters::reset_embedder_calls();
+        assert_eq!(counters::embedder_call_count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Lays the groundwork for the regression gate planned in #181 without shipping the gate itself. Small, reviewable in isolation; subsequent PRs add indexing benches, baseline.json, and the CI workflow.

## What this PR adds

- **`benches/search_latency.rs`** — criterion-based hybrid search bench (FTS5 + vector + entity) covering a fixed query set over the e2e testdata corpus. Manual `cargo bench --bench search_latency` only; no CI gate yet.
- **`bench-counters` cargo feature** — gates an `AtomicU64` in `embed_via_socket_at` so future indexing benches can verify the ADR-0007 invariant *embedder is not called more often than expected*. Off by default; release builds compile the counters out entirely.
- **README \"Benchmarks\" section** documenting prerequisites (`tsmd` running + corpus indexed) and the feature flag.

## Why split this out

Per advisor feedback: ship a small harness PR first, let the bench harness inform the design of baseline / gate / workflow that follow. Reduces review surface and de-risks the gate design.

## Variance check (Step 0 spike)

Before committing to a 5% threshold I ran a throwaway spike on `ubuntu-latest`. Initial CLI-roundtrip variance was CV 38% (bimodal due to `lindera` cold-cache load), but switching to in-process measurement via `searcher::search()` directly gave **CV 0.15%** with values clustered tightly at ~108ms. So the eventual gate threshold can stay at 5% — no statistical comparison or self-hosted runner needed.

## Out of scope (follow-up PRs)

- Indexing benches (full / incremental)
- `benches/baseline.json` and `scripts/check_regression.sh`
- `.github/workflows/bench.yml` with PR gate and nightly baseline updates
- FTS5-only search bench (needs API extension to bypass hybrid path)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (499 passed)
- [x] `cargo test --features bench-counters` (501 passed; 2 new counter tests)
- [x] `cargo build --release`
- [x] `cargo build --release --features bench-counters`
- [x] `rumdl check README.md`
- [ ] `cargo bench --bench search_latency` against a live `tsmd` (manual; CI runs it in PR2)

Refs: #181