### PR TITLE
feat(embedder, config): add cache_*_dir helpers and embedder fallback (ADR-0008 Task 3)

### DIFF
--- a/src/bin/tsmd/embedder_mode.rs
+++ b/src/bin/tsmd/embedder_mode.rs
@@ -42,8 +42,8 @@ fn load_model(model_dir: Option<&Path>) -> Result<Embedder> {
             );
         }
         log::warn!(
-            "Model files incomplete in {}; falling back to HF Hub cache. \
-             Run `tsm setup` to install model files locally.",
+            "Model files incomplete in {}; falling back to default resolution \
+             (state_dir override → cache_dir). Run `tsm setup` to populate the cache.",
             dir.display()
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -901,6 +901,40 @@ pub fn models_dir_complete() -> Option<PathBuf> {
     }
 }
 
+// ─── Machine-wide cache helpers (ADR-0008) ─────────────────────
+
+/// Cache directory for the ruri-v3-30m model: `{cache_dir}/models/ruri-v3-30m/`.
+pub fn cache_models_dir() -> PathBuf {
+    cache_dir().join("models/ruri-v3-30m")
+}
+
+/// `Some(path)` if all files in `MODEL_FILES` are present in `cache_models_dir()`,
+/// `None` otherwise.
+pub fn cache_models_dir_complete() -> Option<PathBuf> {
+    let dir = cache_models_dir();
+    if MODEL_FILES.iter().all(|f| dir.join(f).is_file()) {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
+/// WordNet DB path inside the machine-wide cache: `{cache_dir}/wnjpn.db`.
+pub fn cache_wordnet_db_path() -> PathBuf {
+    cache_dir().join("wnjpn.db")
+}
+
+/// Directory holding tsm-owned source artefacts (e.g. `wnjpn-vX.Y.db`):
+/// `{cache_dir}/sources/`.
+pub fn cache_sources_dir() -> PathBuf {
+    cache_dir().join("sources")
+}
+
+/// Cache manifest JSON: `{cache_dir}/manifest.json`.
+pub fn cache_manifest_path() -> PathBuf {
+    cache_dir().join("manifest.json")
+}
+
 // ─── Model cache (XDG) ──────────────────────────────────────────
 // NOTE: model_cache_dir and ensure_model_cache_env are intentionally NOT
 // part of ResolvedConfig. ensure_model_cache_env performs a side-effectful
@@ -2151,6 +2185,89 @@ half_life_days = 180
         assert!(result.is_some());
         assert_eq!(result.unwrap(), dir);
         std::env::remove_var("TSM_STATE_DIR");
+        reload();
+    }
+
+    // ─── cache_*_dir / cache_models_dir_complete (ADR-0008 Task 3) ──
+
+    #[test]
+    #[serial]
+    fn test_cache_models_dir_returns_correct_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("TSM_CACHE_DIR", tmp.path());
+        reload();
+        assert_eq!(cache_models_dir(), tmp.path().join("models/ruri-v3-30m"));
+        std::env::remove_var("TSM_CACHE_DIR");
+        reload();
+    }
+
+    #[test]
+    #[serial]
+    fn test_cache_wordnet_db_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("TSM_CACHE_DIR", tmp.path());
+        reload();
+        assert_eq!(cache_wordnet_db_path(), tmp.path().join("wnjpn.db"));
+        std::env::remove_var("TSM_CACHE_DIR");
+        reload();
+    }
+
+    #[test]
+    #[serial]
+    fn test_cache_sources_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("TSM_CACHE_DIR", tmp.path());
+        reload();
+        assert_eq!(cache_sources_dir(), tmp.path().join("sources"));
+        std::env::remove_var("TSM_CACHE_DIR");
+        reload();
+    }
+
+    #[test]
+    #[serial]
+    fn test_cache_manifest_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("TSM_CACHE_DIR", tmp.path());
+        reload();
+        assert_eq!(cache_manifest_path(), tmp.path().join("manifest.json"));
+        std::env::remove_var("TSM_CACHE_DIR");
+        reload();
+    }
+
+    #[test]
+    #[serial]
+    fn test_cache_models_dir_complete_returns_none_when_files_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("TSM_CACHE_DIR", tmp.path());
+        reload();
+        // Empty cache dir — no model files yet.
+        std::fs::create_dir_all(cache_models_dir()).unwrap();
+        assert!(cache_models_dir_complete().is_none());
+
+        // Partial: only one file present.
+        std::fs::write(cache_models_dir().join("config.json"), "{}").unwrap();
+        assert!(cache_models_dir_complete().is_none());
+
+        std::env::remove_var("TSM_CACHE_DIR");
+        reload();
+    }
+
+    #[test]
+    #[serial]
+    fn test_cache_models_dir_complete_returns_some_when_all_files_present() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::env::set_var("TSM_CACHE_DIR", tmp.path());
+        reload();
+        let dir = cache_models_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        for f in &MODEL_FILES {
+            std::fs::write(dir.join(f), "dummy").unwrap();
+        }
+        let result = cache_models_dir_complete();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap(), dir);
+
+        std::env::remove_var("TSM_CACHE_DIR");
         reload();
     }
 }

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -3,7 +3,7 @@ use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use candle_core::{DType, Device, Tensor, D};
 use candle_nn::VarBuilder;
 use candle_transformers::models::modernbert::{Config, ModernBert};
@@ -11,8 +11,6 @@ use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer};
 
 use crate::config;
 use crate::ipc::{read_message, write_message};
-
-const MODEL_ID: &str = "cl-nagoya/ruri-v3-30m";
 
 /// The embedder engine: loads model and produces embeddings.
 pub struct Embedder {
@@ -24,41 +22,38 @@ pub struct Embedder {
 impl Embedder {
     /// Load the ruri-v3-30m model.
     ///
-    /// Resolution order:
-    /// 1. `{state_dir}/models/ruri-v3-30m/` — if all 3 files are present
-    /// 2. HuggingFace Hub cache — fallback for backward compatibility
+    /// Resolution order (ADR-0008):
+    /// 1. `{state_dir}/models/ruri-v3-30m/` — workspace override
+    ///    (lets users drop a fine-tuned model into a single workspace)
+    /// 2. `{cache_dir}/models/ruri-v3-30m/` — machine-wide cache
+    ///    populated by `tsm setup`
+    /// 3. Neither populated → fail with an actionable error message
     pub fn load(device: &Device) -> Result<Self> {
-        // Try local models_dir first
         if let Some(dir) = config::models_dir_complete() {
-            log::info!("Loading model from {}", dir.display());
-            return Self::load_from_paths(
-                &dir.join("config.json"),
-                &dir.join("tokenizer.json"),
-                &dir.join("model.safetensors"),
-                device,
-            );
+            log::info!("Loading model from workspace override: {}", dir.display());
+            return Self::load_from_dir(&dir, device);
         }
 
-        // Fallback to HF Hub cache
-        log::warn!(
-            "Local model not found in {}; falling back to HF Hub cache (requires network)",
+        if let Some(dir) = config::cache_models_dir_complete() {
+            log::info!("Loading model from cache: {}", dir.display());
+            return Self::load_from_dir(&dir, device);
+        }
+
+        anyhow::bail!(
+            "ruri-v3-30m model not found. Run `tsm setup` to populate the cache, \
+             or place the model files at {} (workspace override).",
             config::models_dir().display()
         );
-        let api = hf_hub::api::sync::Api::new()?;
-        let repo = api.repo(hf_hub::Repo::new(
-            MODEL_ID.to_string(),
-            hf_hub::RepoType::Model,
-        ));
+    }
 
-        let config_path = repo.get("config.json").context("config.json not found")?;
-        let tokenizer_path = repo
-            .get("tokenizer.json")
-            .context("tokenizer.json not found")?;
-        let weights_path = repo
-            .get("model.safetensors")
-            .context("model.safetensors not found")?;
-
-        Self::load_from_paths(&config_path, &tokenizer_path, &weights_path, device)
+    /// Helper: load all three required files from a single directory.
+    fn load_from_dir(dir: &Path, device: &Device) -> Result<Self> {
+        Self::load_from_paths(
+            &dir.join("config.json"),
+            &dir.join("tokenizer.json"),
+            &dir.join("model.safetensors"),
+            device,
+        )
     }
 
     /// Load model from explicit file paths.
@@ -289,6 +284,40 @@ mod tests {
     fn test_embed_via_socket_nonexistent_path() {
         let result = embed_via_socket_at(Path::new("/tmp/nonexistent.sock"), &[]);
         assert!(result.is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_embedder_load_fails_with_helpful_message_when_no_model() {
+        // Both workspace override and cache are empty — load() must bail with
+        // an actionable message that points the user at `tsm setup`.
+        let tmp_state = tempfile::TempDir::new().unwrap();
+        let tmp_cache = tempfile::TempDir::new().unwrap();
+
+        std::env::set_var("TSM_STATE_DIR", tmp_state.path());
+        std::env::set_var("TSM_CACHE_DIR", tmp_cache.path());
+        config::reload();
+
+        let result = Embedder::load(&Device::Cpu);
+
+        std::env::remove_var("TSM_STATE_DIR");
+        std::env::remove_var("TSM_CACHE_DIR");
+        config::reload();
+
+        // Embedder doesn't implement Debug; use match instead of unwrap_err.
+        let err = match result {
+            Ok(_) => panic!("Embedder::load unexpectedly succeeded with empty dirs"),
+            Err(e) => e,
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("tsm setup"),
+            "expected error to mention `tsm setup`, got: {msg}"
+        );
+        assert!(
+            msg.contains("ruri-v3-30m"),
+            "expected error to mention model name, got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #188. Refs umbrella #185.

## Summary

- Adds five cache-side accessors in `src/config.rs`: `cache_models_dir`, `cache_models_dir_complete`, `cache_wordnet_db_path`, `cache_sources_dir`, `cache_manifest_path`. They mirror the existing `state_dir` helpers and reuse `MODEL_FILES`.
- `Embedder::load` now resolves in order: workspace override → machine-wide cache → bail with an actionable error pointing at `tsm setup`.
- Removes the HF Hub fallback (and the unused `MODEL_ID` const). ADR-0008 makes `tsm setup` the single ingress for upstream resources; downloading silently from inside the embedder would defeat the cache contract.
- Factored out `Embedder::load_from_dir` to share the three-file load path between the two new lookup branches.

## Tests

7 new tests:

| Test | File | Covers |
|---|---|---|
| `test_cache_models_dir_returns_correct_path` | config.rs | `{cache_dir}/models/ruri-v3-30m` |
| `test_cache_wordnet_db_path` | config.rs | `{cache_dir}/wnjpn.db` |
| `test_cache_sources_dir` | config.rs | `{cache_dir}/sources` |
| `test_cache_manifest_path` | config.rs | `{cache_dir}/manifest.json` |
| `test_cache_models_dir_complete_returns_none_when_files_missing` | config.rs | None for empty + partial dir |
| `test_cache_models_dir_complete_returns_some_when_all_files_present` | config.rs | Some(path) when all 3 model files present |
| `test_embedder_load_fails_with_helpful_message_when_no_model` | embedder.rs | bail message mentions `tsm setup` and `ruri-v3-30m` |

```
cargo test --lib test_cache_     -> 12 passed (6 new + 6 from Task 1)
cargo test --lib test_embedder_load -> 1 passed
cargo test --lib                 -> 523 passed, 1 failed (pre-existing
                                    macOS /private/var symlink test)
```

## CI verification

- `cargo clippy --lib --tests`: 2 warnings, both pre-existing on `main` (`indexer/mod.rs:1628 unused_variables`, `config.rs:1144 cloned_ref_to_slice_refs`).
- `cargo fmt --check`: clean.

## Out of scope

- Building the cache layout (`tsm setup` rewrite): Task 4 (#189). Until that lands, the new `cache_*` paths return Some only if a user manually populates them.
- Workspace-side links to the cache: Task 5 (#190).
- Doctor's two-layer integrity report: Task 6 (#191).